### PR TITLE
Add inbound OAuth bearer auth for /mcp/ routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pi
+.DS_Store
 .direnv
 .envrc
 *.nix

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Secrets are not intentionally logged.
 
 ## Auth debug mode
 
-For local OAuth troubleshooting, Atryum can require a bearer JWT while skipping
-JWT verification:
+For local OAuth troubleshooting, Atryum can completely bypass inbound auth on
+`/mcp/`:
 
 ```toml
 [auth_debug]
@@ -71,10 +71,10 @@ or:
 ATRYUM_AUTH_DEBUG_SKIP_VERIFY=1 go run ./cmd/atryum -config atryum.auth0.toml
 ```
 
-When enabled, `/mcp/` still requires `Authorization: Bearer ...`, but Atryum
-parses the JWT claims without verifying signature, issuer, audience, expiry, or
-scope. It extracts the agent identity from the configured `agent_id_claim`
-fallback chain and then continues handling the MCP request.
+When enabled, the `Authorization` header is ignored entirely on `/mcp/`: no
+bearer token is required, no claims are parsed, and no agent identity is set
+on the request context. Requests reach the upstream MCP server as if no
+`[[auth]]` section had been configured.
 
 This is only for local debugging. Do not enable it in shared or production
 environments.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ to log concise MCP proxy activity in local run output. Current debug logging inc
 
 Secrets are not intentionally logged.
 
+## Auth debug mode
+
+For local OAuth troubleshooting, Atryum can require a bearer JWT while skipping
+JWT verification:
+
+```toml
+[auth_debug]
+skip_verify = true
+```
+
+or:
+
+```bash
+ATRYUM_AUTH_DEBUG_SKIP_VERIFY=1 go run ./cmd/atryum -config atryum.auth0.toml
+```
+
+When enabled, `/mcp/` still requires `Authorization: Bearer ...`, but Atryum
+parses the JWT claims without verifying signature, issuer, audience, expiry, or
+scope. It extracts the agent identity from the configured `agent_id_claim`
+fallback chain and then continues handling the MCP request.
+
+This is only for local debugging. Do not enable it in shared or production
+environments.
+
 ## Database configuration
 
 SQLite remains the default storage provider:

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -13,6 +13,12 @@ log_level = "info"
 [defaults]
 request_timeout_seconds = 30
 
+# Local-only auth debug mode. When true, /mcp/ still requires a bearer JWT but
+# Atryum parses its claims without verifying signature, issuer, audience,
+# expiry, or scope. Never enable outside local debugging.
+[auth_debug]
+skip_verify = false
+
 # Bootstrap-only upstream definitions.
 # On startup, Atryum seeds mcp_servers from these entries only when the DB is empty.
 # After bootstrap, runtime resolution uses SQLite as the source of truth.

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -36,3 +36,25 @@ SHORTCUT_READONLY = "true"
 # timeout_seconds = 30
 # enabled = true
 # auth_token = ""
+
+# Inbound OAuth bearer-token authentication for /mcp/. Multiple [[auth]]
+# sections are supported; the validator picks the matching one based on
+# the token's `iss` claim. Other routes (/ui, /api/v1/admin/*,
+# /api/v1/external/*, /healthz) are NOT affected.
+#
+# [[auth]]
+# enabled        = true
+# issuer         = "https://keycloak.example/realms/atryum"
+# audience       = "atryum"
+# # jwks_url is optional. When omitted, OIDC discovery
+# # (issuer + /.well-known/openid-configuration) is used.
+# # jwks_url     = "https://keycloak.example/realms/atryum/protocol/openid-connect/certs"
+# required_scope = "atryum:mcp"
+# agent_id_claim = "client_id"
+#
+# [[auth]]
+# enabled        = true
+# issuer         = "https://your-tenant.us.auth0.com/"
+# audience       = "https://atryum.example/mcp"
+# required_scope = "atryum:mcp"
+# agent_id_claim = "client_id"

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -49,6 +49,7 @@ SHORTCUT_READONLY = "true"
 # # jwks_url is optional. When omitted, OIDC discovery
 # # (issuer + /.well-known/openid-configuration) is used.
 # # jwks_url     = "https://keycloak.example/realms/atryum/protocol/openid-connect/certs"
+# # Leave required_scope empty or omit it to allow tokens without a scope claim.
 # required_scope = "atryum:mcp"
 # agent_id_claim = "client_id"
 #
@@ -56,5 +57,6 @@ SHORTCUT_READONLY = "true"
 # enabled        = true
 # issuer         = "https://your-tenant.us.auth0.com/"
 # audience       = "https://atryum.example/mcp"
+# # Leave required_scope empty or omit it to allow tokens without a scope claim.
 # required_scope = "atryum:mcp"
 # agent_id_claim = "client_id"

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -13,9 +13,9 @@ log_level = "info"
 [defaults]
 request_timeout_seconds = 30
 
