### PR TITLE
feat: docker + omnibus support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /atryum ./cmd/atryum
+
+FROM node:22-alpine
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /atryum /usr/local/bin/atryum
+WORKDIR /app
+ENTRYPOINT ["atryum", "-config", "/app/atryum.toml"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,27 @@
+# ── Stage 1: Build Vite frontend ──────────────────────────────────────
+FROM node:22-alpine AS frontend
+WORKDIR /build
+COPY frontend/package.json frontend/package-lock.json frontend/.npmrc ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build:atryum
+
+# ── Stage 2: Build Go binary with embedded frontend ──────────────────
+FROM golang:1.25-alpine AS builder
+WORKDIR /src
+COPY atryum/go.mod atryum/go.sum ./
+RUN go mod download
+COPY atryum/ .
+# Replace the dev web UI with the production Vite build
+RUN rm -rf internal/api/web
+COPY --from=frontend /build/build-atryum internal/api/web
+# Rename the Vite entry point so the Go embed serves it as index.html
+RUN mv internal/api/web/atryum.html internal/api/web/index.html
+RUN CGO_ENABLED=0 go build -o /atryum ./cmd/atryum
+
+# ── Stage 3: Minimal runtime ─────────────────────────────────────────
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /atryum /usr/local/bin/atryum
+WORKDIR /app
+ENTRYPOINT ["atryum", "-config", "/app/atryum.toml"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ to log concise MCP proxy activity in local run output. Current debug logging inc
 
 Secrets are not intentionally logged.
 
+## Docker Compose
+
+Two profiles, mutually exclusive (postgres always runs):
+
+```bash
+docker compose --profile dev up    # Go server + Vite dev frontend (HMR on :5175)
+docker compose --profile prod up   # Single Go binary with embedded prod UI (:8080)
+```
+
+- **dev** (`Dockerfile`): backend at `:8080`, separate Vite dev server at `:5175`, source bind-mounted from `../frontend`. Use this for active development.
+- **prod** (`Dockerfile.prod`): multi-stage build — Vite builds the React app, Go embeds the output via `//go:embed` and serves the SPA from `/ui/` (with router fallback). One binary, one port. `atryum.toml` is baked into the image.
+
+Bare `docker compose up` only starts postgres. Run `docker compose down -v` between profile switches if you hit port or network weirdness.
+
 ## Database configuration
 
 SQLite remains the default storage provider:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,5 +15,77 @@ services:
       timeout: 5s
       retries: 10
 
+  atryum:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./atryum.toml:/app/atryum.toml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # Production: single binary with embedded Vite frontend (off by default)
+  # Usage: docker compose --profile prod up atryum-prod
+  atryum-prod:
+    profiles: ["prod"]
+    build:
+      context: ..
+      dockerfile: atryum/Dockerfile.prod
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./atryum.toml:/app/atryum.toml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  frontend-init:
+    profiles: ["dev"]
+    image: busybox
+    command: ["chown", "-R", "1000:1000", "/app/node_modules"]
+    volumes:
+      - ../frontend:/app
+      - frontend_node_modules:/app/node_modules
+
+  frontend:
+    profiles: ["dev"]
+    image: node:22-alpine
+    user: "1000:1000"
+    working_dir: /app
+    command: sh -c "npm install && npm run dev:atryum"
+    ports:
+      - "5175:5175"
+    volumes:
+      - ../frontend:/app
+      - frontend_node_modules:/app/node_modules
+    environment:
+      - ATRYUM_BACKEND_URL=http://atryum:8080
+    depends_on:
+      atryum:
+        condition: service_healthy
+      frontend-init:
+        condition: service_completed_successfully
+
 volumes:
   pgdata:
+  frontend_node_modules:
+
+networks:
+  default:
+    name: atryum-net

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -245,7 +245,7 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/external/invocations", h.externalInvocations)
 	mux.HandleFunc("/api/v1/external/invocations/", h.externalInvocationDetail)
 	mux.HandleFunc("/ui", h.uiIndex)
-	mux.Handle("/ui/", http.StripPrefix("/ui/", h.staticHTTP))
+	mux.Handle("/ui/", http.StripPrefix("/ui/", h.spaFileServer()))
 	mux.HandleFunc("/", h.root)
 	return mux
 }
@@ -268,6 +268,24 @@ func (h *Handler) uiIndex(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	http.Redirect(w, r, "/ui/", http.StatusFound)
+}
+
+// spaFileServer returns a handler that serves static files from the embedded
+// web/ directory. If the requested path doesn't match a real file it falls back
+// to index.html so the React SPA router can handle the route.
+func (h *Handler) spaFileServer() http.Handler {
+	staticSub, _ := fs.Sub(webFS, "web")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if path == "" || path == "/" {
+			path = "index.html"
+		}
+		// Try to open the requested file; if it doesn't exist, serve index.html.
+		if _, err := fs.Stat(staticSub, path); err != nil {
+			r.URL.Path = "/"
+		}
+		h.staticHTTP.ServeHTTP(w, r)
+	})
 }
 
 func (h *Handler) invokeUpstream(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This adds a docker compose flow to run atryum + postgres + frontend

This also adds a dockerfile + compose target to run a 'unified' atryum with frontend embedded in go and served by the go binary.

```
# runs everything separate in dev mode
docker compose --profile dev up 

# runs an omnibus with prod settings
docker compose --profile prod up --build --force-recreate
```