### PR TITLE
Add approval rules with per-server/tool pattern matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 atryum.toml
 atryum.db
 .codex
+__inspiration

--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,9 @@ set shell := ["bash", "-cu"]
 
 config := "./atryum.toml"
 
+default:
+    just --list
+
 setup:
 	go mod tidy
 
@@ -18,3 +21,17 @@ stop:
 	pkill -f '/atryum -config|go run ./cmd/atryum'
 
 check: fmt test
+
+# PostgreSQL via docker-compose
+pg-up:
+	docker compose up -d --wait
+
+pg-down:
+	docker compose down
+
+pg-reset:
+	docker compose down -v
+	docker compose up -d --wait
+
+pg-logs:
+	docker compose logs -f postgres

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -44,6 +44,7 @@ func main() {
 	eventRepo := store.NewEventRepoWithDialect(db, dialect)
 	serverRepo := store.NewServerRepoWithDialect(db, dialect)
 	oauthRepo := store.NewOAuthRepoWithDialect(db, dialect)
+	rulesRepo := store.NewRulesRepoWithDialect(db, dialect)
 	resolver := mcp.NewResolver(serverRepo, cfg)
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
 		log.Fatalf("bootstrap servers: %v", err)
@@ -78,9 +79,9 @@ func main() {
 	}
 	log.Printf("policy provider: %s", policyRegistry.Active().DisplayName())
 
-	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second)
+	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo)
 	serverAdmin := api.NewServerAdminService(serverRepo, oauthRepo, client, 5*time.Second)