-# Local-only auth debug mode. When true, /mcp/ still requires a bearer JWT but
-# Atryum parses its claims without verifying signature, issuer, audience,
-# expiry, or scope. Never enable outside local debugging.
+# Local-only auth debug mode. When true, the Authorization header is ignored
+# entirely on /mcp/: no bearer token is required and no identity is set on
+# the request context. Never enable outside local debugging.
 [auth_debug]
 skip_verify = false
 

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -84,7 +84,7 @@ func main() {
 	authDebugSkipVerify := cfg.AuthDebug.SkipVerify || truthyEnv("ATRYUM_AUTH_DEBUG_SKIP_VERIFY")
 	if authDebugSkipVerify {
 		handler.SetAuthDebugSkipVerify(true)
-		log.Printf("WARNING: inbound auth debug skip_verify enabled; bearer JWTs are parsed but not verified")
+		log.Printf("WARNING: inbound auth debug skip_verify enabled; /mcp/ Authorization header is ignored entirely")
 	}
 
 	srv := &http.Server{

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"atryum/internal/api"
+	"atryum/internal/auth"
 	"atryum/internal/config"
 	"atryum/internal/invocation"
 	"atryum/internal/invocation/policy"
@@ -69,6 +70,17 @@ func main() {
 	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo)
 	serverAdmin := api.NewServerAdminService(serverRepo, oauthRepo, client, 5*time.Second)
 	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo)
+
+	authValidator, err := auth.NewValidator(cfg.Auth, nil)
+	if err != nil {
+		log.Fatalf("auth: %v", err)
+	}
+	if authValidator != nil {
+		handler.SetAuthValidator(authValidator)
+		log.Printf("inbound auth enabled (%d issuer(s))", len(authValidator.Configs()))
+	} else {
+		log.Printf("inbound auth disabled (no [[auth]] section configured)")
+	}
 
 	srv := &http.Server{
 		Addr:              cfg.Server.ListenAddr,

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -81,6 +81,11 @@ func main() {
 	} else {
 		log.Printf("inbound auth disabled (no [[auth]] section configured)")
 	}
+	authDebugSkipVerify := cfg.AuthDebug.SkipVerify || truthyEnv("ATRYUM_AUTH_DEBUG_SKIP_VERIFY")
+	if authDebugSkipVerify {
+		handler.SetAuthDebugSkipVerify(true)
+		log.Printf("WARNING: inbound auth debug skip_verify enabled; bearer JWTs are parsed but not verified")
+	}
 
 	srv := &http.Server{
 		Addr:              cfg.Server.ListenAddr,
@@ -102,4 +107,9 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = srv.Shutdown(shutdownCtx)
+}
+
+func truthyEnv(name string) bool {
+	value := os.Getenv(name)
+	return value == "1" || value == "true" || value == "TRUE" || value == "yes" || value == "YES"
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/Masterminds/squirrel v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.2
 	modernc.org/sqlite v1.35.0
@@ -12,7 +13,6 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd h1:gbpYu9NMq8jhDVbvlGkMFWCjLFlqqEZjEmObmhUy6Vo=
 github.com/google/pprof v0.0.0-20240409012703-83162a5b38cd/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -1,0 +1,254 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+
+	"atryum/internal/auth"
+	"atryum/internal/invocation"
+	"atryum/internal/mcp"
+)
+
+// jwksHandler serves a minimal JWKS document for the given RSA public key so
+// the auth.Validator can verify signatures during tests.
+func jwksHandler(pub *rsa.PublicKey, kid string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		nB := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+		eB := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes())
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{{
+				"kty": "RSA", "kid": kid, "alg": "RS256", "use": "sig",
+				"n": nB, "e": eB,
+			}},
+		})
+	}
+}
+
+// authTestRig bundles the IdP server, RSA key, and a configured Validator so
+// each test can mint tokens and assert routing/identity behavior.
+type authTestRig struct {
+	priv *rsa.PrivateKey
+	idp  *httptest.Server
+	v    *auth.Validator
+	kid  string
+}
+
+func newAuthTestRig(t *testing.T) *authTestRig {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	rig := &authTestRig{priv: priv, kid: "k1"}
+	rig.idp = httptest.NewServer(jwksHandler(&priv.PublicKey, rig.kid))
+	t.Cleanup(rig.idp.Close)
+	v, err := auth.NewValidator([]auth.Config{{
+		Enabled:       true,
+		Issuer:        "https://idp.test",
+		Audience:      "atryum",
+		JWKSURL:       rig.idp.URL,
+		RequiredScope: "atryum:mcp",
+		AgentIDClaim:  "client_id",
+	}}, nil)
+	if err != nil {
+		t.Fatalf("validator: %v", err)
+	}
+	rig.v = v
+	return rig
+}
+
+func (r *authTestRig) sign(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = r.kid
+	signed, err := tok.SignedString(r.priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signed
+}
+
+func defaultClaims() jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss":       "https://idp.test",
+		"aud":       "atryum",
+		"sub":       "subject-1",
+		"client_id": "agent-007",
+		"scope":     "atryum:mcp",
+		"iat":       now.Unix(),
+		"exp":       now.Add(5 * time.Minute).Unix(),
+	}
+}
+
+func newAuthedHandler(t *testing.T, svc service, rig *authTestRig) http.Handler {
+	t.Helper()
+	h := NewHandler(svc, stubServerService{}, nil, nil)
+	h.SetAuthValidator(rig.v)
+	return h.Routes()
+}
+
+func TestMCPRequiresAuthWhenValidatorConfigured(t *testing.T) {
+	rig := newAuthTestRig(t)
+	h := newAuthedHandler(t, &stubService{}, rig)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without bearer, got %d body=%s", w.Code, w.Body.String())
+	}
+	chal := w.Header().Get("WWW-Authenticate")
+	if !strings.Contains(chal, "Bearer") {
+		t.Fatalf("expected Bearer challenge, got %q", chal)
+	}
+	if !strings.Contains(chal, "resource_metadata=") {
+		t.Fatalf("expected resource_metadata advertisement, got %q", chal)
+	}
+}
+
+func TestMCPRejectsInvalidToken(t *testing.T) {
+	rig := newAuthTestRig(t)
+	h := newAuthedHandler(t, &stubService{}, rig)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	req.Header.Set("Authorization", "Bearer not-a-jwt")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for malformed token, got %d", w.Code)
+	}
+}
+
+func TestMCPRejectsTokenMissingScope(t *testing.T) {
+	rig := newAuthTestRig(t)
+	h := newAuthedHandler(t, &stubService{}, rig)
+	claims := defaultClaims()
+	claims["scope"] = "wrong"
+	tok := rig.sign(t, claims)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for insufficient scope, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMCPAcceptsValidTokenAndPlumbsAgentID(t *testing.T) {
+	rig := newAuthTestRig(t)
+	now := time.Now().UTC()
+	svc := &stubService{
+		invoke: invocation.InvocationResponse{
+			InvocationID: "inv_1", ServerName: "demo", ToolName: "demo_tool",
+			Status: invocation.StatusSucceeded, Input: json.RawMessage(`{"a":1}`),
+			SubmittedAt: now, CompletedAt: &now,
+			Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`),
+		},
+	}
+	h := newAuthedHandler(t, svc, rig)
+
+	tok := rig.sign(t, defaultClaims())
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"demo_tool","arguments":{"a":1}}}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if svc.invokedReq == nil {
+		t.Fatal("expected service.Invoke to be called")
+	}
+	id := auth.AgentIDFromContext(svc.invokedCtx)
+	if id != "agent-007" {
+		t.Fatalf("expected agent_id agent-007 on invoke ctx, got %q", id)
+	}
+}
+
+func TestUnprotectedRoutesRemainOpenWhenAuthEnabled(t *testing.T) {
+	rig := newAuthTestRig(t)
+	now := time.Now().UTC()
+	svc := &stubService{invoke: invocation.InvocationResponse{InvocationID: "inv_1", ServerName: "demo", ToolName: "demo_tool", Status: invocation.StatusSucceeded, SubmittedAt: now}}
+	h := newAuthedHandler(t, svc, rig)
+
+	cases := []struct {
+		method string
+		path   string
+		body   string
+		want   int
+	}{
+		{http.MethodGet, "/healthz", "", http.StatusOK},
+		{http.MethodGet, "/api/v1/admin/invocations", "", http.StatusOK},
+		{http.MethodGet, "/ui/", "", http.StatusOK},
+		{http.MethodPost, "/api/v1/external/invocations", `{"tool":"x","input":{}}`, http.StatusOK},
+	}
+	for _, c := range cases {
+		var body *strings.Reader
+		if c.body != "" {
+			body = strings.NewReader(c.body)
+		} else {
+			body = strings.NewReader("")
+		}
+		req := httptest.NewRequest(c.method, c.path, body)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != c.want {
+			t.Errorf("%s %s: expected %d (no auth required), got %d body=%s", c.method, c.path, c.want, w.Code, w.Body.String())
+		}
+		if got := w.Header().Get("WWW-Authenticate"); got != "" {
+			t.Errorf("%s %s: did not expect WWW-Authenticate, got %q", c.method, c.path, got)
+		}
+	}
+}
+
+func TestProtectedResourceMetadataServed(t *testing.T) {
+	rig := newAuthTestRig(t)
+	h := newAuthedHandler(t, &stubService{}, rig)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	req.Host = "atryum.example"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var doc auth.ProtectedResourceMetadata
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode: %v body=%s", err, w.Body.String())
+	}
+	if doc.Resource != "http://atryum.example/mcp" {
+		t.Fatalf("resource = %q", doc.Resource)
+	}
+	if len(doc.AuthorizationServers) != 1 || doc.AuthorizationServers[0] != "https://idp.test" {
+		t.Fatalf("authorization_servers = %#v", doc.AuthorizationServers)
+	}
+}
+
+// Sanity: when no validator is configured, /mcp/ behaves as before.
+func TestMCPNoValidatorPreservesAnonymousAccess(t *testing.T) {
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
+	w := httptest.NewRecorder()
+	h.Routes().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 anonymous, got %d", w.Code)
+	}
+}
+
+// satisfy unused import in some build configurations
+var _ = context.Background
+var _ = mcp.ConnectionStatusReady

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -17,7 +16,6 @@ import (
 
 	"atryum/internal/auth"
 	"atryum/internal/invocation"
-	"atryum/internal/mcp"
 )
 
 // jwksHandler serves a minimal JWKS document for the given RSA public key so
@@ -248,7 +246,3 @@ func TestMCPNoValidatorPreservesAnonymousAccess(t *testing.T) {
 		t.Fatalf("expected 200 anonymous, got %d", w.Code)
 	}
 }
-
-// satisfy unused import in some build configurations
-var _ = context.Background
-var _ = mcp.ConnectionStatusReady

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -75,6 +75,7 @@ type Handler struct {
 	forwarder      mcpEnvelopeForwarder
 	staticHTTP     http.Handler
 	debug          bool
+	authDebugSkip  bool
 	authValidator  *auth.Validator
 }
 
@@ -237,6 +238,10 @@ func (h *Handler) SetAuthValidator(v *auth.Validator) {
 	h.authValidator = v
 }
 
+func (h *Handler) SetAuthDebugSkipVerify(enabled bool) {
+	h.authDebugSkip = enabled
+}
+
 // protectedResourceMetadata serves the OAuth 2.0 protected-resource metadata
 // (RFC 9728) document so MCP clients can discover the authorization server.
 // The resource URL is computed from the incoming request so deployments
@@ -252,7 +257,7 @@ func (h *Handler) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", h.healthz)
 	mux.Handle("/.well-known/oauth-protected-resource", h.protectedResourceMetadata())
-	mcpHandler := auth.Middleware(h.authValidator, "/.well-known/oauth-protected-resource")(http.HandlerFunc(h.invokeUpstream))
+	mcpHandler := auth.MiddlewareWithOptions(h.authValidator, "/.well-known/oauth-protected-resource", auth.MiddlewareOptions{SkipVerify: h.authDebugSkip})(http.HandlerFunc(h.invokeUpstream))
 	mux.Handle("/mcp/", mcpHandler)
 	mux.HandleFunc("/api/v1/invocations", h.invocations)
 	mux.HandleFunc("/api/v1/admin/invocations", h.adminInvocations)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"atryum/internal/auth"
 	"atryum/internal/invocation"
 	"atryum/internal/invocation/policy"
 	"atryum/internal/mcp"
@@ -74,6 +75,7 @@ type Handler struct {
 	forwarder      mcpEnvelopeForwarder
 	staticHTTP     http.Handler
 	debug          bool
+	authValidator  *auth.Validator
 }
 
 type PolicyStatusResponse struct {
@@ -228,10 +230,30 @@ func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Reg
 	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
 }
 
+// SetAuthValidator installs the inbound auth validator. When non-nil, the
+// /mcp/ routes require a valid bearer token. Pass nil (or omit) to leave
+// /mcp/ anonymous.
+func (h *Handler) SetAuthValidator(v *auth.Validator) {
+	h.authValidator = v
+}
+
+// protectedResourceMetadata serves the OAuth 2.0 protected-resource metadata
+// (RFC 9728) document so MCP clients can discover the authorization server.
+// The resource URL is computed from the incoming request so deployments
+// behind reverse proxies pick up X-Forwarded-* automatically.
+func (h *Handler) protectedResourceMetadata() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resource := strings.TrimRight(baseURL(r), "/") + "/mcp"
+		auth.ProtectedResourceHandler(h.authValidator, resource).ServeHTTP(w, r)
+	})
+}
+
 func (h *Handler) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", h.healthz)
-	mux.HandleFunc("/mcp/", h.invokeUpstream)
+	mux.Handle("/.well-known/oauth-protected-resource", h.protectedResourceMetadata())
+	mcpHandler := auth.Middleware(h.authValidator, "/.well-known/oauth-protected-resource")(http.HandlerFunc(h.invokeUpstream))
+	mux.Handle("/mcp/", mcpHandler)
 	mux.HandleFunc("/api/v1/invocations", h.invocations)
 	mux.HandleFunc("/api/v1/admin/invocations", h.adminInvocations)
 	mux.HandleFunc("/api/v1/admin/invocations/stream", h.adminInvocationStream)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -257,7 +257,7 @@ func (h *Handler) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", h.healthz)
 	mux.Handle("/.well-known/oauth-protected-resource", h.protectedResourceMetadata())
-	mcpHandler := auth.MiddlewareWithOptions(h.authValidator, "/.well-known/oauth-protected-resource", auth.MiddlewareOptions{SkipVerify: h.authDebugSkip})(http.HandlerFunc(h.invokeUpstream))
+	mcpHandler := auth.MiddlewareWithOptions(h.authValidator, "/.well-known/oauth-protected-resource", auth.MiddlewareOptions{SkipVerify: h.authDebugSkip, DebugLogIdentity: h.debug})(http.HandlerFunc(h.invokeUpstream))
 	mux.Handle("/mcp/", mcpHandler)
 	mux.HandleFunc("/api/v1/invocations", h.invocations)
 	mux.HandleFunc("/api/v1/admin/invocations", h.adminInvocations)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -23,10 +23,12 @@ type stubService struct {
 	fwdErr   error
 
 	invokedReq *invocation.CreateInvocationRequest
+	invokedCtx context.Context
 }
 
-func (s *stubService) Invoke(_ context.Context, req invocation.CreateInvocationRequest) (invocation.InvocationResponse, error) {
+func (s *stubService) Invoke(ctx context.Context, req invocation.CreateInvocationRequest) (invocation.InvocationResponse, error) {
 	s.invokedReq = &req
+	s.invokedCtx = ctx
 	return s.invoke, s.invErr
 }
 func (s *stubService) ListTools(context.Context, string) ([]mcp.Tool, error) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -171,6 +171,40 @@ func TestValidatorWrongAudience(t *testing.T) {
 	}
 }
 
+func TestValidatorSelectsConfigByIssuerAndAudience(t *testing.T) {
+	idp := newTestIdP(t)
+	configs := []Config{
+		{
+			Enabled:       true,
+			Issuer:        "https://idp.example/",
+			Audience:      "other-api",
+			JWKSURL:       idp.jwksURL(),
+			RequiredScope: "other:scope",
+			AgentIDClaim:  "sub",
+		},
+		{
+			Enabled:       true,
+			Issuer:        "https://idp.example/",
+			Audience:      "atryum",
+			JWKSURL:       idp.jwksURL(),
+			RequiredScope: "atryum:mcp",
+			AgentIDClaim:  "client_id",
+		},
+	}
+	v, err := NewValidator(configs, nil)
+	if err != nil {
+		t.Fatalf("NewValidator: %v", err)
+	}
+	tok := idp.sign(t, validClaims())
+	id, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if id.AgentID != "agent-1" {
+		t.Fatalf("expected config matching atryum audience, got agent id %q", id.AgentID)
+	}
+}
+
 func TestValidatorMissingScope(t *testing.T) {
 	idp := newTestIdP(t)
 	v := newValidatorForIdP(t, idp)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -435,6 +435,54 @@ func TestMiddlewareDebugSkipVerifyAcceptsUnverifiedJWT(t *testing.T) {
 	}
 }
 
+func TestMiddlewareDoesNotLogValidIdentityByDefault(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	tok := idp.sign(t, validClaims())
+	var logs bytes.Buffer
+	origWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(origWriter) })
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	h := Middleware(v, "/.well-known/oauth-protected-resource")(next)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	got := logs.String()
+	if strings.Contains(got, "[auth] valid_token") {
+		t.Fatalf("expected no valid token identity log by default, got %q", got)
+	}
+}
+
+func TestMiddlewareLogsValidIdentityInDebugMode(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	tok := idp.sign(t, validClaims())
+	var logs bytes.Buffer
+	origWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(origWriter) })
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	h := MiddlewareWithOptions(v, "/.well-known/oauth-protected-resource", MiddlewareOptions{DebugLogIdentity: true})(next)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	got := logs.String()
+	if !strings.Contains(got, "[auth] valid_token") ||
+		!strings.Contains(got, `agent_id="agent-1"`) ||
+		!strings.Contains(got, `issuer="https://idp.example"`) ||
+		!strings.Contains(got, `subject="agent-subject"`) {
+		t.Fatalf("expected valid token identity log, got %q", got)
+	}
+	if strings.Contains(got, tok) {
+		t.Fatal("auth log should not include bearer token")
+	}
+}
+
 func TestMiddlewareSetsIdentityOnContext(t *testing.T) {
 	idp := newTestIdP(t)
 	v := newValidatorForIdP(t, idp)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -218,6 +218,25 @@ func TestValidatorMissingScope(t *testing.T) {
 	}
 }
 
+func TestValidatorAllowsMissingTokenScopeWhenRequiredScopeEmpty(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp, func(c *Config) { c.RequiredScope = "" })
+	claims := validClaims()
+	delete(claims, "scope")
+	delete(claims, "scp")
+	tok := idp.sign(t, claims)
+	id, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("expected ok without token scope, got %v", err)
+	}
+	if id.AgentID != "agent-1" {
+		t.Fatalf("agent id = %q", id.AgentID)
+	}
+	if id.Scope != "" {
+		t.Fatalf("scope = %q", id.Scope)
+	}
+}
+
 func TestValidatorScpClaimArrayAccepted(t *testing.T) {
 	idp := newTestIdP(t)
 	v := newValidatorForIdP(t, idp)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -436,36 +436,48 @@ func TestMiddlewareLogsInvalidToken(t *testing.T) {
 	}
 }
 
-func TestMiddlewareDebugSkipVerifyAcceptsUnverifiedJWT(t *testing.T) {
+func TestMiddlewareDebugSkipVerifyIgnoresAuthorizationHeader(t *testing.T) {
 	idp := newTestIdP(t)
 	v := newValidatorForIdP(t, idp)
-	claims := validClaims()
-	claims["aud"] = "wrong-audience"
-	claims["scope"] = "wrong-scope"
-	claims["exp"] = time.Now().Add(-1 * time.Hour).Unix()
-	tok := idp.signWithKid(t, claims, "unknown-key")
 
-	var got Identity
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		id, ok := IdentityFromContext(r.Context())
-		if !ok {
-			t.Fatal("identity not on context")
-		}
-		got = id
-	})
-	h := MiddlewareWithOptions(v, "/.well-known/oauth-protected-resource", MiddlewareOptions{SkipVerify: true})(next)
-	req := httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}"))
-	req.Header.Set("Authorization", "Bearer "+tok)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, req)
-	if w.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	cases := []struct {
+		name       string
+		setHeader  bool
+		authHeader string
+	}{
+		{name: "no header", setHeader: false},
+		{name: "invalid scheme", setHeader: true, authHeader: "Basic abc"},
+		{name: "malformed bearer", setHeader: true, authHeader: "Bearer not-a-jwt"},
+		{name: "expired token", setHeader: true, authHeader: "Bearer " + idp.sign(t, jwt.MapClaims{
+			"iss": "https://idp.example/", "aud": "atryum", "sub": "x", "exp": time.Now().Add(-time.Hour).Unix(),
+		})},
 	}
-	if got.AgentID != "agent-1" {
-		t.Fatalf("expected debug identity from unverified claims, got %q", got.AgentID)
-	}
-	if got.Scope != "wrong-scope" {
-		t.Fatalf("scope = %q", got.Scope)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			called := false
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				if _, ok := IdentityFromContext(r.Context()); ok {
+					t.Fatal("expected no identity on context when skip_verify is true")
+				}
+			})
+			h := MiddlewareWithOptions(v, "/.well-known/oauth-protected-resource", MiddlewareOptions{SkipVerify: true})(next)
+			req := httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}"))
+			if c.setHeader {
+				req.Header.Set("Authorization", c.authHeader)
+			}
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+			}
+			if !called {
+				t.Fatal("expected next handler to be called")
+			}
+			if got := w.Header().Get("WWW-Authenticate"); got != "" {
+				t.Fatalf("did not expect WWW-Authenticate, got %q", got)
+			}
+		})
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -333,6 +333,40 @@ func TestMiddlewareBlocksMissingToken(t *testing.T) {
 	}
 }
 
+func TestMiddlewareOmitsChallengeScopeForMixedEmptyRequiredScopes(t *testing.T) {
+	idp := newTestIdP(t)
+	v, err := NewValidator([]Config{
+		{
+			Enabled:       true,
+			Issuer:        "https://idp.example/",
+			Audience:      "atryum",
+			JWKSURL:       idp.jwksURL(),
+			RequiredScope: "",
+			AgentIDClaim:  "client_id",
+		},
+		{
+			Enabled:       true,
+			Issuer:        "https://other-idp.example/",
+			Audience:      "other-api",
+			JWKSURL:       idp.jwksURL(),
+			RequiredScope: "atryum:mcp",
+			AgentIDClaim:  "client_id",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewValidator: %v", err)
+	}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	h := Middleware(v, "/.well-known/oauth-protected-resource")(next)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}")))
+	chal := w.Header().Get("WWW-Authenticate")
+	if strings.Contains(chal, "scope=") {
+		t.Fatalf("expected challenge to omit scope for mixed empty/non-empty required scopes, got %q", chal)
+	}
+}
+
 func TestMiddlewareReturns403ForMissingScope(t *testing.T) {
 	idp := newTestIdP(t)
 	v := newValidatorForIdP(t, idp)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -402,6 +402,39 @@ func TestMiddlewareLogsInvalidToken(t *testing.T) {
 	}
 }
 
+func TestMiddlewareDebugSkipVerifyAcceptsUnverifiedJWT(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	claims := validClaims()
+	claims["aud"] = "wrong-audience"
+	claims["scope"] = "wrong-scope"
+	claims["exp"] = time.Now().Add(-1 * time.Hour).Unix()
+	tok := idp.signWithKid(t, claims, "unknown-key")
+
+	var got Identity
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := IdentityFromContext(r.Context())
+		if !ok {
+			t.Fatal("identity not on context")
+		}
+		got = id
+	})
+	h := MiddlewareWithOptions(v, "/.well-known/oauth-protected-resource", MiddlewareOptions{SkipVerify: true})(next)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if got.AgentID != "agent-1" {
+		t.Fatalf("expected debug identity from unverified claims, got %q", got.AgentID)
+	}
+	if got.Scope != "wrong-scope" {
+		t.Fatalf("scope = %q", got.Scope)
+	}
+}
+
 func TestMiddlewareSetsIdentityOnContext(t *testing.T) {
 	idp := newTestIdP(t)
 	v := newValidatorForIdP(t, idp)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -242,6 +242,21 @@ func TestValidatorUnknownKid(t *testing.T) {
 	}
 }
 
+func TestRSAPublicKeyFromJWKRejectsOversizedExponent(t *testing.T) {
+	_, err := rsaPublicKeyFromJWK(jwk{
+		Kty: "RSA",
+		Kid: "bad-exp",
+		N:   base64.RawURLEncoding.EncodeToString([]byte{1}),
+		E:   base64.RawURLEncoding.EncodeToString([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9}),
+	})
+	if err == nil {
+		t.Fatal("expected oversized exponent to be rejected")
+	}
+	if !strings.Contains(err.Error(), "invalid exponent") {
+		t.Fatalf("expected invalid exponent error, got %v", err)
+	}
+}
+
 func TestMiddlewareBlocksMissingToken(t *testing.T) {
 	idp := newTestIdP(t)
 	v := newValidatorForIdP(t, idp)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,357 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+// testIdP stands up an in-memory IdP that serves a JWKS document for an RSA
+// signing key. It can also mint signed JWTs with arbitrary claims so tests
+// can exercise every validation path without external dependencies.
+type testIdP struct {
+	server *httptest.Server
+	priv   *rsa.PrivateKey
+	kid    string
+}
+
+func newTestIdP(t *testing.T) *testIdP {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa: %v", err)
+	}
+	idp := &testIdP{priv: priv, kid: "test-key-1"}
+	idp.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/jwks.json") {
+			http.NotFound(w, r)
+			return
+		}
+		nB := base64.RawURLEncoding.EncodeToString(priv.PublicKey.N.Bytes())
+		eBytes := big.NewInt(int64(priv.PublicKey.E)).Bytes()
+		eB := base64.RawURLEncoding.EncodeToString(eBytes)
+		_ = json.NewEncoder(w).Encode(jwkSet{Keys: []jwk{{
+			Kty: "RSA", Kid: idp.kid, Alg: "RS256", Use: "sig", N: nB, E: eB,
+		}}})
+	}))
+	t.Cleanup(idp.server.Close)
+	return idp
+}
+
+func (idp *testIdP) jwksURL() string { return idp.server.URL + "/jwks.json" }
+
+func (idp *testIdP) sign(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = idp.kid
+	signed, err := token.SignedString(idp.priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signed
+}
+
+// signWithKid lets a test override the kid header (used to simulate an
+// unknown signing key).
+func (idp *testIdP) signWithKid(t *testing.T, claims jwt.MapClaims, kid string) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(idp.priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signed
+}
+
+func validClaims() jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss":       "https://idp.example/",
+		"aud":       "atryum",
+		"sub":       "agent-subject",
+		"client_id": "agent-1",
+		"scope":     "atryum:mcp other:scope",
+		"iat":       now.Unix(),
+		"exp":       now.Add(5 * time.Minute).Unix(),
+	}
+}
+
+func newValidatorForIdP(t *testing.T, idp *testIdP, overrides ...func(*Config)) *Validator {
+	t.Helper()
+	c := Config{
+		Enabled:       true,
+		Issuer:        "https://idp.example/",
+		Audience:      "atryum",
+		JWKSURL:       idp.jwksURL(),
+		RequiredScope: "atryum:mcp",
+		AgentIDClaim:  "client_id",
+	}
+	for _, override := range overrides {
+		override(&c)
+	}
+	v, err := NewValidator([]Config{c}, nil)
+	if err != nil {
+		t.Fatalf("NewValidator: %v", err)
+	}
+	return v
+}
+
+func TestValidatorMissingToken(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	_, err := v.Validate(context.Background(), "")
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Result != ResultMissing {
+		t.Fatalf("expected ResultMissing, got %v", err)
+	}
+}
+
+func TestValidatorMalformedToken(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	_, err := v.Validate(context.Background(), "not-a-jwt")
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Result != ResultInvalid {
+		t.Fatalf("expected ResultInvalid, got %v", err)
+	}
+}
+
+func TestValidatorExpiredToken(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	claims := validClaims()
+	claims["exp"] = time.Now().Add(-1 * time.Hour).Unix()
+	claims["iat"] = time.Now().Add(-2 * time.Hour).Unix()
+	tok := idp.sign(t, claims)
+	_, err := v.Validate(context.Background(), tok)
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Result != ResultInvalid {
+		t.Fatalf("expected ResultInvalid for expired, got %v", err)
+	}
+	if !strings.Contains(ve.Description, "expired") {
+		t.Fatalf("expected expired description, got %q", ve.Description)
+	}
+}
+
+func TestValidatorWrongIssuer(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	claims := validClaims()
+	claims["iss"] = "https://attacker.example/"
+	tok := idp.sign(t, claims)
+	_, err := v.Validate(context.Background(), tok)
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Result != ResultInvalid {
+		t.Fatalf("expected ResultInvalid for issuer mismatch, got %v", err)
+	}
+}
+
+func TestValidatorWrongAudience(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	claims := validClaims()
+	claims["aud"] = "someone-else"
+	tok := idp.sign(t, claims)
+	_, err := v.Validate(context.Background(), tok)
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Result != ResultInvalid {
+		t.Fatalf("expected ResultInvalid for audience mismatch, got %v", err)
+	}
+}
+
+func TestValidatorMissingScope(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	claims := validClaims()
+	claims["scope"] = "other:scope"
+	tok := idp.sign(t, claims)
+	_, err := v.Validate(context.Background(), tok)
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Result != ResultMissingScope {
+		t.Fatalf("expected ResultMissingScope, got %v", err)
+	}
+}
+
+func TestValidatorScpClaimArrayAccepted(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	claims := validClaims()
+	delete(claims, "scope")
+	claims["scp"] = []any{"foo", "atryum:mcp"}
+	tok := idp.sign(t, claims)
+	id, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if id.AgentID != "agent-1" {
+		t.Fatalf("agent id = %q", id.AgentID)
+	}
+}
+
+func TestValidatorValidToken(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	tok := idp.sign(t, validClaims())
+	id, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if id.AgentID != "agent-1" {
+		t.Fatalf("AgentID = %q", id.AgentID)
+	}
+	if id.Issuer != "https://idp.example" {
+		t.Fatalf("Issuer = %q", id.Issuer)
+	}
+}
+
+func TestValidatorAgentIDFallbackToSub(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp, func(c *Config) { c.AgentIDClaim = "preferred_username" })
+	claims := validClaims()
+	delete(claims, "client_id")
+	tok := idp.sign(t, claims)
+	id, err := v.Validate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if id.AgentID != "agent-subject" {
+		t.Fatalf("expected fallback to sub, got %q", id.AgentID)
+	}
+}
+
+func TestValidatorUnknownKid(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	tok := idp.signWithKid(t, validClaims(), "different-kid")
+	_, err := v.Validate(context.Background(), tok)
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Result != ResultInvalid {
+		t.Fatalf("expected ResultInvalid, got %v", err)
+	}
+}
+
+func TestMiddlewareBlocksMissingToken(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true })
+	h := Middleware(v, "/.well-known/oauth-protected-resource")(next)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}")))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+	chal := w.Header().Get("WWW-Authenticate")
+	if !strings.Contains(chal, "Bearer") || !strings.Contains(chal, "resource_metadata=") {
+		t.Fatalf("expected Bearer challenge with resource_metadata, got %q", chal)
+	}
+	if called {
+		t.Fatal("next handler should not have been called")
+	}
+}
+
+func TestMiddlewareReturns403ForMissingScope(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	claims := validClaims()
+	claims["scope"] = "wrong"
+	tok := idp.sign(t, claims)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	h := Middleware(v, "/.well-known/oauth-protected-resource")(next)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if !strings.Contains(w.Header().Get("WWW-Authenticate"), "insufficient_scope") {
+		t.Fatalf("expected insufficient_scope challenge, got %q", w.Header().Get("WWW-Authenticate"))
+	}
+}
+
+func TestMiddlewareSetsIdentityOnContext(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	tok := idp.sign(t, validClaims())
+	var got Identity
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := IdentityFromContext(r.Context())
+		if !ok {
+			t.Fatal("identity not on context")
+		}
+		got = id
+	})
+	h := Middleware(v, "/.well-known/oauth-protected-resource")(next)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if got.AgentID != "agent-1" {
+		t.Fatalf("expected agent-1, got %q", got.AgentID)
+	}
+}
+
+func TestMiddlewareNilValidatorIsPassThrough(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true })
+	h := Middleware(nil, "/x")(next)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/mcp/x", nil))
+	if !called {
+		t.Fatal("expected pass-through when validator is nil")
+	}
+}
+
+func TestProtectedResourceMetadata(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	h := ProtectedResourceHandler(v, "https://atryum.example/mcp")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var doc ProtectedResourceMetadata
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if doc.Resource != "https://atryum.example/mcp" {
+		t.Fatalf("resource = %q", doc.Resource)
+	}
+	if len(doc.AuthorizationServers) != 1 || doc.AuthorizationServers[0] != "https://idp.example" {
+		t.Fatalf("unexpected authorization_servers: %#v", doc.AuthorizationServers)
+	}
+	if len(doc.ScopesSupported) != 1 || doc.ScopesSupported[0] != "atryum:mcp" {
+		t.Fatalf("unexpected scopes: %#v", doc.ScopesSupported)
+	}
+}
+
+func TestNewValidatorRejectsMissingFields(t *testing.T) {
+	if _, err := NewValidator([]Config{{Enabled: true, Audience: "x"}}, nil); err == nil {
+		t.Fatal("expected error for missing issuer")
+	}
+	if _, err := NewValidator([]Config{{Enabled: true, Issuer: "https://x"}}, nil); err == nil {
+		t.Fatal("expected error for missing audience")
+	}
+	v, err := NewValidator(nil, nil)
+	if err != nil || v != nil {
+		t.Fatalf("expected nil validator/no-error for empty configs, got v=%v err=%v", v, err)
+	}
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,12 +1,14 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"log"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -348,6 +350,55 @@ func TestMiddlewareReturns403ForMissingScope(t *testing.T) {
 	}
 	if !strings.Contains(w.Header().Get("WWW-Authenticate"), "insufficient_scope") {
 		t.Fatalf("expected insufficient_scope challenge, got %q", w.Header().Get("WWW-Authenticate"))
+	}
+}
+
+func TestMiddlewareLogsMissingScope(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	claims := validClaims()
+	claims["scope"] = "wrong"
+	tok := idp.sign(t, claims)
+	var logs bytes.Buffer
+	origWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(origWriter) })
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	h := Middleware(v, "/.well-known/oauth-protected-resource")(next)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	got := logs.String()
+	if !strings.Contains(got, "[auth] insufficient_scope") || !strings.Contains(got, `scope="atryum:mcp"`) {
+		t.Fatalf("expected insufficient scope auth log, got %q", got)
+	}
+	if strings.Contains(got, tok) {
+		t.Fatal("auth log should not include bearer token")
+	}
+}
+
+func TestMiddlewareLogsInvalidToken(t *testing.T) {
+	idp := newTestIdP(t)
+	v := newValidatorForIdP(t, idp)
+	var logs bytes.Buffer
+	origWriter := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(origWriter) })
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	h := Middleware(v, "/.well-known/oauth-protected-resource")(next)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/x", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer not-a-jwt")
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	got := logs.String()
+	if !strings.Contains(got, "[auth] invalid_token") || !strings.Contains(got, `description="malformed token"`) {
+		t.Fatalf("expected invalid token auth log, got %q", got)
+	}
+	if strings.Contains(got, "not-a-jwt") {
+		t.Fatal("auth log should not include bearer token")
 	}
 }
 

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -1,0 +1,42 @@
+// Package auth implements inbound OAuth bearer-token authentication for
+// agent-facing routes. It validates JWTs using OIDC discovery / JWKS and
+// extracts an agent identity that the rest of the system uses for policy
+// decisions and audit.
+package auth
+
+import "strings"
+
+// DefaultRequiredScope is the OAuth scope required on incoming MCP requests
+// when [auth].required_scope is not configured.
+const DefaultRequiredScope = "atryum:mcp"
+
+// DefaultAgentIDClaim is the JWT claim consulted first when extracting the
+// agent identity. Falls back to client_id, then azp, then sub.
+const DefaultAgentIDClaim = "client_id"
+
+// Config describes one configured authorization server (e.g. one Keycloak
+// realm or one Auth0 tenant). Multiple configs are supported.
+type Config struct {
+	Enabled       bool   `toml:"enabled"`
+	Issuer        string `toml:"issuer"`
+	Audience      string `toml:"audience"`
+	JWKSURL       string `toml:"jwks_url"`
+	RequiredScope string `toml:"required_scope"`
+	AgentIDClaim  string `toml:"agent_id_claim"`
+}
+
+// Normalized returns a copy with whitespace trimmed and defaults applied.
+func (c Config) Normalized() Config {
+	c.Issuer = strings.TrimRight(strings.TrimSpace(c.Issuer), "/")
+	c.Audience = strings.TrimSpace(c.Audience)
+	c.JWKSURL = strings.TrimSpace(c.JWKSURL)
+	c.RequiredScope = strings.TrimSpace(c.RequiredScope)
+	c.AgentIDClaim = strings.TrimSpace(c.AgentIDClaim)
+	if c.RequiredScope == "" {
+		c.RequiredScope = DefaultRequiredScope
+	}
+	if c.AgentIDClaim == "" {
+		c.AgentIDClaim = DefaultAgentIDClaim
+	}
+	return c
+}

--- a/internal/auth/config.go
+++ b/internal/auth/config.go
@@ -6,10 +6,6 @@ package auth
 
 import "strings"
 
-// DefaultRequiredScope is the OAuth scope required on incoming MCP requests
-// when [auth].required_scope is not configured.
-const DefaultRequiredScope = "atryum:mcp"
-
 // DefaultAgentIDClaim is the JWT claim consulted first when extracting the
 // agent identity. Falls back to client_id, then azp, then sub.
 const DefaultAgentIDClaim = "client_id"
@@ -26,15 +22,13 @@ type Config struct {
 }
 
 // Normalized returns a copy with whitespace trimmed and defaults applied.
+// Empty RequiredScope intentionally means no scope claim is required.
 func (c Config) Normalized() Config {
 	c.Issuer = strings.TrimRight(strings.TrimSpace(c.Issuer), "/")
 	c.Audience = strings.TrimSpace(c.Audience)
 	c.JWKSURL = strings.TrimSpace(c.JWKSURL)
 	c.RequiredScope = strings.TrimSpace(c.RequiredScope)
 	c.AgentIDClaim = strings.TrimSpace(c.AgentIDClaim)
-	if c.RequiredScope == "" {
-		c.RequiredScope = DefaultRequiredScope
-	}
 	if c.AgentIDClaim == "" {
 		c.AgentIDClaim = DefaultAgentIDClaim
 	}

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -1,0 +1,26 @@
+package auth
+
+import "context"
+
+type ctxKey int
+
+const identityKey ctxKey = iota
+
+// WithIdentity returns a child context carrying the given Identity.
+func WithIdentity(parent context.Context, id Identity) context.Context {
+	return context.WithValue(parent, identityKey, id)
+}
+
+// IdentityFromContext returns the authenticated Identity if one is present.
+func IdentityFromContext(ctx context.Context) (Identity, bool) {
+	id, ok := ctx.Value(identityKey).(Identity)
+	return id, ok
+}
+
+// AgentIDFromContext is a convenience returning just the agent id.
+func AgentIDFromContext(ctx context.Context) string {
+	if id, ok := IdentityFromContext(ctx); ok {
+		return id.AgentID
+	}
+	return ""
+}

--- a/internal/auth/jwks.go
+++ b/internal/auth/jwks.go
@@ -1,0 +1,141 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// jwk is a minimal JWK as defined in RFC 7517. We only need RSA public-key
+// fields here.
+type jwk struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	Use string `json:"use"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+type jwkSet struct {
+	Keys []jwk `json:"keys"`
+}
+
+// keyCache fetches and caches a JWKS document. It refreshes once per ttl.
+// On verification failure for an unknown kid it forces a refresh so newly
+// rotated keys are picked up promptly.
+type keyCache struct {
+	url    string
+	client *http.Client
+	ttl    time.Duration
+
+	mu        sync.RWMutex
+	keys      map[string]*rsa.PublicKey
+	fetchedAt time.Time
+}
+
+func newKeyCache(url string, client *http.Client, ttl time.Duration) *keyCache {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	return &keyCache{url: url, client: client, ttl: ttl, keys: map[string]*rsa.PublicKey{}}
+}
+
+// Get returns the RSA public key for the given key ID, refreshing the cache
+// from the JWKS URL when the kid is unknown or the cache has expired.
+func (c *keyCache) Get(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	c.mu.RLock()
+	key, ok := c.keys[kid]
+	stale := time.Since(c.fetchedAt) > c.ttl
+	c.mu.RUnlock()
+	if ok && !stale {
+		return key, nil
+	}
+	if err := c.refresh(ctx); err != nil {
+		// If the cached key is still usable, fall back to it rather than
+		// failing every request when the IdP is briefly unreachable.
+		if ok {
+			return key, nil
+		}
+		return nil, err
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if k, ok := c.keys[kid]; ok {
+		return k, nil
+	}
+	return nil, fmt.Errorf("jwks: signing key %q not found", kid)
+}
+
+func (c *keyCache) refresh(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return fmt.Errorf("jwks request: %w", err)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("jwks fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("jwks fetch: status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("jwks read: %w", err)
+	}
+	var set jwkSet
+	if err := json.Unmarshal(body, &set); err != nil {
+		return fmt.Errorf("jwks decode: %w", err)
+	}
+	keys := make(map[string]*rsa.PublicKey, len(set.Keys))
+	for _, k := range set.Keys {
+		if !strings.EqualFold(k.Kty, "RSA") {
+			continue
+		}
+		pub, err := rsaPublicKeyFromJWK(k)
+		if err != nil {
+			continue
+		}
+		keys[k.Kid] = pub
+	}
+	c.mu.Lock()
+	c.keys = keys
+	c.fetchedAt = time.Now()
+	c.mu.Unlock()
+	return nil
+}
+
+func rsaPublicKeyFromJWK(k jwk) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("decode n: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("decode e: %w", err)
+	}
+	if len(eBytes) == 0 {
+		return nil, fmt.Errorf("empty exponent")
+	}
+	// Pad eBytes to 8 bytes for binary.BigEndian.Uint64.
+	padded := make([]byte, 8)
+	copy(padded[8-len(eBytes):], eBytes)
+	e := binary.BigEndian.Uint64(padded)
+	if e == 0 || e > (1<<31-1) {
+		return nil, fmt.Errorf("invalid exponent")
+	}
+	return &rsa.PublicKey{N: new(big.Int).SetBytes(nBytes), E: int(e)}, nil
+}

--- a/internal/auth/jwks.go
+++ b/internal/auth/jwks.go
@@ -130,6 +130,9 @@ func rsaPublicKeyFromJWK(k jwk) (*rsa.PublicKey, error) {
 	if len(eBytes) == 0 {
 		return nil, fmt.Errorf("empty exponent")
 	}
+	if len(eBytes) > 8 {
+		return nil, fmt.Errorf("invalid exponent")
+	}
 	// Pad eBytes to 8 bytes for binary.BigEndian.Uint64.
 	padded := make([]byte, 8)
 	copy(padded[8-len(eBytes):], eBytes)

--- a/internal/auth/metadata.go
+++ b/internal/auth/metadata.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// ProtectedResourceMetadata is the OAuth 2.0 protected resource metadata
+// document defined by RFC 9728. MCP clients use it to discover which
+// authorization server to use.
+type ProtectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+	ScopesSupported      []string `json:"scopes_supported,omitempty"`
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+}
+
+// ProtectedResourceHandler returns an http.Handler that serves the OAuth
+// protected-resource metadata document for this resource server. resource is
+// the canonical URL identifying the protected resource (typically the base
+// URL of the MCP endpoint).
+func ProtectedResourceHandler(v *Validator, resource string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		issuers := []string{}
+		scopes := map[string]struct{}{}
+		if v != nil {
+			for _, c := range v.Configs() {
+				issuers = append(issuers, c.Issuer)
+				if c.RequiredScope != "" {
+					scopes[c.RequiredScope] = struct{}{}
+				}
+			}
+		}
+		scopeList := make([]string, 0, len(scopes))
+		for s := range scopes {
+			scopeList = append(scopeList, s)
+		}
+		doc := ProtectedResourceMetadata{
+			Resource:               strings.TrimRight(resource, "/"),
+			AuthorizationServers:   issuers,
+			ScopesSupported:        scopeList,
+			BearerMethodsSupported: []string{"header"},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(doc)
+	})
+}

--- a/internal/auth/metadata.go
+++ b/internal/auth/metadata.go
@@ -10,9 +10,9 @@ import (
 // document defined by RFC 9728. MCP clients use it to discover which
 // authorization server to use.
 type ProtectedResourceMetadata struct {
-	Resource             string   `json:"resource"`
-	AuthorizationServers []string `json:"authorization_servers"`
-	ScopesSupported      []string `json:"scopes_supported,omitempty"`
+	Resource               string   `json:"resource"`
+	AuthorizationServers   []string `json:"authorization_servers"`
+	ScopesSupported        []string `json:"scopes_supported,omitempty"`
 	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
 }
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -15,6 +16,16 @@ import (
 // authorization server. When v is nil, the middleware is a no-op (auth
 // disabled).
 func Middleware(v *Validator, resourceMetadataPath string) func(http.Handler) http.Handler {
+	return MiddlewareWithOptions(v, resourceMetadataPath, MiddlewareOptions{})
+}
+
+type MiddlewareOptions struct {
+	// SkipVerify is a local-only debug mode. It parses bearer JWT claims without
+	// verifying signature, issuer, audience, expiry, or required scope.
+	SkipVerify bool
+}
+
+func MiddlewareWithOptions(v *Validator, resourceMetadataPath string, opts MiddlewareOptions) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		if v == nil {
 			return next
@@ -31,7 +42,7 @@ func Middleware(v *Validator, resourceMetadataPath string) func(http.Handler) ht
 				return
 			}
 			token := strings.TrimSpace(header[len("Bearer "):])
-			identity, err := v.Validate(r.Context(), token)
+			identity, err := validateBearer(r.Context(), v, token, opts)
 			if err != nil {
 				ve, _ := err.(*ValidationError)
 				switch {
@@ -50,6 +61,13 @@ func Middleware(v *Validator, resourceMetadataPath string) func(http.Handler) ht
 			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), identity)))
 		})
 	}
+}
+
+func validateBearer(ctx context.Context, v *Validator, token string, opts MiddlewareOptions) (Identity, error) {
+	if opts.SkipVerify {
+		return v.DebugIdentity(token)
+	}
+	return v.Validate(ctx, token)
 }
 
 func logAuthFailure(r *http.Request, code string, description string, scope string) {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 )
@@ -35,10 +36,13 @@ func Middleware(v *Validator, resourceMetadataPath string) func(http.Handler) ht
 				ve, _ := err.(*ValidationError)
 				switch {
 				case ve != nil && ve.Result == ResultMissingScope:
+					logAuthFailure(r, "insufficient_scope", ve.Description, requiredScope(v))
 					writeChallenge(w, http.StatusForbidden, ve.Description, "insufficient_scope", metadataURL, requiredScope(v))
 				case ve != nil:
+					logAuthFailure(r, "invalid_token", ve.Description, requiredScope(v))
 					writeChallenge(w, http.StatusUnauthorized, ve.Description, "invalid_token", metadataURL, requiredScope(v))
 				default:
+					logAuthFailure(r, "invalid_token", "invalid token", requiredScope(v))
 					writeChallenge(w, http.StatusUnauthorized, "invalid token", "invalid_token", metadataURL, requiredScope(v))
 				}
 				return