-	handler := api.NewHandler(service, serverAdmin, policyRegistry)
+	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo)
 
 	srv := &http.Server{
 		Addr:              cfg.Server.ListenAddr,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: atryum
+      POSTGRES_USER: atryum
+      POSTGRES_PASSWORD: atryum
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U atryum"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  pgdata:

--- a/examples/amp-plugin/README.md
+++ b/examples/amp-plugin/README.md
@@ -1,0 +1,84 @@
+# Atryum amp plugin
+
+A minimal [amp](https://ampcode.com) plugin that routes every tool call the
+amp coding harness wants to make through Atryum for human approval, and
+reports execution outcome back to Atryum for audit.
+
+This makes Atryum work for tool calls that are **not** over MCP — e.g. amp's
+`Bash`, `edit_file`, `Read`, etc. — by treating amp itself as the executor
+and Atryum as the approval mediator and audit log.
+
+## How it works
+
+```diagram
+╭───────────────╮  POST /api/v1/external/invocations    ╭──────────╮
+│ amp tool.call │ ─────────────────────────────────────▶│ Atryum   │
+│   handler     │                                        │  pending │
+╰──────┬────────╯                                        │ approval │
+       │     poll GET /api/v1/external/invocations/:id   ╰────┬─────╯
+       │ ◀─────────────────────────────────────────────────── │
+       │            (approved | denied)              human ──▶│ /ui/
+       ▼
+   allow | reject
+       │
+       │  tool runs in amp harness
+       ▼
+╭──────────────────╮  PATCH /api/v1/external/invocations/:id
+│ amp tool.result  │ ─────────────────────────────────▶ atryum updates
+│    handler       │   {execution_status: completed|failed|cancelled}
+╰──────────────────╯
+```
+
+## Install
+
+> The Amp plugin API only works when the Amp CLI is installed via the binary
+> install method, not via `npm install`.
+
+Plugins must be enabled at runtime by setting `PLUGINS=all` in the env amp
+runs in:
+
+```sh
+export PLUGINS=all
+```
+
+### System-wide (recommended)
+
+Drop the plugin into `~/.config/amp/plugins/` and it will gate every amp
+session on the machine:
+
+```sh
+mkdir -p ~/.config/amp/plugins
+cp examples/amp-plugin/atryum.ts ~/.config/amp/plugins/atryum.ts
+```
+
+### Per-project
+
+Or scope it to a single project:
+
+```sh
+mkdir -p .amp/plugins
+cp examples/amp-plugin/atryum.ts .amp/plugins/atryum.ts
+```
+
+Make sure atryum is running (default `http://localhost:8080`) and open the
+admin UI at <http://localhost:8080/ui/>. Pending tool calls will appear there
+with Approve / Deny buttons.
+
+## Configure (env vars)
+
+| var               | default                | meaning                                                     |
+| ----------------- | ---------------------- | ----------------------------------------------------------- |
+| `ATRYUM_URL`      | `http://localhost:8080`| base URL of the atryum server                               |
+| `ATRYUM_SOURCE`   | `amp`                  | label shown as the "upstream" column in the atryum UI       |
+| `ATRYUM_POLL_MS`  | `2000`                 | how often the plugin polls atryum while awaiting approval   |
+
+## API used
+
+This plugin only depends on three endpoints atryum exposes for external
+executors:
+
+- `POST /api/v1/external/invocations` — submit a tool call for approval (returns immediately with `status: pending_approval`)
+- `GET  /api/v1/external/invocations/:id` — poll status (`approved`, `denied`, …)
+- `PATCH /api/v1/external/invocations/:id` — report `running` / `completed` / `failed` / `cancelled`
+
+The same admin UI and admin endpoints (`/api/v1/admin/invocations/:id/approve|deny`) used for MCP-proxied calls work for these external invocations too.

--- a/examples/amp-plugin/atryum.ts
+++ b/examples/amp-plugin/atryum.ts
@@ -1,0 +1,168 @@
+// @i-know-the-amp-plugin-api-is-wip-and-very-experimental-right-now
+//
+// Atryum amp plugin
+// -----------------
+// Routes every amp tool.call through Atryum for human approval, then reports
+// the execution outcome on tool.result. Atryum itself does not execute the
+// tool — amp does. Atryum is the approval mediator and audit log.
+//
+// Configure via env:
+//   ATRYUM_URL    base URL of the atryum server, default http://localhost:8080
+//   ATRYUM_SOURCE label that shows up in the atryum UI as the "upstream"
+//                 column, default "amp"
+//   ATRYUM_POLL_MS poll interval in ms while waiting for approval, default 2000
+
+import type { PluginAPI } from "@ampcode/plugin";
+
+const API = process.env.ATRYUM_URL || "http://localhost:8080";
+const SOURCE = process.env.ATRYUM_SOURCE || "amp";
+const POLL_INTERVAL = Number(process.env.ATRYUM_POLL_MS || 2000);
+// Amp exposes the current thread ID as $THREAD_ID in the plugin process env.
+const THREAD_ID = process.env.THREAD_ID || "";
+
+type InvocationStatus =
+  | "received"
+  | "executing"
+  | "pending_approval"
+  | "approved"
+  | "denied"
+  | "expired"
+  | "cancelled"
+  | "succeeded"
+  | "failed";
+
+type InvocationResponse = {
+  invocation_id: string;
+  status: InvocationStatus;
+  error?: unknown;
+};
+
+// toolUseID -> atryum invocation id, so tool.result can patch the right row.
+const invocationMap = new Map<string, string>();
+
+function describe(input: Record<string, unknown>): string {
+  const parts = Object.entries(input)
+    .filter(([, v]) => typeof v === "string")
+    .map(([k, v]) => {
+      const s = String(v);
+      return `${k}: ${s.length > 200 ? s.slice(0, 200) + "..." : s}`;
+    });
+  return parts.join(" | ") || "(no string params)";
+}
+
+async function submit(
+  tool: string,
+  toolUseID: string,
+  input: Record<string, unknown>
+): Promise<InvocationResponse> {
+  const res = await fetch(`${API}/api/v1/external/invocations`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      source: SOURCE,
+      tool,
+      description: describe(input),
+      input,
+      request_id: toolUseID,
+      thread_id: THREAD_ID || undefined,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`atryum submit failed: ${res.status} ${await res.text()}`);
+  }
+  return (await res.json()) as InvocationResponse;
+}
+
+async function poll(invocationID: string): Promise<InvocationResponse> {
+  while (true) {
+    const res = await fetch(
+      `${API}/api/v1/external/invocations/${invocationID}`
+    );
+    if (!res.ok) {
+      throw new Error(`atryum poll failed: ${res.status}`);
+    }
+    const inv = (await res.json()) as InvocationResponse;
+    if (inv.status !== "pending_approval" && inv.status !== "received") {
+      return inv;
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL));
+  }
+}
+
+async function patchExecution(
+  invocationID: string,
+  body: {
+    execution_status: "running" | "completed" | "failed" | "cancelled";
+    result?: unknown;
+    error?: unknown;
+    message?: string;
+  }
+): Promise<void> {
+  await fetch(`${API}/api/v1/external/invocations/${invocationID}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export default function (amp: PluginAPI) {
+  amp.on("tool.call", async (event, ctx) => {
+    try {
+      const submitted = await submit(event.tool, event.toolUseID, event.input);
+      invocationMap.set(event.toolUseID, submitted.invocation_id);
+      ctx.logger.log(
+        `atryum: submitted ${event.tool} as ${submitted.invocation_id} — awaiting approval`
+      );
+
+      const decided = await poll(submitted.invocation_id);
+      if (decided.status === "approved") {
+        await patchExecution(submitted.invocation_id, {
+          execution_status: "running",
+        });
+        ctx.logger.log(
+          `atryum: approved ${event.tool} (${submitted.invocation_id})`
+        );
+        return { action: "allow" };
+      }
+      ctx.logger.log(
+        `atryum: rejected ${event.tool} (${submitted.invocation_id}, status=${decided.status})`
+      );
+      invocationMap.delete(event.toolUseID);
+      return {
+        action: "reject-and-continue",
+        message: `atryum: tool call '${event.tool}' was ${decided.status} by reviewer.`,
+      };
+    } catch (err) {
+      ctx.logger.log(`atryum error: ${err}`);
+      return {
+        action: "reject-and-continue",
+        message: `atryum: failed to gate tool call: ${err}`,
+      };
+    }
+  });
+
+  amp.on("tool.result", async (event, ctx) => {
+    const invocationID = invocationMap.get(event.toolUseID);
+    if (!invocationID) return;
+    invocationMap.delete(event.toolUseID);
+    try {
+      if (event.status === "done") {
+        await patchExecution(invocationID, {
+          execution_status: "completed",
+          result: event.output,
+        });
+      } else if (event.status === "error") {
+        await patchExecution(invocationID, {
+          execution_status: "failed",
+          error: event.output,
+        });
+      } else if (event.status === "cancelled") {
+        await patchExecution(invocationID, {
+          execution_status: "cancelled",
+        });
+      }
+    } catch (err) {
+      ctx.logger.log(`atryum result update error: ${err}`);
+    }
+  });
+}

--- a/examples/amp-plugin/atryum.ts
+++ b/examples/amp-plugin/atryum.ts
@@ -110,11 +110,19 @@ export default function (amp: PluginAPI) {
     try {
       const submitted = await submit(event.tool, event.toolUseID, event.input);
       invocationMap.set(event.toolUseID, submitted.invocation_id);
-      ctx.logger.log(
-        `atryum: submitted ${event.tool} as ${submitted.invocation_id} — awaiting approval`
-      );
 
-      const decided = await poll(submitted.invocation_id);
+      // If rules already decided (auto_approve / auto_deny), skip polling.
+      let decided = submitted;
+      if (
+        submitted.status === "pending_approval" ||
+        submitted.status === "received"
+      ) {
+        ctx.logger.log(
+          `atryum: submitted ${event.tool} as ${submitted.invocation_id} — awaiting approval`
+        );
+        decided = await poll(submitted.invocation_id);
+      }
+
       if (decided.status === "approved") {
         await patchExecution(submitted.invocation_id, {
           execution_status: "running",

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -29,6 +29,8 @@ var webFS embed.FS
 type service interface {
 	Invoke(ctx context.Context, req invocation.CreateInvocationRequest) (invocation.InvocationResponse, error)
 	ListTools(ctx context.Context, server string) ([]mcp.Tool, error)
+	ListAllTools(ctx context.Context) ([]mcp.Tool, error)
+	ResolveToolServer(ctx context.Context, toolName string) (string, error)
 	Get(ctx context.Context, id string) (invocation.InvocationResponse, error)
 	List(ctx context.Context, filter invocation.InvocationListFilter) (invocation.InvocationListResponse, error)
 	Events(ctx context.Context, invocationID string, filter invocation.EventListFilter) (invocation.EventListResponse, error)
@@ -51,10 +53,21 @@ type serverService interface {
 	CompleteConnect(ctx context.Context, state string, code string, errorText string) (OAuthConnectStatusResponse, error)
 }
 
+type rulesRepo interface {
+	Create(ctx context.Context, rule store.Rule) error
+	Get(ctx context.Context, id string) (store.Rule, error)
+	List(ctx context.Context) ([]store.Rule, error)
+	NextOrder(ctx context.Context) (int, error)
+	Update(ctx context.Context, rule store.Rule) error
+	Delete(ctx context.Context, id string) error
+	Move(ctx context.Context, id string, direction string) ([]store.Rule, error)
+}
+
 type Handler struct {
 	svc            service
 	serverSvc      serverService
 	policyRegistry *policy.Registry
+	rulesRepo      rulesRepo
 	forwarder      mcpEnvelopeForwarder
 	staticHTTP     http.Handler
 	debug          bool
@@ -146,6 +159,36 @@ type OAuthConnectStatusResponse struct {
 	CompletedAt *time.Time `json:"completed_at,omitempty"`
 }
 
+// ─── Rules ───────────────────────────────────────────────────────────────────
+
+type AdminRule struct {
+	ID             string    `json:"id"`
+	Action         string    `json:"action"`
+	ServerPatterns []string  `json:"server_patterns"`
+	ToolPatterns   []string  `json:"tool_patterns"`
+	UserPattern    string    `json:"user_pattern"`
+	Description    string    `json:"description,omitempty"`
+	Enabled        bool      `json:"enabled"`
+	Order          int       `json:"order"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type AdminRuleInput struct {
+	Action         string   `json:"action"`
+	ServerPatterns []string `json:"server_patterns"`
+	ToolPatterns   []string `json:"tool_patterns"`
+	UserPattern    string   `json:"user_pattern"`
+	Description    string   `json:"description,omitempty"`
+	Enabled        *bool    `json:"enabled,omitempty"`
+}
+
+type RuleListResponse struct {
+	Items []AdminRule `json:"items"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 type jsonRPCRequest struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      json.RawMessage `json:"id,omitempty"`
@@ -164,7 +207,7 @@ type invocationStreamEnvelope struct {
 	Items []invocation.InvocationResponse `json:"items"`
 }
 
-func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Registry) *Handler {
+func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Registry, rules rulesRepo) *Handler {
 	staticSub, err := fs.Sub(webFS, "web")
 	if err != nil {
 		panic(err)
@@ -174,7 +217,7 @@ func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Reg
 	if f, ok := svc.(mcpEnvelopeForwarder); ok {
 		forwarder = f
 	}
-	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
+	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
 }
 
 func (h *Handler) Routes() http.Handler {
@@ -187,6 +230,8 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/admin/invocations/", h.adminInvocationDetail)
 	mux.HandleFunc("/api/v1/admin/servers", h.adminServers)
 	mux.HandleFunc("/api/v1/admin/servers/", h.adminServerDetail)
+	mux.HandleFunc("/api/v1/admin/rules", h.adminRules)
+	mux.HandleFunc("/api/v1/admin/rules/", h.adminRuleDetail)
 	mux.HandleFunc("/api/v1/admin/oauth/callback", h.oauthCallback)
 	mux.HandleFunc("/api/v1/admin/policy", h.adminPolicy)
 	mux.HandleFunc("/ui", h.uiIndex)
@@ -216,7 +261,15 @@ func (h *Handler) uiIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) invokeUpstream(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodGet || r.Method == http.MethodDelete {
+	server := strings.TrimPrefix(r.URL.Path, "/mcp/")
+	server = strings.Trim(server, "/")
+
+	// GET: open an SSE keepalive stream (Streamable HTTP transport and legacy SSE clients both try GET)
+	if r.Method == http.MethodGet {
+		h.handleMCPSSE(w, r)
+		return
+	}
+	if r.Method == http.MethodDelete {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
@@ -224,17 +277,46 @@ func (h *Handler) invokeUpstream(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	server := strings.TrimPrefix(r.URL.Path, "/mcp/")
-	server = strings.Trim(server, "/")
+	if isJSONRPCRequest(r) {
+		// server may be "" — handleMCPProxy handles the aggregate (no-server) case
+		h.handleMCPProxy(w, r, server)
+		return
+	}
 	if server == "" {
 		writeError(w, http.StatusNotFound, "server not found")
 		return
 	}
-	if isJSONRPCRequest(r) {
-		h.handleMCPProxy(w, r, server)
+	h.handleInvocation(w, r, server)
+}
+
+// handleMCPSSE opens a long-lived SSE stream so Cursor's MCP client can establish
+// a connection. Actual JSON-RPC exchanges still travel over POST; this stream
+// exists purely to satisfy the SSE handshake and sends periodic keepalive pings.
+func (h *Handler) handleMCPSSE(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported")
 		return
 	}
-	h.handleInvocation(w, r, server)
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, ": atryum mcp ready\n\n")
+	flusher.Flush()
+
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			fmt.Fprintf(w, ": ping\n\n")
+			flusher.Flush()
+		}
+	}
 }
 
 func isJSONRPCRequest(r *http.Request) bool {
@@ -313,7 +395,13 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 	case "notifications/initialized":
 		w.WriteHeader(http.StatusAccepted)
 	case "tools/list":
-		tools, err := h.svc.ListTools(r.Context(), server)
+		var tools []mcp.Tool
+		var err error
+		if server == "" {
+			tools, err = h.svc.ListAllTools(r.Context())
+		} else {
+			tools, err = h.svc.ListTools(r.Context(), server)
+		}
 		if err != nil {
 			h.writeRPCError(w, req.ID, -32000, err.Error())
 			return
@@ -329,7 +417,16 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 			h.writeRPCError(w, req.ID, -32602, "invalid params")
 			return
 		}
-		toolReq := invocation.CreateInvocationRequest{Server: server, Tool: params.Name, Input: params.Arguments}
+		callServer := server
+		if callServer == "" {
+			resolved, err := h.svc.ResolveToolServer(r.Context(), params.Name)
+			if err != nil {
+				h.writeRPCError(w, req.ID, -32000, err.Error())
+				return
+			}
+			callServer = resolved
+		}
+		toolReq := invocation.CreateInvocationRequest{Server: callServer, Tool: params.Name, Input: params.Arguments}
 		if requestID != "" {
 			toolReq.RequestID = stringPtr(requestID)
 		}
@@ -545,6 +642,24 @@ func (h *Handler) adminServerDetail(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
+	if strings.HasSuffix(trimmed, "/tools") {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		name := strings.TrimSuffix(trimmed, "/tools")
+		name = strings.TrimSuffix(name, "/")
+		tools, err := h.svc.ListTools(r.Context(), name)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if tools == nil {
+			tools = []mcp.Tool{}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"items": tools})
+		return
+	}
 	if strings.HasSuffix(trimmed, "/test") {
 		if r.Method != http.MethodPost {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -719,6 +834,225 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, map[string]any{"error": map[string]string{"message": message}})
+}
+
+func (h *Handler) adminRules(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		rules, err := h.rulesRepo.List(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		items := make([]AdminRule, 0, len(rules))
+		for _, rule := range rules {
+			items = append(items, toAdminRule(rule))
+		}
+		writeJSON(w, http.StatusOK, RuleListResponse{Items: items})
+	case http.MethodPost:
+		var req AdminRuleInput
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json")
+			return
+		}
+		if err := validateRuleInput(req); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		order, err := h.rulesRepo.NextOrder(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		enabled := true
+		if req.Enabled != nil {
+			enabled = *req.Enabled
+		}
+		rule := store.Rule{
+			ID:             "rule_" + newUUID(),
+			Action:         req.Action,
+			ServerPatterns: normalizePatternSlice(req.ServerPatterns),
+			ToolPatterns:   normalizePatternSlice(req.ToolPatterns),
+			UserPattern:    defaultPattern(req.UserPattern),
+			Description:    req.Description,
+			Enabled:        enabled,
+			Order:          order,
+		}
+		if err := h.rulesRepo.Create(r.Context(), rule); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		created, err := h.rulesRepo.Get(r.Context(), rule.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusCreated, toAdminRule(created))
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (h *Handler) adminRuleDetail(w http.ResponseWriter, r *http.Request) {
+	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/rules/")
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	if strings.HasSuffix(trimmed, "/move") {
+		if r.Method != http.MethodPut {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		id := strings.TrimSuffix(trimmed, "/move")
+		id = strings.TrimSuffix(id, "/")
+		var body struct {
+			Direction string `json:"direction"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json")
+			return
+		}
+		rules, err := h.rulesRepo.Move(r.Context(), id, body.Direction)
+		if err != nil {
+			status := http.StatusBadRequest
+			if err == sql.ErrNoRows {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err.Error())
+			return
+		}
+		items := make([]AdminRule, 0, len(rules))
+		for _, rule := range rules {
+			items = append(items, toAdminRule(rule))
+		}
+		writeJSON(w, http.StatusOK, RuleListResponse{Items: items})
+		return
+	}
+
+	id := trimmed
+	switch r.Method {
+	case http.MethodGet:
+		rule, err := h.rulesRepo.Get(r.Context(), id)
+		if err != nil {
+			status := http.StatusInternalServerError
+			if err == sql.ErrNoRows {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, toAdminRule(rule))
+	case http.MethodPut:
+		var req AdminRuleInput
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json")
+			return
+		}
+		if err := validateRuleInput(req); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		existing, err := h.rulesRepo.Get(r.Context(), id)
+		if err != nil {
+			status := http.StatusInternalServerError
+			if err == sql.ErrNoRows {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err.Error())
+			return
+		}
+		enabled := existing.Enabled
+		if req.Enabled != nil {
+			enabled = *req.Enabled
+		}
+		existing.Action = req.Action
+		existing.ServerPatterns = normalizePatternSlice(req.ServerPatterns)
+		existing.ToolPatterns = normalizePatternSlice(req.ToolPatterns)
+		existing.UserPattern = defaultPattern(req.UserPattern)
+		existing.Description = req.Description
+		existing.Enabled = enabled
+		if err := h.rulesRepo.Update(r.Context(), existing); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		updated, err := h.rulesRepo.Get(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, toAdminRule(updated))
+	case http.MethodDelete:
+		if err := h.rulesRepo.Delete(r.Context(), id); err != nil {
+			status := http.StatusInternalServerError
+			if err == sql.ErrNoRows {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func toAdminRule(r store.Rule) AdminRule {
+	sp := r.ServerPatterns
+	if sp == nil {
+		sp = []string{}
+	}
+	tp := r.ToolPatterns
+	if tp == nil {
+		tp = []string{}
+	}
+	return AdminRule{
+		ID:             r.ID,
+		Action:         r.Action,
+		ServerPatterns: sp,
+		ToolPatterns:   tp,
+		UserPattern:    r.UserPattern,
+		Description:    r.Description,
+		Enabled:        r.Enabled,
+		Order:          r.Order,
+		CreatedAt:      r.CreatedAt,
+		UpdatedAt:      r.UpdatedAt,
+	}
+}
+
+func normalizePatternSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+func validateRuleInput(req AdminRuleInput) error {
+	switch req.Action {
+	case "auto_approve", "auto_deny", "human_approval":
+	default:
+		return fmt.Errorf("action must be one of: auto_approve, auto_deny, human_approval")
+	}
+	return nil
+}
+
+func defaultPattern(p string) string {
+	if strings.TrimSpace(p) == "" {
+		return "*"
+	}
+	return p
+}
+
+func newUUID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("uuid generation failed: " + err.Error())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
 
 func readUintQuery(r *http.Request, key string, fallback uint64) uint64 {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -36,6 +36,8 @@ type service interface {
 	Events(ctx context.Context, invocationID string, filter invocation.EventListFilter) (invocation.EventListResponse, error)
 	Approve(ctx context.Context, invocationID string) error
 	Deny(ctx context.Context, invocationID string, message string) error
+	Submit(ctx context.Context, req invocation.ExternalSubmitRequest) (invocation.InvocationResponse, error)
+	RecordExecution(ctx context.Context, invocationID string, update invocation.ExternalExecutionUpdate) (invocation.InvocationResponse, error)
 }
 
 type mcpEnvelopeForwarder interface {
@@ -234,6 +236,8 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/admin/rules/", h.adminRuleDetail)
 	mux.HandleFunc("/api/v1/admin/oauth/callback", h.oauthCallback)
 	mux.HandleFunc("/api/v1/admin/policy", h.adminPolicy)
+	mux.HandleFunc("/api/v1/external/invocations", h.externalInvocations)
+	mux.HandleFunc("/api/v1/external/invocations/", h.externalInvocationDetail)
 	mux.HandleFunc("/ui", h.uiIndex)
 	mux.Handle("/ui/", http.StripPrefix("/ui/", h.staticHTTP))
 	mux.HandleFunc("/", h.root)
@@ -1298,6 +1302,73 @@ func (s *ServerAdminService) CompleteConnect(ctx context.Context, state string, 
 		return OAuthConnectStatusResponse{}, err
 	}
 	return OAuthConnectStatusResponse{Status: "succeeded", Message: &message, StartedAt: &session.StartedAt, CompletedAt: &now}, nil
+}
+
+func (h *Handler) externalInvocations(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req invocation.ExternalSubmitRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if req.RequestID == nil {
+		if rid := strings.TrimSpace(r.Header.Get("X-Request-Id")); rid != "" {
+			req.RequestID = &rid
+		}
+	}
+	if req.IdempotencyKey == nil {
+		if key := strings.TrimSpace(r.Header.Get("Idempotency-Key")); key != "" {
+			req.IdempotencyKey = &key
+		}
+	}
+	resp, err := h.svc.Submit(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) externalInvocationDetail(w http.ResponseWriter, r *http.Request) {
+	id := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/external/invocations/"), "/")
+	if id == "" {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		resp, err := h.svc.Get(r.Context(), id)
+		if err != nil {
+			status := http.StatusInternalServerError
+			if err == sql.ErrNoRows {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	case http.MethodPatch:
+		var update invocation.ExternalExecutionUpdate
+		if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json")
+			return
+		}
+		resp, err := h.svc.RecordExecution(r.Context(), id, update)
+		if err != nil {
+			status := http.StatusBadRequest
+			if err == sql.ErrNoRows {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, resp)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
 }
 
 func toAdminServer(upstream mcp.Upstream) AdminServer {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -32,6 +32,12 @@ func (s *stubService) Invoke(_ context.Context, req invocation.CreateInvocationR
 func (s *stubService) ListTools(context.Context, string) ([]mcp.Tool, error) {
 	return s.tools, s.listErr
 }
+func (s *stubService) ListAllTools(context.Context) ([]mcp.Tool, error) {
+	return s.tools, s.listErr
+}
+func (s *stubService) ResolveToolServer(_ context.Context, _ string) (string, error) {
+	return s.upstream.Name, nil
+}
 func (s *stubService) Get(context.Context, string) (invocation.InvocationResponse, error) {
 	return s.invoke, nil
 }
@@ -74,7 +80,7 @@ func (stubServerService) CompleteConnect(context.Context, string, string, string
 }
 
 func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("MCP-Protocol-Version", "2025-11-25")
@@ -99,7 +105,7 @@ func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 }
 
 func TestMCPInitializedNotificationReturnsAccepted(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`))
 	w := httptest.NewRecorder()
 
@@ -112,7 +118,7 @@ func TestMCPInitializedNotificationReturnsAccepted(t *testing.T) {
 
 func TestMCPPingPassThrough(t *testing.T) {
 	svc := &stubService{upstream: mcp.Upstream{Name: "demo", Mode: mcp.UpstreamModeHTTP}, forward: mcp.ForwardResult{StatusCode: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`), ContentType: "application/json", ProtocolVersion: "2025-11-25"}}
-	h := NewHandler(svc, stubServerService{}, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping","params":{}}`))
 	w := httptest.NewRecorder()
 
@@ -128,7 +134,7 @@ func TestMCPPingPassThrough(t *testing.T) {
 
 func TestMCPUnknownNotificationPassThroughFallbackAccepted(t *testing.T) {
 	svc := &stubService{fwdErr: context.Canceled}
-	h := NewHandler(svc, stubServerService{}, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/custom","params":{"x":1}}`))
 	w := httptest.NewRecorder()
 
@@ -140,7 +146,7 @@ func TestMCPUnknownNotificationPassThroughFallbackAccepted(t *testing.T) {
 }
 
 func TestMCPMalformedJSONReturnsParseError(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":`))
 	w := httptest.NewRecorder()
 
@@ -151,20 +157,39 @@ func TestMCPMalformedJSONReturnsParseError(t *testing.T) {
 	}
 }
 
-func TestMCPGetDeleteReturn405(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil)
-	for _, method := range []string{http.MethodGet, http.MethodDelete} {
-		req := httptest.NewRequest(method, "/mcp/demo", nil)
-		w := httptest.NewRecorder()
+func TestMCPGetOpenSSEStream(t *testing.T) {
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodGet, "/mcp/demo", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
 		h.Routes().ServeHTTP(w, req)
-		if w.Code != http.StatusMethodNotAllowed {
-			t.Fatalf("method %s expected 405, got %d", method, w.Code)
-		}
+		close(done)
+	}()
+	// Cancel immediately — the SSE handler should exit once the context is done
+	cancel()
+	<-done
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /mcp expected 200 SSE, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
+		t.Fatalf("expected text/event-stream, got %s", ct)
+	}
+}
+
+func TestMCPDeleteReturn405(t *testing.T) {
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	req := httptest.NewRequest(http.MethodDelete, "/mcp/demo", nil)
+	w := httptest.NewRecorder()
+	h.Routes().ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("DELETE expected 405, got %d", w.Code)
 	}
 }
 
 func TestMCPToolsList(t *testing.T) {
-	h := NewHandler(&stubService{tools: []mcp.Tool{{Name: "demo_tool"}}}, stubServerService{}, nil)
+	h := NewHandler(&stubService{tools: []mcp.Tool{{Name: "demo_tool"}}}, stubServerService{}, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
 	w := httptest.NewRecorder()
 
@@ -178,7 +203,7 @@ func TestMCPToolsList(t *testing.T) {
 func TestMCPToolsCallInterceptsInvocation(t *testing.T) {
 	now := time.Now().UTC()
 	svc := &stubService{invoke: invocation.InvocationResponse{InvocationID: "inv_123", ServerName: "demo", ToolName: "demo_tool", Status: invocation.StatusSucceeded, Input: json.RawMessage(`{"a":1}`), SubmittedAt: now, CompletedAt: &now, Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)}}
-	h := NewHandler(svc, stubServerService{}, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"demo_tool","arguments":{"a":1}}}`))
 	w := httptest.NewRecorder()
 
@@ -201,7 +226,7 @@ func TestMCPToolsCallInterceptsInvocation(t *testing.T) {
 func TestAdminInvocationsResponsesIncludeServerToolAndInput(t *testing.T) {
 	now := time.Now().UTC()
 	svc := &stubService{invoke: invocation.InvocationResponse{InvocationID: "inv_123", ServerName: "demo-server", ToolName: "demo_tool", Status: invocation.StatusSucceeded, Input: json.RawMessage(`{"issue":123,"verbose":true}`), SubmittedAt: now, CompletedAt: &now}}
-	h := NewHandler(svc, stubServerService{}, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil)
 
 	t.Run("list", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -49,6 +49,12 @@ func (s *stubService) Events(context.Context, string, invocation.EventListFilter
 }
 func (s *stubService) Approve(context.Context, string) error      { return nil }
 func (s *stubService) Deny(context.Context, string, string) error { return nil }
+func (s *stubService) Submit(context.Context, invocation.ExternalSubmitRequest) (invocation.InvocationResponse, error) {
+	return invocation.InvocationResponse{}, nil
+}
+func (s *stubService) RecordExecution(context.Context, string, invocation.ExternalExecutionUpdate) (invocation.InvocationResponse, error) {
+	return invocation.InvocationResponse{}, nil
+}
 func (s *stubService) ForwardEnvelope(context.Context, mcp.Upstream, mcp.Envelope, string) (mcp.ForwardResult, error) {
 	return s.forward, s.fwdErr
 }

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -78,6 +78,30 @@ type CreateInvocationRequest struct {
 	IdempotencyKey *string        `json:"idempotency_key,omitempty"`
 }
 
+// ExternalSubmitRequest is used by callers that execute the tool themselves
+// (e.g. an amp coding harness via a plugin) and only want Atryum to gate the
+// call for human approval and record audit events. Atryum will NOT execute
+// the tool when this path is used.
+type ExternalSubmitRequest struct {
+	Source         string         `json:"source"`
+	Tool           string         `json:"tool"`
+	Description    string         `json:"description,omitempty"`
+	Input          map[string]any `json:"input"`
+	RequestID      *string        `json:"request_id,omitempty"`
+	IdempotencyKey *string        `json:"idempotency_key,omitempty"`
+	ThreadID       string         `json:"thread_id,omitempty"`
+}
+
+// ExternalExecutionUpdate is sent by the external executor to report on a
+// pending or completed run. ExecutionStatus is one of:
+//   running | completed | failed | cancelled
+type ExternalExecutionUpdate struct {
+	ExecutionStatus string          `json:"execution_status"`
+	Result          json.RawMessage `json:"result,omitempty"`
+	Error           json.RawMessage `json:"error,omitempty"`
+	Message         string          `json:"message,omitempty"`
+}
+
 type InvocationResponse struct {
 	InvocationID string          `json:"invocation_id"`
 	ServerName   string          `json:"server_name"`

--- a/internal/invocation/rules.go
+++ b/internal/invocation/rules.go
@@ -1,0 +1,67 @@
+package invocation
+
+import "context"
+
+// Rule actions.
+const (
+	RuleActionAutoApprove   = "auto_approve"
+	RuleActionAutoDeny      = "auto_deny"
+	RuleActionHumanApproval = "human_approval"
+)
+
+// ApprovalRule is the invocation-layer view of a configured rule.
+// It is intentionally decoupled from the store layer to avoid import cycles.
+type ApprovalRule struct {
+	Action         string   // one of the RuleAction* constants
+	ServerPatterns []string // empty slice = match any server
+	ToolPatterns   []string // empty slice = match any tool
+	UserPattern    string   // "*" or "" = match any user
+	Enabled        bool
+}
+
+// rulesStore is the minimal interface the invocation service needs.
+// store.RulesRepo satisfies this via its ListApprovalRules method.
+type rulesStore interface {
+	ListApprovalRules(ctx context.Context) ([]ApprovalRule, error)
+}
+
+// matchRule returns the first enabled rule that matches the given invocation
+// parameters, or nil if no rule matches (fall back to human approval).
+func matchRule(rules []ApprovalRule, server, tool, user string) *ApprovalRule {
+	for i := range rules {
+		r := &rules[i]
+		if !r.Enabled {
+			continue
+		}
+		if !matchPatterns(r.ServerPatterns, server) {
+			continue
+		}
+		if !matchPatterns(r.ToolPatterns, tool) {
+			continue
+		}
+		if !matchUserPattern(r.UserPattern, user) {
+			continue
+		}
+		return r
+	}
+	return nil
+}
+
+// matchPatterns returns true when value matches any entry in patterns,
+// or when patterns is empty (meaning "match all").
+func matchPatterns(patterns []string, value string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	for _, p := range patterns {
+		if p == "*" || p == value {
+			return true
+		}
+	}
+	return false
+}
+
+// matchUserPattern returns true when the rule's user pattern matches user.
+func matchUserPattern(pattern, user string) bool {
+	return pattern == "" || pattern == "*" || pattern == user
+}

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -316,30 +316,191 @@ func (s *Service) Approve(ctx context.Context, invocationID string) error {
 	s.mu.Lock()
 	ch, ok := s.pendingApprovals[invocationID]
 	s.mu.Unlock()
-	if !ok {
-		return fmt.Errorf("invocation %s is not pending approval", invocationID)
+	if ok {
+		select {
+		case ch <- approvalDecision{approved: true}:
+			return nil
+		default:
+			return fmt.Errorf("invocation %s approval already decided", invocationID)
+		}
 	}
-	select {
-	case ch <- approvalDecision{approved: true}:
-		return nil
-	default:
-		return fmt.Errorf("invocation %s approval already decided", invocationID)
-	}
+	// External (mediated) invocation: no in-memory waiter. Update DB directly
+	// so the polling external executor can pick up the decision.
+	return s.recordExternalDecision(ctx, invocationID, true, "")
 }
 
 func (s *Service) Deny(ctx context.Context, invocationID string, message string) error {
 	s.mu.Lock()
 	ch, ok := s.pendingApprovals[invocationID]
 	s.mu.Unlock()
-	if !ok {
-		return fmt.Errorf("invocation %s is not pending approval", invocationID)
+	if ok {
+		select {
+		case ch <- approvalDecision{approved: false, message: message}:
+			return nil
+		default:
+			return fmt.Errorf("invocation %s approval already decided", invocationID)
+		}
 	}
-	select {
-	case ch <- approvalDecision{approved: false, message: message}:
+	return s.recordExternalDecision(ctx, invocationID, false, message)
+}
+
+func (s *Service) recordExternalDecision(ctx context.Context, invocationID string, approved bool, message string) error {
+	inv, err := s.invocations.Get(ctx, invocationID)
+	if err != nil {
+		return err
+	}
+	if inv.Status != StatusPendingApproval {
+		return fmt.Errorf("invocation %s is not pending approval (status=%s)", invocationID, inv.Status)
+	}
+	now := time.Now().UTC()
+	if approved {
+		inv.Status = StatusApproved
+		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
+			return err
+		}
+		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.approved", Payload: mustJSON(map[string]any{"input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}), CreatedAt: now})
 		return nil
-	default:
-		return fmt.Errorf("invocation %s approval already decided", invocationID)
 	}
+	inv.Status = StatusDenied
+	inv.CompletedAt = &now
+	msg := "Tool call denied by the MCP permissions system."
+	if message != "" {
+		msg += "\n\nReason: " + message
+	}
+	inv.Error = mustJSON(map[string]any{"content": []map[string]any{{"type": "text", "text": msg}}, "isError": true})
+	if err := s.invocations.UpdateResult(ctx, inv); err != nil {
+		return err
+	}
+	_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.denied", Payload: mustJSON(map[string]any{"message": message, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}), CreatedAt: now})
+	return nil
+}
+
+// Submit creates an invocation in the pending_approval state on behalf of an
+// external executor (e.g. an amp coding harness plugin). It does NOT execute
+// the tool — the caller is expected to poll Get() until status is approved or
+// denied, run the tool itself, and then RecordExecution() with the outcome.
+func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (InvocationResponse, error) {
+	if req.Tool == "" {
+		return InvocationResponse{}, fmt.Errorf("tool is required")
+	}
+	source := req.Source
+	if source == "" {
+		source = "external"
+	}
+	if req.IdempotencyKey != nil && *req.IdempotencyKey != "" {
+		existing, err := s.invocations.GetByIdempotencyKey(ctx, *req.IdempotencyKey)
+		if err == nil {
+			return s.toResponse(existing), nil
+		}
+		if err != nil && err != sql.ErrNoRows {
+			return InvocationResponse{}, err
+		}
+	}
+	inputJSON, err := json.Marshal(req.Input)
+	if err != nil {
+		return InvocationResponse{}, err
+	}
+	now := time.Now().UTC()
+	inv := Invocation{
+		InvocationID:   "inv_" + uuid.NewString(),
+		RequestID:      req.RequestID,
+		IdempotencyKey: req.IdempotencyKey,
+		Tool:           req.Tool,
+		Upstream:       source,
+		Status:         StatusReceived,
+		Input:          inputJSON,
+		SubmittedAt:    now,
+	}
+	if err := s.invocations.Create(ctx, inv); err != nil {
+		return InvocationResponse{}, err
+	}
+	receivedPayload := map[string]any{"tool": req.Tool, "upstream": source, "request_id": req.RequestID, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "external": true}
+	if req.Description != "" {
+		receivedPayload["description"] = req.Description
+	}
+	if req.ThreadID != "" {
+		receivedPayload["thread_id"] = req.ThreadID
+	}
+	_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.received", Payload: mustJSON(receivedPayload), CreatedAt: now})
+	inv.Status = StatusPendingApproval
+	if err := s.invocations.UpdateResult(ctx, inv); err != nil {
+		return InvocationResponse{}, err
+	}
+	_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.pending_approval", Payload: mustJSON(receivedPayload), CreatedAt: time.Now().UTC()})
+	return s.toResponse(inv), nil
+}
+
+// RecordExecution updates an externally-executed invocation with the outcome
+// reported by the executor. Valid execStatus values:
+//
+//	running | completed | failed | cancelled
+func (s *Service) RecordExecution(ctx context.Context, invocationID string, update ExternalExecutionUpdate) (InvocationResponse, error) {
+	inv, err := s.invocations.Get(ctx, invocationID)
+	if err != nil {
+		return InvocationResponse{}, err
+	}
+	now := time.Now().UTC()
+	switch update.ExecutionStatus {
+	case "running":
+		if inv.Status != StatusApproved && inv.Status != StatusExecuting {
+			return InvocationResponse{}, fmt.Errorf("invocation %s cannot move to running from %s", invocationID, inv.Status)
+		}
+		inv.Status = StatusExecuting
+		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
+			return InvocationResponse{}, err
+		}
+		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.executing", Payload: mustJSON(map[string]any{"upstream": inv.Upstream, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "external": true}), CreatedAt: now})
+	case "completed":
+		inv.Status = StatusSucceeded
+		inv.CompletedAt = &now
+		if len(update.Result) > 0 {
+			inv.Response = []byte(update.Result)
+		}
+		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
+			return InvocationResponse{}, err
+		}
+		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.succeeded", Payload: mustJSON(map[string]any{"upstream": inv.Upstream, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "body": json.RawMessage(nullableRaw(inv.Response)), "external": true}), CreatedAt: now})
+	case "failed":
+		inv.Status = StatusFailed
+		inv.CompletedAt = &now
+		if len(update.Error) > 0 {
+			inv.Error = []byte(update.Error)
+		} else if update.Message != "" {
+			inv.Error = mustJSON(map[string]any{"message": update.Message})
+		} else {
+			inv.Error = mustJSON(map[string]any{"message": "tool execution failed"})
+		}
+		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
+			return InvocationResponse{}, err
+		}
+		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.failed", Payload: mustJSON(map[string]any{"upstream": inv.Upstream, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "body": json.RawMessage(inv.Error), "external": true}), CreatedAt: now})
+	case "cancelled":
+		inv.Status = StatusCancelled
+		inv.CompletedAt = &now
+		if len(update.Error) > 0 {
+			inv.Error = []byte(update.Error)
+		} else {
+			msg := "Tool execution cancelled."
+			if update.Message != "" {
+				msg = update.Message
+			}
+			inv.Error = mustJSON(map[string]any{"content": []map[string]any{{"type": "text", "text": msg}}, "isError": true})
+		}
+		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
+			return InvocationResponse{}, err
+		}
+		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.cancelled", Payload: mustJSON(map[string]any{"upstream": inv.Upstream, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "body": json.RawMessage(inv.Error), "external": true}), CreatedAt: now})
+	default:
+		return InvocationResponse{}, fmt.Errorf("invalid execution_status %q (expected running|completed|failed|cancelled)", update.ExecutionStatus)
+	}
+	return s.toResponse(inv), nil
+}
+
+func nullableRaw(b []byte) []byte {
+	if len(b) == 0 {
+		return []byte("null")
+	}
+	return b
 }
 
 func (s *Service) ListTools(ctx context.Context, server string) ([]mcp.Tool, error) {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -34,6 +34,7 @@ type eventRepo interface {
 
 type resolver interface {
 	ResolveContext(ctx context.Context, name string) (mcp.Upstream, error)
+	ListAll(ctx context.Context) ([]mcp.Upstream, error)
 }
 
 type upstreamClient interface {
@@ -48,18 +49,20 @@ type Service struct {
 	resolver         resolver
 	client           upstreamClient
 	policy           policy.Provider
+	rules            rulesStore // nil = no rule evaluation
 	defaultTimeout   time.Duration
 	mu               sync.Mutex
 	pendingApprovals map[string]chan approvalDecision
 }
 
-func NewService(inv invocationRepo, evt eventRepo, resolver resolver, client upstreamClient, policyProvider policy.Provider, defaultTimeout time.Duration) *Service {
+func NewService(inv invocationRepo, evt eventRepo, resolver resolver, client upstreamClient, policyProvider policy.Provider, defaultTimeout time.Duration, rules rulesStore) *Service {
 	return &Service{
 		invocations:      inv,
 		events:           evt,
 		resolver:         resolver,
 		client:           client,
 		policy:           policyProvider,
+		rules:            rules,
 		defaultTimeout:   defaultTimeout,
 		pendingApprovals: make(map[string]chan approvalDecision),
 	}
@@ -105,12 +108,36 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		return InvocationResponse{}, err
 	}
 
-	// Evaluate policy before taking any action so the disposition is in the
-	// received event. Errors fail closed (fall back to human approval).
-	callCtx := policy.CallContext{Server: upstream.Name, Tool: req.Tool, Input: req.Input}
-	decision, policyErr := s.policy.Evaluate(ctx, callCtx)
-	if policyErr != nil {
-		decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "policy error: " + policyErr.Error()}
+	// Determine disposition: check rules first (fine-grained), then fall back to policy (global).
+	// Both resolve to a policy.Decision so the rest of the flow is uniform.
+	var decision policy.Decision
+	ruleMatched := false
+	if s.rules != nil {
+		if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
+			user := ""
+			if req.RequestID != nil {
+				user = *req.RequestID
+			}
+			if matched := matchRule(approvalRules, upstream.Name, req.Tool, user); matched != nil {
+				ruleMatched = true
+				switch matched.Action {
+				case RuleActionAutoDeny:
+					decision = policy.Decision{Disposition: policy.DispositionNever, Reason: "matched approval rule (auto_deny)"}
+				case RuleActionAutoApprove:
+					decision = policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (auto_approve)"}
+				default:
+					decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (human_approval)"}
+				}
+			}
+		}
+	}
+	if !ruleMatched && s.policy != nil {
+		callCtx := policy.CallContext{Server: upstream.Name, Tool: req.Tool, Input: req.Input}
+		var policyErr error
+		decision, policyErr = s.policy.Evaluate(ctx, callCtx)
+		if policyErr != nil {
+			decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "policy error: " + policyErr.Error()}
+		}
 	}
 
 	_ = s.events.Create(ctx, Event{
@@ -131,13 +158,12 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 	case policy.DispositionAuto:
 		return s.executeNow(ctx, inv, upstream, req, decision.Reason)
 	default:
-		// DispositionWorkflow falls through to human until ValidMind integration (US-15).
+		// DispositionHuman and DispositionWorkflow both gate on a human decision.
 		return s.waitForHumanApproval(ctx, inv, upstream, req)
 	}
 }
 
-// denyByPolicy hard-denies the call without execution. The invocation record is
-// persisted for audit (US-3 requires denied attempts to appear in the audit trail).
+// denyByPolicy hard-denies the call without execution.
 func (s *Service) denyByPolicy(ctx context.Context, inv Invocation, reason string) (InvocationResponse, error) {
 	completed := time.Now().UTC()
 	inv.Status = StatusDenied
@@ -176,11 +202,8 @@ func (s *Service) executeNow(ctx context.Context, inv Invocation, upstream mcp.U
 	return s.finishExecution(ctx, inv, upstream, req)
 }
 
-// waitForHumanApproval blocks the caller's goroutine until an operator posts to
-// /approve or /deny, or the request context is cancelled.
+// waitForHumanApproval blocks until an operator approves or denies, or the context is cancelled.
 func (s *Service) waitForHumanApproval(ctx context.Context, inv Invocation, upstream mcp.Upstream, req CreateInvocationRequest) (InvocationResponse, error) {
-	// Register the channel before updating status so the UI sees the invocation
-	// as pending_approval as soon as it polls/streams.
 	ch := make(chan approvalDecision, 1)
 	s.mu.Lock()
 	s.pendingApprovals[inv.InvocationID] = ch
@@ -207,21 +230,21 @@ func (s *Service) waitForHumanApproval(ctx context.Context, inv Invocation, upst
 	})
 
 	select {
-	case decision := <-ch:
-		if !decision.approved {
+	case d := <-ch:
+		if !d.approved {
 			completed := time.Now().UTC()
 			inv.Status = StatusDenied
 			inv.CompletedAt = &completed
 			msg := "Tool call denied by the MCP permissions system."
-			if decision.message != "" {
-				msg += "\n\nReason: " + decision.message
+			if d.message != "" {
+				msg += "\n\nReason: " + d.message
 			}
 			inv.Error = mustJSON(map[string]any{"content": []map[string]any{{"type": "text", "text": msg}}, "isError": true})
 			_ = s.invocations.UpdateResult(context.Background(), inv)
 			_ = s.events.Create(context.Background(), Event{
 				InvocationID: inv.InvocationID,
 				EventType:    "invocation.denied",
-				Payload:      mustJSON(map[string]any{"message": decision.message, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}),
+				Payload:      mustJSON(map[string]any{"message": d.message, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}),
 				CreatedAt:    completed,
 			})
 			return s.toResponse(inv), nil
@@ -334,6 +357,49 @@ func (s *Service) ListTools(ctx context.Context, server string) ([]mcp.Tool, err
 		return nil, err
 	}
 	return tools, nil
+}
+
+// ResolveToolServer finds which upstream server provides the named tool.
+// Used in aggregate mode (no server in URL) to route tools/call correctly.
+func (s *Service) ResolveToolServer(ctx context.Context, toolName string) (string, error) {
+	upstreams, err := s.resolver.ListAll(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, upstream := range upstreams {
+		tctx, cancel := context.WithTimeout(ctx, s.defaultTimeout)
+		tools, err := s.client.ListTools(tctx, upstream)
+		cancel()
+		if err != nil {
+			continue
+		}
+		for _, t := range tools {
+			if t.Name == toolName {
+				return upstream.Name, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no server found for tool %q", toolName)
+}
+
+// ListAllTools aggregates tools from every enabled upstream. Used when the MCP
+// client connects to the root /mcp endpoint without specifying a server name.
+func (s *Service) ListAllTools(ctx context.Context) ([]mcp.Tool, error) {
+	upstreams, err := s.resolver.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var all []mcp.Tool
+	for _, upstream := range upstreams {
+		tctx, cancel := context.WithTimeout(ctx, s.defaultTimeout)
+		tools, err := s.client.ListTools(tctx, upstream)
+		cancel()
+		if err != nil {
+			continue // skip unreachable servers rather than failing the whole list
+		}
+		all = append(all, tools...)
+	}
+	return all, nil
 }
 
 func (s *Service) Get(ctx context.Context, id string) (InvocationResponse, error) {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -168,6 +168,7 @@ func (s *Service) denyByPolicy(ctx context.Context, inv Invocation, reason strin
 	completed := time.Now().UTC()
 	inv.Status = StatusDenied
 	inv.CompletedAt = &completed
+	inv.Approval = &Approval{Status: "auto_denied", Reason: stringPtr(reason)}
 	msg := "Tool call hard-denied by policy."
 	if reason != "" {
 		msg += " Reason: " + reason
@@ -186,6 +187,7 @@ func (s *Service) denyByPolicy(ctx context.Context, inv Invocation, reason strin
 // executeNow runs the tool call immediately without waiting for human approval.
 func (s *Service) executeNow(ctx context.Context, inv Invocation, upstream mcp.Upstream, req CreateInvocationRequest, reason string) (InvocationResponse, error) {
 	inv.Status = StatusExecuting
+	inv.Approval = &Approval{Status: "auto_approved", Reason: stringPtr(reason)}
 	if err := s.invocations.UpdateResult(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
@@ -235,6 +237,7 @@ func (s *Service) waitForHumanApproval(ctx context.Context, inv Invocation, upst
 			completed := time.Now().UTC()
 			inv.Status = StatusDenied
 			inv.CompletedAt = &completed
+			inv.Approval = &Approval{Status: "denied", Reason: stringPtr("human")}
 			msg := "Tool call denied by the MCP permissions system."
 			if d.message != "" {
 				msg += "\n\nReason: " + d.message
@@ -260,6 +263,7 @@ func (s *Service) waitForHumanApproval(ctx context.Context, inv Invocation, upst
 	}
 
 	inv.Status = StatusExecuting
+	inv.Approval = &Approval{Status: "approved", Reason: stringPtr("human")}
 	if err := s.invocations.UpdateResult(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
@@ -355,6 +359,7 @@ func (s *Service) recordExternalDecision(ctx context.Context, invocationID strin
 	now := time.Now().UTC()
 	if approved {
 		inv.Status = StatusApproved
+		inv.Approval = &Approval{Status: "approved", Reason: stringPtr("human")}
 		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
 			return err
 		}
@@ -363,6 +368,7 @@ func (s *Service) recordExternalDecision(ctx context.Context, invocationID strin
 	}
 	inv.Status = StatusDenied
 	inv.CompletedAt = &now
+	inv.Approval = &Approval{Status: "denied", Reason: stringPtr("human")}
 	msg := "Tool call denied by the MCP permissions system."
 	if message != "" {
 		msg += "\n\nReason: " + message
@@ -375,10 +381,15 @@ func (s *Service) recordExternalDecision(ctx context.Context, invocationID strin
 	return nil
 }
 
-// Submit creates an invocation in the pending_approval state on behalf of an
-// external executor (e.g. an amp coding harness plugin). It does NOT execute
-// the tool — the caller is expected to poll Get() until status is approved or
-// denied, run the tool itself, and then RecordExecution() with the outcome.
+// Submit creates an invocation on behalf of an external executor (e.g. an amp
+// coding harness plugin). It does NOT execute the tool — the caller is expected
+// to poll Get() until status is approved or denied, run the tool itself, and
+// then RecordExecution() with the outcome.
+//
+// Rules are evaluated against the source (as the "server") and tool name.
+// If a rule matches auto_approve, the invocation is immediately approved.
+// If a rule matches auto_deny, it is immediately denied.
+// Otherwise, the invocation enters pending_approval for human review.
 func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (InvocationResponse, error) {
 	if req.Tool == "" {
 		return InvocationResponse{}, fmt.Errorf("tool is required")
@@ -414,6 +425,21 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	if err := s.invocations.Create(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
+
+	// Evaluate rules against (source, tool, user) — same logic as Invoke.
+	ruleAction := ""
+	if s.rules != nil {
+		if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
+			user := ""
+			if req.RequestID != nil {
+				user = *req.RequestID
+			}
+			if matched := matchRule(approvalRules, source, req.Tool, user); matched != nil {
+				ruleAction = matched.Action
+			}
+		}
+	}
+
 	receivedPayload := map[string]any{"tool": req.Tool, "upstream": source, "request_id": req.RequestID, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "external": true}
 	if req.Description != "" {
 		receivedPayload["description"] = req.Description
@@ -421,7 +447,33 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	if req.ThreadID != "" {
 		receivedPayload["thread_id"] = req.ThreadID
 	}
+	if ruleAction != "" {
+		receivedPayload["disposition"] = ruleAction
+	}
 	_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.received", Payload: mustJSON(receivedPayload), CreatedAt: now})
+
+	switch ruleAction {
+	case RuleActionAutoDeny:
+		completed := time.Now().UTC()
+		inv.Status = StatusDenied
+		inv.CompletedAt = &completed
+		inv.Approval = &Approval{Status: "auto_denied", Reason: stringPtr("matched approval rule (auto_deny)")}
+		inv.Error = mustJSON(map[string]any{"content": []map[string]any{{"type": "text", "text": "Tool call denied by approval rule (auto_deny)."}}, "isError": true})
+		_ = s.invocations.UpdateResult(context.Background(), inv)
+		_ = s.events.Create(context.Background(), Event{InvocationID: inv.InvocationID, EventType: "invocation.denied", Payload: mustJSON(map[string]any{"reason": "matched approval rule (auto_deny)", "disposition": "never"}), CreatedAt: completed})
+		return s.toResponse(inv), nil
+
+	case RuleActionAutoApprove:
+		inv.Status = StatusApproved
+		inv.Approval = &Approval{Status: "auto_approved", Reason: stringPtr("matched approval rule (auto_approve)")}
+		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
+			return InvocationResponse{}, err
+		}
+		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.approved", Payload: mustJSON(map[string]any{"auto_approved": true, "auto_reason": "matched approval rule (auto_approve)"}), CreatedAt: time.Now().UTC()})
+		return s.toResponse(inv), nil
+	}
+
+	// Default: human approval required.
 	inv.Status = StatusPendingApproval
 	if err := s.invocations.UpdateResult(ctx, inv); err != nil {
 		return InvocationResponse{}, err
@@ -613,6 +665,8 @@ func mustJSON(v any) []byte {
 	b, _ := json.Marshal(v)
 	return b
 }
+
+func stringPtr(v string) *string { return &v }
 
 func normalizedLimit(limit uint64, fallback uint64) uint64 {
 	if limit == 0 {

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -194,7 +194,7 @@ func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	return invocation.NewService(store.NewInvocationRepo(db), store.NewEventRepo(db), resolver, mcp.NewHTTPClient(), policy.AlwaysApproveProvider{}, 5*time.Second)
+	return invocation.NewService(store.NewInvocationRepo(db), store.NewEventRepo(db), resolver, mcp.NewHTTPClient(), policy.AlwaysApproveProvider{}, 5*time.Second, nil)
 }
 
 func approveNextInvocation(t *testing.T, service *invocation.Service, delay time.Duration) {

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -198,14 +198,16 @@ func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 }
 
 func approveNextInvocation(t *testing.T, service *invocation.Service, delay time.Duration) {
-	t.Helper()
 	time.Sleep(delay)
 	list, err := service.List(context.Background(), invocation.InvocationListFilter{Limit: 10})
 	if err != nil || len(list.Items) == 0 {
-		t.Fatalf("list invocations: %v", err)
+		// Log instead of Fatalf — this runs in a goroutine and the parent test
+		// may have already finished, which would cause a panic.
+		t.Errorf("list invocations: %v", err)
+		return
 	}
 	if err := service.Approve(context.Background(), list.Items[0].InvocationID); err != nil {
-		t.Fatalf("approve invocation: %v", err)
+		t.Errorf("approve invocation: %v", err)
 	}
 }
 
@@ -232,8 +234,11 @@ func assertInvokeLifecycle(t *testing.T, service *invocation.Service, server, to
 	if resp.ToolName != tool {
 		t.Fatalf("expected tool name %q, got %q", tool, resp.ToolName)
 	}
-	if resp.Approval != nil {
-		t.Fatal("expected nil approval")
+	if resp.Approval == nil {
+		t.Fatal("expected approval to be set")
+	}
+	if resp.Approval.Status != "auto_approved" {
+		t.Fatalf("expected auto_approved status, got %q", resp.Approval.Status)
 	}
 	if string(resp.Input) != `{"n":1}` {
 		t.Fatalf("expected input to be surfaced, got %s", string(resp.Input))

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -257,6 +257,26 @@ func (r *Resolver) ResolveContext(ctx context.Context, name string) (Upstream, e
 	return upstream, nil
 }
 
+func (r *Resolver) ListAll(ctx context.Context) ([]Upstream, error) {
+	if r.store != nil {
+		enabled := true
+		upstreams, _, err := r.store.ListServers(ctx, ServerFilter{Enabled: &enabled})
+		if err != nil {
+			return nil, err
+		}
+		if len(upstreams) > 0 {
+			return upstreams, nil
+		}
+	}
+	var result []Upstream
+	for _, u := range r.bootstrap {
+		if u.Enabled {
+			result = append(result, u)
+		}
+	}
+	return result, nil
+}
+
 func (r *Resolver) BootstrapIfEmpty(ctx context.Context) error {
 	if r.store == nil {
 		return nil

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 3 {
+	if len(migrations) != 4 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -56,6 +56,7 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{1, "001_init_schema.sql"},
 		{2, "002_server_status_columns.sql"},
 		{3, "003_oauth_tables.sql"},
+		{4, "004_rules_table.sql"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -66,11 +67,11 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 2 {
+	if len(pending) != 3 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	if pending[0].Version != 2 || pending[1].Version != 3 {
-		t.Fatalf("pending versions = %d, %d", pending[0].Version, pending[1].Version)
+	if pending[0].Version != 2 || pending[1].Version != 3 || pending[2].Version != 4 {
+		t.Fatalf("pending versions = %d, %d, %d", pending[0].Version, pending[1].Version, pending[2].Version)
 	}
 }
 

--- a/internal/store/migrations/004_rules_table.go
+++ b/internal/store/migrations/004_rules_table.go
@@ -1,0 +1,40 @@
+package migrations
+
+func migration004() Definition {
+	return Definition{
+		Version: 4,
+		Name:    "004_rules_table.sql",
+		Steps: []Step{
+			RawDialect("create approval_rules table", `
+				CREATE TABLE IF NOT EXISTS approval_rules (
+					id             TEXT    PRIMARY KEY,
+					action         TEXT    NOT NULL,
+					server_pattern TEXT    NOT NULL DEFAULT '[]',
+					tool_pattern   TEXT    NOT NULL DEFAULT '[]',
+					user_pattern   TEXT    NOT NULL DEFAULT '*',
+					description    TEXT,
+					enabled        INTEGER NOT NULL DEFAULT 1,
+					rule_order     INTEGER NOT NULL DEFAULT 0,
+					created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					updated_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)
+			`, `
+				CREATE TABLE IF NOT EXISTS approval_rules (
+					id             TEXT    PRIMARY KEY,
+					action         TEXT    NOT NULL,
+					server_pattern TEXT    NOT NULL DEFAULT '[]',
+					tool_pattern   TEXT    NOT NULL DEFAULT '[]',
+					user_pattern   TEXT    NOT NULL DEFAULT '*',
+					description    TEXT,
+					enabled        INTEGER NOT NULL DEFAULT 1,
+					rule_order     INTEGER NOT NULL DEFAULT 0,
+					created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					updated_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)
+			`),
+			Raw("create approval_rules order index", `
+				CREATE INDEX IF NOT EXISTS idx_approval_rules_order ON approval_rules (rule_order ASC)
+			`),
+		},
+	}
+}

--- a/internal/store/migrations/004_rules_table.sql
+++ b/internal/store/migrations/004_rules_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS approval_rules (
+    id             TEXT    PRIMARY KEY,
+    action         TEXT    NOT NULL,
+    server_pattern TEXT    NOT NULL DEFAULT '*',
+    tool_pattern   TEXT    NOT NULL DEFAULT '*',
+    user_pattern   TEXT    NOT NULL DEFAULT '*',
+    description    TEXT,
+    enabled        INTEGER NOT NULL DEFAULT 1,
+    rule_order     INTEGER NOT NULL DEFAULT 0,
+    created_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_approval_rules_order ON approval_rules (rule_order ASC);

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -37,5 +37,6 @@ func All() []Definition {
 		migration001(),
 		migration002(),
 		migration003(),
+		migration004(),
 	}
 }

--- a/internal/store/rules.go
+++ b/internal/store/rules.go
@@ -1,0 +1,331 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+
+	"atryum/internal/invocation"
+)
+
+// Rule is the store-level representation of an approval rule.
+// ServerPatterns and ToolPatterns are serialized as JSON arrays in the
+// server_pattern / tool_pattern TEXT columns; an empty slice means "match all".
+type Rule struct {
+	ID             string
+	Action         string
+	ServerPatterns []string
+	ToolPatterns   []string
+	UserPattern    string
+	Description    string
+	Enabled        bool
+	Order          int
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+// RulesRepo provides CRUD and ordering operations for approval_rules.
+type RulesRepo struct {
+	db *sql.DB
+	sb sq.StatementBuilderType
+}
+
+func NewRulesRepo(db *sql.DB) *RulesRepo {
+	return NewRulesRepoWithDialect(db, DialectSQLite)
+}
+
+func NewRulesRepoWithDialect(db *sql.DB, dialect Dialect) *RulesRepo {
+	return &RulesRepo{db: db, sb: statementBuilderForDialect(dialect)}
+}
+
+var ruleColumns = []string{
+	"id", "action", "server_pattern", "tool_pattern", "user_pattern",
+	"description", "enabled", "rule_order", "created_at", "updated_at",
+}
+
+func (r *RulesRepo) Create(ctx context.Context, rule Rule) error {
+	now := time.Now().UTC()
+	serverJSON, toolJSON, err := encodeRulePatterns(rule)
+	if err != nil {
+		return err
+	}
+	query, args, err := r.sb.Insert("approval_rules").
+		Columns(ruleColumns...).
+		Values(
+			rule.ID, rule.Action, serverJSON, toolJSON, rule.UserPattern,
+			emptyToNil(rule.Description), boolToInt(rule.Enabled), rule.Order, now, now,
+		).ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = r.db.ExecContext(ctx, query, args...)
+	return err
+}
+
+func (r *RulesRepo) Get(ctx context.Context, id string) (Rule, error) {
+	query, args, err := r.sb.Select(ruleColumns...).
+		From("approval_rules").
+		Where(sq.Eq{"id": id}).
+		ToSql()
+	if err != nil {
+		return Rule{}, err
+	}
+	return scanRule(r.db.QueryRowContext(ctx, query, args...))
+}
+
+func (r *RulesRepo) List(ctx context.Context) ([]Rule, error) {
+	query, args, err := r.sb.Select(ruleColumns...).
+		From("approval_rules").
+		OrderBy("rule_order ASC").
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Rule
+	for rows.Next() {
+		rule, err := scanRule(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, rule)
+	}
+	return out, rows.Err()
+}
+
+// NextOrder returns MAX(rule_order)+1 so new rules are appended at the end.
+func (r *RulesRepo) NextOrder(ctx context.Context) (int, error) {
+	query, args, err := r.sb.Select("COALESCE(MAX(rule_order) + 1, 0)").
+		From("approval_rules").
+		ToSql()
+	if err != nil {
+		return 0, err
+	}
+	var order int
+	if err := r.db.QueryRowContext(ctx, query, args...).Scan(&order); err != nil {
+		return 0, err
+	}
+	return order, nil
+}
+
+func (r *RulesRepo) Update(ctx context.Context, rule Rule) error {
+	now := time.Now().UTC()
+	serverJSON, toolJSON, err := encodeRulePatterns(rule)
+	if err != nil {
+		return err
+	}
+	query, args, err := r.sb.Update("approval_rules").
+		Set("action", rule.Action).
+		Set("server_pattern", serverJSON).
+		Set("tool_pattern", toolJSON).
+		Set("user_pattern", rule.UserPattern).
+		Set("description", emptyToNil(rule.Description)).
+		Set("enabled", boolToInt(rule.Enabled)).
+		Set("updated_at", now).
+		Where(sq.Eq{"id": rule.ID}).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err == nil && n == 0 {
+		return sql.ErrNoRows
+	}
+	return err
+}
+
+func (r *RulesRepo) Delete(ctx context.Context, id string) error {
+	query, args, err := r.sb.Delete("approval_rules").
+		Where(sq.Eq{"id": id}).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err == nil && n == 0 {
+		return sql.ErrNoRows
+	}
+	return err
+}
+
+// Move swaps the rule_order of the target rule with its neighbor in the given
+// direction ("up" or "down") and returns the full re-ordered list.
+func (r *RulesRepo) Move(ctx context.Context, id string, direction string) ([]Rule, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	query, args, err := r.sb.Select("id", "rule_order").
+		From("approval_rules").
+		OrderBy("rule_order ASC").
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	type idOrder struct {
+		id    string
+		order int
+	}
+	var items []idOrder
+	for rows.Next() {
+		var item idOrder
+		if err := rows.Scan(&item.id, &item.order); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	idx := -1
+	for i, item := range items {
+		if item.id == id {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		return nil, sql.ErrNoRows
+	}
+
+	var neighborIdx int
+	switch direction {
+	case "up":
+		if idx == 0 {
+			return nil, fmt.Errorf("rule is already first")
+		}
+		neighborIdx = idx - 1
+	case "down":
+		if idx == len(items)-1 {
+			return nil, fmt.Errorf("rule is already last")
+		}
+		neighborIdx = idx + 1
+	default:
+		return nil, fmt.Errorf("direction must be 'up' or 'down'")
+	}
+
+	now := time.Now().UTC()
+
+	swapA, swapAArgs, err := r.sb.Update("approval_rules").
+		Set("rule_order", items[neighborIdx].order).
+		Set("updated_at", now).
+		Where(sq.Eq{"id": items[idx].id}).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+	swapB, swapBArgs, err := r.sb.Update("approval_rules").
+		Set("rule_order", items[idx].order).
+		Set("updated_at", now).
+		Where(sq.Eq{"id": items[neighborIdx].id}).
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := tx.ExecContext(ctx, swapA, swapAArgs...); err != nil {
+		return nil, err
+	}
+	if _, err := tx.ExecContext(ctx, swapB, swapBArgs...); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return r.List(ctx)
+}
+
+func scanRule(scanner interface{ Scan(dest ...any) error }) (Rule, error) {
+	var rule Rule
+	var serverJSON, toolJSON string
+	var description sql.NullString
+	var enabled int
+	if err := scanner.Scan(
+		&rule.ID, &rule.Action, &serverJSON, &toolJSON, &rule.UserPattern,
+		&description, &enabled, &rule.Order, &rule.CreatedAt, &rule.UpdatedAt,
+	); err != nil {
+		return Rule{}, err
+	}
+	rule.Enabled = enabled == 1
+	rule.Description = description.String
+	if err := json.Unmarshal([]byte(serverJSON), &rule.ServerPatterns); err != nil {
+		rule.ServerPatterns = []string{}
+	}
+	if rule.ServerPatterns == nil {
+		rule.ServerPatterns = []string{}
+	}
+	if err := json.Unmarshal([]byte(toolJSON), &rule.ToolPatterns); err != nil {
+		rule.ToolPatterns = []string{}
+	}
+	if rule.ToolPatterns == nil {
+		rule.ToolPatterns = []string{}
+	}
+	return rule, nil
+}
+
+// ListApprovalRules satisfies the invocation.rulesStore interface.
+// It converts store.Rule to invocation.ApprovalRule for evaluation in the
+// invocation service without creating an import cycle.
+func (r *RulesRepo) ListApprovalRules(ctx context.Context) ([]invocation.ApprovalRule, error) {
+	rules, err := r.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]invocation.ApprovalRule, 0, len(rules))
+	for _, rule := range rules {
+		out = append(out, invocation.ApprovalRule{
+			Action:         rule.Action,
+			ServerPatterns: rule.ServerPatterns,
+			ToolPatterns:   rule.ToolPatterns,
+			UserPattern:    rule.UserPattern,
+			Enabled:        rule.Enabled,
+		})
+	}
+	return out, nil
+}
+
+func encodeRulePatterns(rule Rule) (serverJSON string, toolJSON string, err error) {
+	sp := rule.ServerPatterns
+	if sp == nil {
+		sp = []string{}
+	}
+	tp := rule.ToolPatterns
+	if tp == nil {
+		tp = []string{}
+	}
+	spBytes, e := json.Marshal(sp)
+	if e != nil {
+		return "", "", e
+	}
+	tpBytes, e := json.Marshal(tp)
+	if e != nil {
+		return "", "", e
+	}
+	return string(spBytes), string(tpBytes), nil
+}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -41,12 +41,12 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 3 {
-		t.Fatalf("expected 3 migrations, got %d", count)
+	if count != 4 {
+		t.Fatalf("expected 4 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
-	tables := []string{"invocations", "invocation_events", "mcp_servers", "oauth_credentials", "oauth_connect_sessions"}
+	tables := []string{"invocations", "invocation_events", "mcp_servers", "oauth_credentials", "oauth_connect_sessions", "approval_rules"}
 	for _, table := range tables {
 		var name string
 		if err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&name); err != nil {
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 3 {
-		t.Fatalf("expected 3 migrations after double init, got %d", count)
+	if count != 4 {
+		t.Fatalf("expected 4 migrations after double init, got %d", count)
 	}
 }
 


### PR DESCRIPTION
## What and why?

Adds a fine-grained **approval rules** system that sits in front of the global policy registry. Rules are ordered, pattern-matched entries (server glob × tool glob × user pattern) that map to one of three actions:

- **auto_approve** — tool call proceeds immediately, no human gate
- **auto_deny** — tool call is rejected without waiting for a human
- **human_approval** — falls through to the existing pending-approval flow

If no rule matches, the active **policy provider** (`always_approve`, `always_deny`, or `timed_approve`) is used as the global fallback. This keeps the existing policy toggle working while giving operators fine-grained per-tool control.

Also includes two infrastructure fixes needed to make Atryum work as a proper MCP endpoint in Cursor:

1. **SSE keepalive on `GET /mcp/*`** — Cursor tries GET first to establish an SSE stream; the previous 405 prevented the initial connection handshake.
2. **Aggregate mode on the root `/mcp/` endpoint** — `tools/list` now merges tools from all enabled upstreams and `tools/call` resolves the correct upstream by tool name, so the URL `http://localhost:8080/mcp` works without a server-name path segment.

## What changed

| File | Change |
|---|---|
| `internal/invocation/rules.go` | `ApprovalRule` type, `matchRule` / `matchPatterns` glob helpers |
| `internal/store/rules.go` | `RulesRepo` — CRUD, `NextOrder`, and `Move` (swap neighbours); dialect-aware (SQLite + Postgres) |
| `internal/store/migrations.go` | Migration 004 — `approval_rules` table |
| `internal/invocation/service.go` | Rules-first + policy-fallback decision in `Invoke`; keeps upstream helper methods; merges upstream Postgres + policy-registry work |
| `internal/api/handlers.go` | `GET\|POST /api/v1/admin/rules` and `/api/v1/admin/rules/{id}` (CRUD + move); `GET /api/v1/admin/servers/{name}/tools`; `Handler` carries both `policyRegistry` and `rulesRepo`; SSE keepalive; aggregate tools endpoints |
| `internal/mcp/client.go` | `Resolver.ListAll` — enumerates all enabled upstreams |
| `cmd/atryum/main.go` | Wires `rulesRepo` alongside `policyRegistry`; uses `WithDialect` constructors |

## Conflict resolution

This branch also resolves the stash conflict with commit `85a8ec2` (Postgres + pluggable policy system). Both systems are preserved: rules take priority, policy is the fallback.

## How to test

1. Start Atryum: `go run ./cmd/atryum`
2. Add a rule via the Rules UI (or `POST /api/v1/admin/rules`), e.g. action=`auto_deny`, server_patterns=`[]`, tool_patterns=`["write_file"]`
3. Call `write_file` through MCP — it should be denied immediately without a human-approval prompt
4. Call any other tool — it should route through the policy provider (default: `always_approve`)
5. Connect Cursor to `http://localhost:8080/mcp` — it should establish an SSE connection and list all tools from all configured upstream servers

## What needs special review?

- **Rules-before-policy ordering** in `service.go` — confirm this is the desired precedence
- **`ResolveToolServer`** iterates all upstreams on each `tools/call` in aggregate mode — acceptable for now; could be cached
- Conflict resolution between the upstream policy refactor and this branch's rules work

Made with [Cursor](https://cursor.com)