@@ -46,6 +50,14 @@ func Middleware(v *Validator, resourceMetadataPath string) func(http.Handler) ht
 			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), identity)))
 		})
 	}
+}
+
+func logAuthFailure(r *http.Request, code string, description string, scope string) {
+	if scope != "" {
+		log.Printf("[auth] %s method=%s path=%s remote=%s scope=%q description=%q", code, r.Method, r.URL.Path, r.RemoteAddr, scope, description)
+		return
+	}
+	log.Printf("[auth] %s method=%s path=%s remote=%s description=%q", code, r.Method, r.URL.Path, r.RemoteAddr, description)
 }
 
 func absoluteURL(r *http.Request, path string) string {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,0 +1,118 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Middleware returns an http.Handler that requires a valid OAuth bearer token
+// before invoking next. resourceMetadataPath is the absolute path of the
+// protected-resource-metadata endpoint and is advertised in the
+// WWW-Authenticate challenge per RFC 9728 so MCP clients can discover the
+// authorization server. When v is nil, the middleware is a no-op (auth
+// disabled).
+func Middleware(v *Validator, resourceMetadataPath string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if v == nil {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			metadataURL := absoluteURL(r, resourceMetadataPath)
+			header := strings.TrimSpace(r.Header.Get("Authorization"))
+			if header == "" {
+				writeChallenge(w, http.StatusUnauthorized, "missing bearer token", "", metadataURL, requiredScope(v))
+				return
+			}
+			if !strings.HasPrefix(strings.ToLower(header), "bearer ") {
+				writeChallenge(w, http.StatusUnauthorized, "invalid Authorization scheme", "invalid_request", metadataURL, requiredScope(v))
+				return
+			}
+			token := strings.TrimSpace(header[len("Bearer "):])
+			identity, err := v.Validate(r.Context(), token)
+			if err != nil {
+				ve, _ := err.(*ValidationError)
+				switch {
+				case ve != nil && ve.Result == ResultMissingScope:
+					writeChallenge(w, http.StatusForbidden, ve.Description, "insufficient_scope", metadataURL, requiredScope(v))
+				case ve != nil:
+					writeChallenge(w, http.StatusUnauthorized, ve.Description, "invalid_token", metadataURL, requiredScope(v))
+				default:
+					writeChallenge(w, http.StatusUnauthorized, "invalid token", "invalid_token", metadataURL, requiredScope(v))
+				}
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), identity)))
+		})
+	}
+}
+
+func absoluteURL(r *http.Request, path string) string {
+	if path == "" {
+		return ""
+	}
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return path
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if proto := strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")); proto != "" {
+		scheme = proto
+	}
+	host := r.Host
+	if forwardedHost := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); forwardedHost != "" {
+		host = forwardedHost
+	}
+	if host == "" {
+		return path
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return scheme + "://" + host + path
+}
+
+func requiredScope(v *Validator) string {
+	for _, c := range v.Configs() {
+		if c.RequiredScope != "" {
+			return c.RequiredScope
+		}
+	}
+	return DefaultRequiredScope
+}
+
+func writeChallenge(w http.ResponseWriter, status int, description string, errorCode string, resourceMetadataURL string, scope string) {
+	parts := []string{`Bearer realm="atryum"`}
+	if errorCode != "" {
+		parts = append(parts, fmt.Sprintf(`error=%q`, errorCode))
+	}
+	if description != "" {
+		parts = append(parts, fmt.Sprintf(`error_description=%q`, description))
+	}
+	if scope != "" {
+		parts = append(parts, fmt.Sprintf(`scope=%q`, scope))
+	}
+	if resourceMetadataURL != "" {
+		parts = append(parts, fmt.Sprintf(`resource_metadata=%q`, resourceMetadataURL))
+	}
+	w.Header().Set("WWW-Authenticate", strings.Join(parts, ", "))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error":             errorCodeOrDefault(errorCode, status),
+		"error_description": description,
+	})
+}
+
+func errorCodeOrDefault(code string, status int) string {
+	if code != "" {
+		return code
+	}
+	if status == http.StatusForbidden {
+		return "insufficient_scope"
+	}
+	return "invalid_token"
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -36,27 +36,28 @@ func MiddlewareWithOptions(v *Validator, resourceMetadataPath string, opts Middl
 			metadataURL := absoluteURL(r, resourceMetadataPath)
 			header := strings.TrimSpace(r.Header.Get("Authorization"))
 			if header == "" {
-				writeChallenge(w, http.StatusUnauthorized, "missing bearer token", "", metadataURL, requiredScope(v))
+				writeChallenge(w, http.StatusUnauthorized, "missing bearer token", "", metadataURL, challengeScope(v, nil))
 				return
 			}
 			if !strings.HasPrefix(strings.ToLower(header), "bearer ") {
-				writeChallenge(w, http.StatusUnauthorized, "invalid Authorization scheme", "invalid_request", metadataURL, requiredScope(v))
+				writeChallenge(w, http.StatusUnauthorized, "invalid Authorization scheme", "invalid_request", metadataURL, challengeScope(v, nil))
 				return
 			}
 			token := strings.TrimSpace(header[len("Bearer "):])
 			identity, err := validateBearer(r.Context(), v, token, opts)
 			if err != nil {
 				ve, _ := err.(*ValidationError)
+				scope := challengeScope(v, ve)
 				switch {
 				case ve != nil && ve.Result == ResultMissingScope:
-					logAuthFailure(r, "insufficient_scope", ve.Description, requiredScope(v))
-					writeChallenge(w, http.StatusForbidden, ve.Description, "insufficient_scope", metadataURL, requiredScope(v))
+					logAuthFailure(r, "insufficient_scope", ve.Description, scope)
+					writeChallenge(w, http.StatusForbidden, ve.Description, "insufficient_scope", metadataURL, scope)
 				case ve != nil:
-					logAuthFailure(r, "invalid_token", ve.Description, requiredScope(v))
-					writeChallenge(w, http.StatusUnauthorized, ve.Description, "invalid_token", metadataURL, requiredScope(v))
+					logAuthFailure(r, "invalid_token", ve.Description, scope)
+					writeChallenge(w, http.StatusUnauthorized, ve.Description, "invalid_token", metadataURL, scope)
 				default:
-					logAuthFailure(r, "invalid_token", "invalid token", requiredScope(v))
-					writeChallenge(w, http.StatusUnauthorized, "invalid token", "invalid_token", metadataURL, requiredScope(v))
+					logAuthFailure(r, "invalid_token", "invalid token", scope)
+					writeChallenge(w, http.StatusUnauthorized, "invalid token", "invalid_token", metadataURL, scope)
 				}
 				return
 			}
@@ -114,13 +115,35 @@ func absoluteURL(r *http.Request, path string) string {
 	return scheme + "://" + host + path
 }
 
-func requiredScope(v *Validator) string {
-	for _, c := range v.Configs() {
-		if c.RequiredScope != "" {
-			return c.RequiredScope
+// challengeScope returns the scope to advertise in the WWW-Authenticate
+// `scope=` parameter. When the validator already matched a specific config
+// (i.e. the ValidationError carries a RequiredScope), that scope is used.
+// Otherwise the function only returns a scope when every configured
+// authorization server agrees on the same non-empty required_scope; if any
+// configured issuer has no required scope (or scopes disagree), we omit
+// `scope=` rather than mislead the client into requesting a scope that is
+// not required for one of the configured issuers.
+func challengeScope(v *Validator, ve *ValidationError) string {
+	if ve != nil && ve.RequiredScope != "" {
+		return ve.RequiredScope
+	}
+	if v == nil {
+		return ""
+	}
+	configs := v.Configs()
+	if len(configs) == 0 {
+		return ""
+	}
+	common := configs[0].RequiredScope
+	if common == "" {
+		return ""
+	}
+	for _, c := range configs[1:] {
+		if c.RequiredScope != common {
+			return ""
 		}
 	}
-	return ""
+	return common
 }
 
 func writeChallenge(w http.ResponseWriter, status int, description string, errorCode string, resourceMetadataURL string, scope string) {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -20,8 +19,9 @@ func Middleware(v *Validator, resourceMetadataPath string) func(http.Handler) ht
 }
 
 type MiddlewareOptions struct {
-	// SkipVerify is a local-only debug mode. It parses bearer JWT claims without
-	// verifying signature, issuer, audience, expiry, or required scope.
+	// SkipVerify is a local-only debug mode. When true, the middleware is a
+	// complete pass-through: the Authorization header is ignored, no token is
+	// required, and no identity is set on the request context.
 	SkipVerify bool
 	// DebugLogIdentity logs the extracted identity after successful validation.
 	DebugLogIdentity bool
@@ -29,7 +29,7 @@ type MiddlewareOptions struct {
 
 func MiddlewareWithOptions(v *Validator, resourceMetadataPath string, opts MiddlewareOptions) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		if v == nil {
+		if v == nil || opts.SkipVerify {
 			return next
 		}
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -44,7 +44,7 @@ func MiddlewareWithOptions(v *Validator, resourceMetadataPath string, opts Middl
 				return
 			}
 			token := strings.TrimSpace(header[len("Bearer "):])
-			identity, err := validateBearer(r.Context(), v, token, opts)
+			identity, err := v.Validate(r.Context(), token)
 			if err != nil {
 				ve, _ := err.(*ValidationError)
 				scope := challengeScope(v, ve)
@@ -67,13 +67,6 @@ func MiddlewareWithOptions(v *Validator, resourceMetadataPath string, opts Middl
 			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), identity)))
 		})
 	}
-}
-
-func validateBearer(ctx context.Context, v *Validator, token string, opts MiddlewareOptions) (Identity, error) {
-	if opts.SkipVerify {
-		return v.DebugIdentity(token)
-	}
-	return v.Validate(ctx, token)
 }
 
 func logAuthFailure(r *http.Request, code string, description string, scope string) {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -23,6 +23,8 @@ type MiddlewareOptions struct {
 	// SkipVerify is a local-only debug mode. It parses bearer JWT claims without
 	// verifying signature, issuer, audience, expiry, or required scope.
 	SkipVerify bool
+	// DebugLogIdentity logs the extracted identity after successful validation.
+	DebugLogIdentity bool
 }
 
 func MiddlewareWithOptions(v *Validator, resourceMetadataPath string, opts MiddlewareOptions) func(http.Handler) http.Handler {
@@ -58,6 +60,9 @@ func MiddlewareWithOptions(v *Validator, resourceMetadataPath string, opts Middl
 				}
 				return
 			}
+			if opts.DebugLogIdentity {
+				logAuthSuccess(r, identity)
+			}
 			next.ServeHTTP(w, r.WithContext(WithIdentity(r.Context(), identity)))
 		})
 	}
@@ -76,6 +81,10 @@ func logAuthFailure(r *http.Request, code string, description string, scope stri
 		return
 	}
 	log.Printf("[auth] %s method=%s path=%s remote=%s description=%q", code, r.Method, r.URL.Path, r.RemoteAddr, description)
+}
+
+func logAuthSuccess(r *http.Request, identity Identity) {
+	log.Printf("[auth] valid_token method=%s path=%s remote=%s agent_id=%q issuer=%q subject=%q scope=%q", r.Method, r.URL.Path, r.RemoteAddr, identity.AgentID, identity.Issuer, identity.Subject, identity.Scope)
 }
 
 func absoluteURL(r *http.Request, path string) string {

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -81,7 +81,7 @@ func requiredScope(v *Validator) string {
 			return c.RequiredScope
 		}
 	}
-	return DefaultRequiredScope
+	return ""
 }
 
 func writeChallenge(w http.ResponseWriter, status int, description string, errorCode string, resourceMetadataURL string, scope string) {

--- a/internal/auth/validator.go
+++ b/internal/auth/validator.go
@@ -92,43 +92,6 @@ func (v *Validator) Configs() []Config {
 	return out
 }
 
-// DebugIdentity parses a bearer JWT without verifying signature, issuer,
-// audience, expiry, or scope. It exists only for explicit local debugging.
-func (v *Validator) DebugIdentity(bearer string) (Identity, error) {
-	bearer = strings.TrimSpace(bearer)
-	if bearer == "" {
-		return Identity{}, &ValidationError{Result: ResultMissing, Description: "missing bearer token"}
-	}
-	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
-	unverified, _, err := parser.ParseUnverified(bearer, jwt.MapClaims{})
-	if err != nil {
-		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "malformed token"}
-	}
-	claims, ok := unverified.Claims.(jwt.MapClaims)
-	if !ok {
-		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "malformed claims"}
-	}
-	agentIDClaim := DefaultAgentIDClaim
-	if v != nil {
-		for _, c := range v.configs {
-			if c.AgentIDClaim != "" {
-				agentIDClaim = c.AgentIDClaim
-				break
-			}
-		}
-	}
-	identity := Identity{
-		AgentID: extractAgentID(claims, agentIDClaim),
-		Issuer:  strings.TrimRight(strings.TrimSpace(stringClaim(claims, "iss")), "/"),
-		Subject: stringClaim(claims, "sub"),
-		Scope:   tokenScope(claims),
-	}
-	if identity.AgentID == "" {
-		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "no usable agent identity claim"}
-	}
-	return identity, nil
-}
-
 // Validate parses, verifies, and inspects the supplied bearer token. It
 // returns the extracted Identity on success. On failure the returned error is
 // always a *ValidationError so middleware can map it to 401/403.

--- a/internal/auth/validator.go
+++ b/internal/auth/validator.go
@@ -43,10 +43,14 @@ const (
 )
 
 // ValidationError carries a Result plus a human-readable description that
-// callers may include in WWW-Authenticate / response bodies.
+// callers may include in WWW-Authenticate / response bodies. RequiredScope
+// is set when the validator matched the token to a specific [[auth]] config
+// and that config has a required_scope; middleware advertises it in the
+// WWW-Authenticate `scope=` parameter.
 type ValidationError struct {
-	Result      Result
-	Description string
+	Result        Result
+	Description   string
+	RequiredScope string
 }
 
 func (e *ValidationError) Error() string { return e.Description }
@@ -192,7 +196,7 @@ func (v *Validator) Validate(ctx context.Context, bearer string) (Identity, erro
 
 	scope := tokenScope(verifiedClaims)
 	if !scopeContains(scope, cfg.RequiredScope) {
-		return Identity{}, &ValidationError{Result: ResultMissingScope, Description: "missing required scope"}
+		return Identity{}, &ValidationError{Result: ResultMissingScope, Description: "missing required scope", RequiredScope: cfg.RequiredScope}
 	}
 
 	identity := Identity{

--- a/internal/auth/validator.go
+++ b/internal/auth/validator.go
@@ -36,10 +36,10 @@ type Identity struct {
 type Result int
 
 const (
-	ResultOK              Result = iota
-	ResultMissing                // No Authorization header
-	ResultInvalid                // Bad signature, malformed, wrong issuer/audience, expired, etc.
-	ResultMissingScope           // Token is otherwise valid but lacks required scope
+	ResultOK           Result = iota
+	ResultMissing             // No Authorization header
+	ResultInvalid             // Bad signature, malformed, wrong issuer/audience, expired, etc.
+	ResultMissingScope        // Token is otherwise valid but lacks required scope
 )
 
 // ValidationError carries a Result plus a human-readable description that
@@ -110,9 +110,9 @@ func (v *Validator) Validate(ctx context.Context, bearer string) (Identity, erro
 	}
 	iss, _ := claims["iss"].(string)
 	iss = strings.TrimRight(strings.TrimSpace(iss), "/")
-	cfg, ok := v.matchConfig(iss)
+	cfg, ok := v.matchConfig(iss, claims["aud"])
 	if !ok {
-		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "issuer not allowed"}
+		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "issuer/audience not allowed"}
 	}
 
 	cache, err := v.cacheFor(ctx, cfg)
@@ -170,13 +170,33 @@ func (v *Validator) Validate(ctx context.Context, bearer string) (Identity, erro
 	return identity, nil
 }
 
-func (v *Validator) matchConfig(issuer string) (Config, bool) {
+func (v *Validator) matchConfig(issuer string, audienceClaim any) (Config, bool) {
 	for _, c := range v.configs {
-		if c.Issuer == issuer {
+		if c.Issuer == issuer && audienceMatches(audienceClaim, c.Audience) {
 			return c, true
 		}
 	}
 	return Config{}, false
+}
+
+func audienceMatches(claim any, audience string) bool {
+	switch v := claim.(type) {
+	case string:
+		return v == audience
+	case []string:
+		for _, item := range v {
+			if item == audience {
+				return true
+			}
+		}
+	case []any:
+		for _, item := range v {
+			if s, ok := item.(string); ok && s == audience {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (v *Validator) cacheFor(ctx context.Context, cfg Config) (*keyCache, error) {
@@ -280,4 +300,3 @@ func stringClaim(claims jwt.MapClaims, name string) string {
 	}
 	return ""
 }
-

--- a/internal/auth/validator.go
+++ b/internal/auth/validator.go
@@ -1,0 +1,283 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+)
+
+// Validator validates incoming bearer tokens against one or more configured
+// authorization servers (e.g. Keycloak, Auth0). It is safe for concurrent use.
+type Validator struct {
+	configs []Config
+	caches  map[string]*keyCache // by issuer
+	client  *http.Client
+	mu      sync.Mutex
+	now     func() time.Time
+}
+
+// Identity is the authenticated agent extracted from a valid token.
+type Identity struct {
+	AgentID string
+	Issuer  string
+	Subject string
+	Scope   string
+}
+
+// Result classifies a validation outcome.
+type Result int
+
+const (
+	ResultOK              Result = iota
+	ResultMissing                // No Authorization header
+	ResultInvalid                // Bad signature, malformed, wrong issuer/audience, expired, etc.
+	ResultMissingScope           // Token is otherwise valid but lacks required scope
+)
+
+// ValidationError carries a Result plus a human-readable description that
+// callers may include in WWW-Authenticate / response bodies.
+type ValidationError struct {
+	Result      Result
+	Description string
+}
+
+func (e *ValidationError) Error() string { return e.Description }
+
+// NewValidator returns a Validator for the given enabled configs. Empty input
+// or all-disabled input returns a nil validator (callers may treat that as
+// "auth disabled").
+func NewValidator(configs []Config, client *http.Client) (*Validator, error) {
+	enabled := make([]Config, 0, len(configs))
+	for _, c := range configs {
+		c = c.Normalized()
+		if !c.Enabled {
+			continue
+		}
+		if c.Issuer == "" {
+			return nil, fmt.Errorf("auth: issuer is required")
+		}
+		if c.Audience == "" {
+			return nil, fmt.Errorf("auth: audience is required (issuer=%s)", c.Issuer)
+		}
+		enabled = append(enabled, c)
+	}
+	if len(enabled) == 0 {
+		return nil, nil
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Validator{configs: enabled, caches: map[string]*keyCache{}, client: client, now: time.Now}, nil
+}
+
+// Configs returns the active validator configs (read-only view).
+func (v *Validator) Configs() []Config {
+	if v == nil {
+		return nil
+	}
+	out := make([]Config, len(v.configs))
+	copy(out, v.configs)
+	return out
+}
+
+// Validate parses, verifies, and inspects the supplied bearer token. It
+// returns the extracted Identity on success. On failure the returned error is
+// always a *ValidationError so middleware can map it to 401/403.
+func (v *Validator) Validate(ctx context.Context, bearer string) (Identity, error) {
+	bearer = strings.TrimSpace(bearer)
+	if bearer == "" {
+		return Identity{}, &ValidationError{Result: ResultMissing, Description: "missing bearer token"}
+	}
+
+	// Pre-parse (unverified) just to determine which configured issuer this
+	// token claims to come from. Signature is still verified below.
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	unverified, _, err := parser.ParseUnverified(bearer, jwt.MapClaims{})
+	if err != nil {
+		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "malformed token"}
+	}
+	claims, ok := unverified.Claims.(jwt.MapClaims)
+	if !ok {
+		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "malformed claims"}
+	}
+	iss, _ := claims["iss"].(string)
+	iss = strings.TrimRight(strings.TrimSpace(iss), "/")
+	cfg, ok := v.matchConfig(iss)
+	if !ok {
+		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "issuer not allowed"}
+	}
+
+	cache, err := v.cacheFor(ctx, cfg)
+	if err != nil {
+		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "cannot fetch signing keys"}
+	}
+
+	// Issuer is already verified via matchConfig (after trailing-slash
+	// normalization), so we don't pass jwt.WithIssuer here — different IdPs
+	// disagree about the trailing slash and the strict comparator would
+	// reject otherwise-valid tokens. Audience, expiry, and not-before are
+	// validated by the JWT library below.
+	verified, err := jwt.ParseWithClaims(bearer, jwt.MapClaims{}, func(t *jwt.Token) (any, error) {
+		if _, isRSA := t.Method.(*jwt.SigningMethodRSA); !isRSA {
+			return nil, fmt.Errorf("unexpected signing method %v", t.Header["alg"])
+		}
+		kid, _ := t.Header["kid"].(string)
+		if kid == "" {
+			return nil, fmt.Errorf("missing kid")
+		}
+		return cache.Get(ctx, kid)
+	}, jwt.WithValidMethods([]string{"RS256", "RS384", "RS512"}), jwt.WithAudience(cfg.Audience), jwt.WithExpirationRequired(), jwt.WithTimeFunc(v.now))
+	if err != nil {
+		switch {
+		case errors.Is(err, jwt.ErrTokenExpired):
+			return Identity{}, &ValidationError{Result: ResultInvalid, Description: "token expired"}
+		case errors.Is(err, jwt.ErrTokenNotValidYet):
+			return Identity{}, &ValidationError{Result: ResultInvalid, Description: "token not yet valid"}
+		case errors.Is(err, jwt.ErrTokenInvalidIssuer):
+			return Identity{}, &ValidationError{Result: ResultInvalid, Description: "invalid issuer"}
+		case errors.Is(err, jwt.ErrTokenInvalidAudience):
+			return Identity{}, &ValidationError{Result: ResultInvalid, Description: "invalid audience"}
+		case errors.Is(err, jwt.ErrTokenSignatureInvalid):
+			return Identity{}, &ValidationError{Result: ResultInvalid, Description: "invalid signature"}
+		default:
+			return Identity{}, &ValidationError{Result: ResultInvalid, Description: "invalid token"}
+		}
+	}
+	verifiedClaims, _ := verified.Claims.(jwt.MapClaims)
+
+	scope := tokenScope(verifiedClaims)
+	if !scopeContains(scope, cfg.RequiredScope) {
+		return Identity{}, &ValidationError{Result: ResultMissingScope, Description: "missing required scope"}
+	}
+
+	identity := Identity{
+		AgentID: extractAgentID(verifiedClaims, cfg.AgentIDClaim),
+		Issuer:  cfg.Issuer,
+		Subject: stringClaim(verifiedClaims, "sub"),
+		Scope:   scope,
+	}
+	if identity.AgentID == "" {
+		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "no usable agent identity claim"}
+	}
+	return identity, nil
+}
+
+func (v *Validator) matchConfig(issuer string) (Config, bool) {
+	for _, c := range v.configs {
+		if c.Issuer == issuer {
+			return c, true
+		}
+	}
+	return Config{}, false
+}
+
+func (v *Validator) cacheFor(ctx context.Context, cfg Config) (*keyCache, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if c, ok := v.caches[cfg.Issuer]; ok {
+		return c, nil
+	}
+	jwksURL := cfg.JWKSURL
+	if jwksURL == "" {
+		discovered, err := discoverJWKSURL(ctx, v.client, cfg.Issuer)
+		if err != nil {
+			return nil, err
+		}
+		jwksURL = discovered
+	}
+	c := newKeyCache(jwksURL, v.client, 10*time.Minute)
+	v.caches[cfg.Issuer] = c
+	return c, nil
+}
+
+// discoverJWKSURL fetches the OIDC discovery document and returns jwks_uri.
+func discoverJWKSURL(ctx context.Context, client *http.Client, issuer string) (string, error) {
+	url := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("oidc discovery: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("oidc discovery: status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	var doc struct {
+		JWKSURI string `json:"jwks_uri"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return "", fmt.Errorf("oidc discovery decode: %w", err)
+	}
+	if doc.JWKSURI == "" {
+		return "", fmt.Errorf("oidc discovery: jwks_uri missing")
+	}
+	return doc.JWKSURI, nil
+}
+
+func tokenScope(claims jwt.MapClaims) string {
+	if s, ok := claims["scope"].(string); ok {
+		return s
+	}
+	if v, ok := claims["scp"]; ok {
+		switch t := v.(type) {
+		case string:
+			return t
+		case []any:
+			parts := make([]string, 0, len(t))
+			for _, item := range t {
+				if s, ok := item.(string); ok {
+					parts = append(parts, s)
+				}
+			}
+			return strings.Join(parts, " ")
+		}
+	}
+	return ""
+}
+
+func scopeContains(scope, required string) bool {
+	if required == "" {
+		return true
+	}
+	for _, s := range strings.Fields(scope) {
+		if s == required {
+			return true
+		}
+	}
+	return false
+}
+
+func extractAgentID(claims jwt.MapClaims, primary string) string {
+	for _, name := range []string{primary, "client_id", "azp", "sub"} {
+		if name == "" {
+			continue
+		}
+		if v := stringClaim(claims, name); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func stringClaim(claims jwt.MapClaims, name string) string {
+	if v, ok := claims[name].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+

--- a/internal/auth/validator.go
+++ b/internal/auth/validator.go
@@ -88,6 +88,43 @@ func (v *Validator) Configs() []Config {
 	return out
 }
 
+// DebugIdentity parses a bearer JWT without verifying signature, issuer,
+// audience, expiry, or scope. It exists only for explicit local debugging.
+func (v *Validator) DebugIdentity(bearer string) (Identity, error) {
+	bearer = strings.TrimSpace(bearer)
+	if bearer == "" {
+		return Identity{}, &ValidationError{Result: ResultMissing, Description: "missing bearer token"}
+	}
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation())
+	unverified, _, err := parser.ParseUnverified(bearer, jwt.MapClaims{})
+	if err != nil {
+		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "malformed token"}
+	}
+	claims, ok := unverified.Claims.(jwt.MapClaims)
+	if !ok {
+		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "malformed claims"}
+	}
+	agentIDClaim := DefaultAgentIDClaim
+	if v != nil {
+		for _, c := range v.configs {
+			if c.AgentIDClaim != "" {
+				agentIDClaim = c.AgentIDClaim
+				break
+			}
+		}
+	}
+	identity := Identity{
+		AgentID: extractAgentID(claims, agentIDClaim),
+		Issuer:  strings.TrimRight(strings.TrimSpace(stringClaim(claims, "iss")), "/"),
+		Subject: stringClaim(claims, "sub"),
+		Scope:   tokenScope(claims),
+	}
+	if identity.AgentID == "" {
+		return Identity{}, &ValidationError{Result: ResultInvalid, Description: "no usable agent identity claim"}
+	}
+	return identity, nil
+}
+
 // Validate parses, verifies, and inspects the supplied bearer token. It
 // returns the extracted Identity on success. On failure the returned error is
 // always a *ValidationError so middleware can map it to 401/403.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,13 @@ type Config struct {
 	// Auth holds zero or more inbound OAuth bearer-token validators
 	// (e.g. one entry for Keycloak, one for Auth0). When empty, the agent-
 	// facing /mcp/ routes remain anonymous.
-	Auth []auth.Config `toml:"auth"`
+	Auth      []auth.Config   `toml:"auth"`
+	AuthDebug AuthDebugConfig `toml:"auth_debug"`
+}
+
+// AuthDebugConfig contains local-only auth debugging switches.
+type AuthDebugConfig struct {
+	SkipVerify bool `toml:"skip_verify"`
 }
 
 // PolicyConfig selects the active approval policy provider at startup.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,12 +1,20 @@
 package config
 
-import "github.com/BurntSushi/toml"
+import (
+	"github.com/BurntSushi/toml"
+
+	"atryum/internal/auth"
+)
 
 type Config struct {
 	Server    ServerConfig     `toml:"server"`
 	Defaults  DefaultsConfig   `toml:"defaults"`
 	Policy    PolicyConfig     `toml:"policy"`
 	Upstreams []UpstreamConfig `toml:"upstreams"`
+	// Auth holds zero or more inbound OAuth bearer-token validators
+	// (e.g. one entry for Keycloak, one for Auth0). When empty, the agent-
+	// facing /mcp/ routes remain anonymous.
+	Auth []auth.Config `toml:"auth"`
 }
 
 // PolicyConfig selects the active approval policy provider at startup.

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -1,0 +1,152 @@
+package invocation_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"atryum/internal/auth"
+	"atryum/internal/config"
+	"atryum/internal/invocation"
+	"atryum/internal/invocation/policy"
+	"atryum/internal/mcp"
+	"atryum/internal/store"
+
+	_ "modernc.org/sqlite"
+)
+
+// stubRulesStore returns a fixed rule list so the test can pin the user
+// matching dimension we exercise (agent_id from auth context).
+type stubRulesStore struct {
+	rules []invocation.ApprovalRule
+}
+
+func (s stubRulesStore) ListApprovalRules(_ context.Context) ([]invocation.ApprovalRule, error) {
+	return s.rules, nil
+}
+
+func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+	}))
+	defer upstream.Close()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Config{
+		Defaults:  config.DefaultsConfig{RequestTimeoutSeconds: 5},
+		Upstreams: []config.UpstreamConfig{{Name: "demo", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+	}
+	resolver := mcp.NewResolver(store.NewServerRepo(db), cfg)
+	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Rule that auto-approves only the authenticated agent_id; if the
+	// service incorrectly matched on request_id (legacy behavior) the rule
+	// would NOT match and the call would fall back to manual approval.
+	rules := stubRulesStore{rules: []invocation.ApprovalRule{{
+		ID: "rule_agent_007", Action: invocation.RuleActionAutoApprove,
+		ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"},
+		UserPattern: "agent-007", Enabled: true,
+	}}}
+
+	svc := invocation.NewService(
+		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
+		mcp.NewHTTPClient(), policy.AlwaysDenyProvider{}, // would deny if the rule didn't match
+		5*time.Second, rules,
+	)
+
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-007", Issuer: "https://idp.test"})
+	resp, err := svc.Invoke(ctx, invocation.CreateInvocationRequest{
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 1},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != invocation.StatusSucceeded {
+		t.Fatalf("expected succeeded (rule auto_approve matched on agent_id), got %s", resp.Status)
+	}
+	if resp.Approval == nil || resp.Approval.Status != "auto_approved" {
+		t.Fatalf("expected auto_approved approval, got %#v", resp.Approval)
+	}
+
+	events, err := svc.Events(context.Background(), resp.InvocationID, invocation.EventListFilter{Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawAgentInReceived bool
+	for _, e := range events.Items {
+		if e.Type != "invocation.received" {
+			continue
+		}
+		if strings.Contains(string(e.Data), `"agent_id":"agent-007"`) {
+			sawAgentInReceived = true
+		}
+	}
+	if !sawAgentInReceived {
+		t.Fatalf("expected invocation.received event to record agent_id; events: %s", eventsAsJSON(events.Items))
+	}
+}
+
+func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+	}))
+	defer upstream.Close()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Config{
+		Defaults:  config.DefaultsConfig{RequestTimeoutSeconds: 5},
+		Upstreams: []config.UpstreamConfig{{Name: "demo", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+	}
+	resolver := mcp.NewResolver(store.NewServerRepo(db), cfg)
+	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	rules := stubRulesStore{rules: []invocation.ApprovalRule{{
+		ID: "rule_legacy", Action: invocation.RuleActionAutoApprove,
+		ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"},
+		UserPattern: "legacy-request-id", Enabled: true,
+	}}}
+	svc := invocation.NewService(
+		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
+		mcp.NewHTTPClient(), policy.AlwaysDenyProvider{},
+		5*time.Second, rules,
+	)
+
+	rid := "legacy-request-id"
+	resp, err := svc.Invoke(context.Background(), invocation.CreateInvocationRequest{
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 1}, RequestID: &rid,
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.Status != invocation.StatusSucceeded {
+		t.Fatalf("expected succeeded via request_id fallback, got %s", resp.Status)
+	}
+}
+
+func eventsAsJSON(items []invocation.EventResponse) string {
+	b, _ := json.Marshal(items)
+	return string(b)
+}

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"atryum/internal/auth"
 	"atryum/internal/invocation/policy"
 	"atryum/internal/mcp"
 )
@@ -108,6 +109,11 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		return InvocationResponse{}, err
 	}
 
+	// agentID is the authenticated agent identity from middleware. When auth
+	// is disabled the field is empty and we fall back to request_id for rule
+	// matching to preserve pre-auth behavior.
+	agentID := auth.AgentIDFromContext(ctx)
+
 	// Determine disposition: check rules first (fine-grained), then fall back to policy (global).
 	// Both resolve to a policy.Decision so the rest of the flow is uniform.
 	var decision policy.Decision
@@ -115,8 +121,8 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 	ruleMatched := false
 	if s.rules != nil {
 		if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
-			user := ""
-			if req.RequestID != nil {
+			user := agentID
+			if user == "" && req.RequestID != nil {
 				user = *req.RequestID
 			}
 			if matched := matchRule(approvalRules, upstream.Name, req.Tool, user); matched != nil {
@@ -136,7 +142,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		}
 	}
 	if !ruleMatched && s.policy != nil {
-		callCtx := policy.CallContext{Server: upstream.Name, Tool: req.Tool, Input: req.Input}
+		callCtx := policy.CallContext{AgentID: agentID, Server: upstream.Name, Tool: req.Tool, Input: req.Input}
 		var policyErr error
 		decision, policyErr = s.policy.Evaluate(ctx, callCtx)
 		if policyErr != nil {
@@ -149,16 +155,20 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		_ = s.invocations.UpdateResult(ctx, inv)
 	}
 
+	receivedPayload := map[string]any{
+		"tool": req.Tool, "upstream": upstream.Name,
+		"request_id": req.RequestID,
+		"input":      json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input),
+		"disposition": string(decision.Disposition), "disposition_reason": decision.Reason,
+	}
+	if agentID != "" {
+		receivedPayload["agent_id"] = agentID
+	}
 	_ = s.events.Create(ctx, Event{
 		InvocationID: inv.InvocationID,
 		EventType:    "invocation.received",
-		Payload: mustJSON(map[string]any{
-			"tool": req.Tool, "upstream": upstream.Name,
-			"request_id": req.RequestID,
-			"input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input),
-			"disposition": string(decision.Disposition), "disposition_reason": decision.Reason,
-		}),
-		CreatedAt: now,
+		Payload:      mustJSON(receivedPayload),
+		CreatedAt:    now,
 	})
 
 	switch decision.Disposition {
@@ -436,11 +446,12 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	}
 
 	// Evaluate rules against (source, tool, user) — same logic as Invoke.
+	agentID := auth.AgentIDFromContext(ctx)
 	ruleAction := ""
 	if s.rules != nil {
 		if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
-			user := ""
-			if req.RequestID != nil {
+			user := agentID
+			if user == "" && req.RequestID != nil {
 				user = *req.RequestID
 			}
 			if matched := matchRule(approvalRules, source, req.Tool, user); matched != nil {
@@ -450,6 +461,9 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	}
 
 	receivedPayload := map[string]any{"tool": req.Tool, "upstream": source, "request_id": req.RequestID, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "external": true}
+	if agentID != "" {
+		receivedPayload["agent_id"] = agentID
+	}
 	if req.Description != "" {
 		receivedPayload["description"] = req.Description
 	}


### PR DESCRIPTION
## Summary

Adds inbound OAuth bearer-token authentication for `/mcp/` routes. Atryum now validates JWT access tokens issued by one or more configured authorization servers (e.g. Keycloak, Auth0) and propagates the authenticated agent identity into policy evaluation, approval-rule matching, and invocation event audit. Other routes (`/healthz`, `/ui/`, `/api/v1/admin/*`, `/api/v1/external/*`) are unchanged and remain anonymous.

Amp-Thread-ID: https://ampcode.com/threads/T-019e22ee-17c1-7603-bfb2-917efa7f6d9b

## Release notes

### New: inbound OAuth on `/mcp/`

- New `[[auth]]` TOML sections configure one or more OIDC issuers. Each entry supports `enabled`, `issuer`, `audience`, optional `jwks_url` (otherwise discovered via `/.well-known/openid-configuration`), `required_scope` (optional — leave empty to allow tokens without a scope claim), and `agent_id_claim` (defaults to `client_id`, falling back to `azp`, then `sub`).
- When at least one `[[auth]]` is configured, requests to `/mcp/` must present `Authorization: Bearer <jwt>`. Atryum verifies signature (RS256/384/512), issuer, audience, expiry, `nbf`, and required scope.
- Returns `401 invalid_token` for missing/malformed/expired/wrong-audience tokens and `403 insufficient_scope` for tokens that pass validation but lack the required scope. `WWW-Authenticate` includes `error`, `error_description`, `scope` (only when unambiguous across configs), and `resource_metadata` per RFC 6750 / 9728.
- New `/.well-known/oauth-protected-resource` endpoint (RFC 9728) lets MCP clients discover the authorization server, supported scopes, and bearer methods. The `resource` URL is computed from the request, honoring `X-Forwarded-Proto` / `X-Forwarded-Host`.
- JWKS keys are cached in memory for 10 minutes, refreshed on unknown `kid` (handles key rotation), and fall back to the stale key on transient IdP outages.
- When no `[[auth]]` section is configured, `/mcp/` continues to accept anonymous requests (no behavior change for existing setups).

### New: agent identity propagation

- The authenticated agent identity (from `agent_id_claim`) flows through the invocation pipeline:
  - `policy.CallContext.AgentID` is populated for policy providers.
  - Approval-rule `user` matching uses the agent ID. When auth is disabled, matching falls back to `request_id` (existing behavior preserved).
  - `invocation.received` events record `agent_id` for audit.

### New: local-only auth debug mode

- `[auth_debug] skip_verify = true` (or `ATRYUM_AUTH_DEBUG_SKIP_VERIFY=1`) makes `/mcp/` a complete pass-through: the `Authorization` header is ignored, no token is required, and no identity is set on the request context. Intended for local OAuth troubleshooting only — a startup warning is logged.
- `--debug` (existing flag) now also logs the extracted agent identity on successful `/mcp/` authentication.

### Behavior changes

- `/mcp/` is now protected by default whenever any `[[auth]]` config is enabled. Deployments that want to keep `/mcp/` open should leave `[[auth]]` empty or rely on `auth_debug.skip_verify`.
- Approval rules with a non-empty `user` pattern now match against the authenticated agent ID first; the previous `request_id`-only behavior remains as a fallback when auth is disabled.

## Configuration example

```toml
[[auth]]
enabled        = true
issuer         = "https://your-tenant.us.auth0.com/"
audience       = "https://atryum.example/mcp"
required_scope = "atryum:mcp"   # leave empty to allow tokens without scope
agent_id_claim = "client_id"
```

See `atryum.example.toml` and the new "Auth debug mode" section in `README.md` for full details.

## Tests

- `internal/auth/auth_test.go` (557 lines): in-memory IdP exercises every validator/middleware code path including JWKS rotation, oversized RSA exponent rejection, scope claim formats (`scope` string vs `scp` array), debug skip-verify pass-through, and WWW-Authenticate challenge formatting.
- `internal/api/auth_test.go` (248 lines): integration tests covering 401/403 responses, agent ID context plumbing into the invocation service, and verifying that non-`/mcp/` routes remain anonymous.
- `internal/invocation/agent_id_test.go` (152 lines): end-to-end tests for agent ID propagation into approval-rule matching and audit events.

## Out of scope

- Upstream MCP auth (`internal/mcp/auth_provider`) is unchanged.
- Token introspection / opaque tokens are not supported; only JWTs.
