### PR TITLE
Add agent_id to invocations; rename rules.user_pattern -> agent_id_pattern

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -177,7 +177,7 @@ type AdminRule struct {
 	Action         string    `json:"action"`
 	ServerPatterns []string  `json:"server_patterns"`
 	ToolPatterns   []string  `json:"tool_patterns"`
-	UserPattern    string    `json:"user_pattern"`
+	AgentIDPattern string    `json:"agent_id_pattern"`
 	Description    string    `json:"description,omitempty"`
 	Enabled        bool      `json:"enabled"`
 	Order          int       `json:"order"`
@@ -189,7 +189,7 @@ type AdminRuleInput struct {
 	Action         string   `json:"action"`
 	ServerPatterns []string `json:"server_patterns"`
 	ToolPatterns   []string `json:"tool_patterns"`
-	UserPattern    string   `json:"user_pattern"`
+	AgentIDPattern string   `json:"agent_id_pattern"`
 	Description    string   `json:"description,omitempty"`
 	Enabled        *bool    `json:"enabled,omitempty"`
 }
@@ -639,7 +639,7 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 				Action:         req.CreateRule.Action,
 				ServerPatterns: normalizePatternSlice(req.CreateRule.ServerPatterns),
 				ToolPatterns:   normalizePatternSlice(req.CreateRule.ToolPatterns),
-				UserPattern:    defaultPattern(req.CreateRule.UserPattern),
+				AgentIDPattern: defaultPattern(req.CreateRule.AgentIDPattern),
 				Description:    req.CreateRule.Description,
 				Enabled:        enabled,
 			}
@@ -687,7 +687,7 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 				Action:         req.CreateRule.Action,
 				ServerPatterns: normalizePatternSlice(req.CreateRule.ServerPatterns),
 				ToolPatterns:   normalizePatternSlice(req.CreateRule.ToolPatterns),
-				UserPattern:    defaultPattern(req.CreateRule.UserPattern),
+				AgentIDPattern: defaultPattern(req.CreateRule.AgentIDPattern),
 				Description:    req.CreateRule.Description,
 				Enabled:        enabled,
 			}
@@ -977,7 +977,7 @@ func (h *Handler) adminRules(w http.ResponseWriter, r *http.Request) {
 			Action:         req.Action,
 			ServerPatterns: normalizePatternSlice(req.ServerPatterns),
 			ToolPatterns:   normalizePatternSlice(req.ToolPatterns),
-			UserPattern:    defaultPattern(req.UserPattern),
+			AgentIDPattern: defaultPattern(req.AgentIDPattern),
 			Description:    req.Description,
 			Enabled:        enabled,
 			Order:          order,
@@ -1075,7 +1075,7 @@ func (h *Handler) adminRuleDetail(w http.ResponseWriter, r *http.Request) {
 		existing.Action = req.Action
 		existing.ServerPatterns = normalizePatternSlice(req.ServerPatterns)
 		existing.ToolPatterns = normalizePatternSlice(req.ToolPatterns)
-		existing.UserPattern = defaultPattern(req.UserPattern)
+		existing.AgentIDPattern = defaultPattern(req.AgentIDPattern)
 		existing.Description = req.Description
 		existing.Enabled = enabled
 		if err := h.rulesRepo.Update(r.Context(), existing); err != nil {
@@ -1117,7 +1117,7 @@ func toAdminRule(r store.Rule) AdminRule {
 		Action:         r.Action,
 		ServerPatterns: sp,
 		ToolPatterns:   tp,
-		UserPattern:    r.UserPattern,
+		AgentIDPattern: r.AgentIDPattern,
 		Description:    r.Description,
 		Enabled:        r.Enabled,
 		Order:          r.Order,

--- a/internal/api/web/app.js
+++ b/internal/api/web/app.js
@@ -166,7 +166,7 @@ function buildPendingRule(action) {
     action,
     server_patterns: servers.length ? servers : (state.currentInvocationDetail ? [state.currentInvocationDetail.server_name] : []),
     tool_patterns: tools.length ? tools : (state.currentInvocationDetail ? [state.currentInvocationDetail.tool_name] : []),
-    user_pattern: $('#rule-user').value.trim() || '*',
+    agent_id_pattern: $('#rule-user').value.trim() || '*',
     description: $('#rule-desc').value.trim(),
   };
 }
@@ -178,7 +178,7 @@ async function createRuleOnly() {
     action: $('#inv-rule-action').value,
     server_patterns: servers,
     tool_patterns: tools,
-    user_pattern: $('#inv-rule-user').value.trim() || '*',
+    agent_id_pattern: $('#inv-rule-user').value.trim() || '*',
     description: $('#inv-rule-desc').value.trim(),
     enabled: true,
   };

--- a/internal/auth/validator.go
+++ b/internal/auth/validator.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -188,10 +189,8 @@ func audienceMatches(claim any, audience string) bool {
 	case string:
 		return v == audience
 	case []string:
-		for _, item := range v {
-			if item == audience {
-				return true
-			}
+		if slices.Contains(v, audience) {
+			return true
 		}
 	case []any:
 		for _, item := range v {

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -59,7 +59,7 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	rules := stubRulesStore{rules: []invocation.ApprovalRule{{
 		ID: "rule_agent_007", Action: invocation.RuleActionAutoApprove,
 		ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"},
-		UserPattern: "agent-007", Enabled: true,
+		AgentIDPattern: "agent-007", Enabled: true,
 	}}}
 
 	svc := invocation.NewService(
@@ -98,6 +98,23 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	if !sawAgentInReceived {
 		t.Fatalf("expected invocation.received event to record agent_id; events: %s", eventsAsJSON(events.Items))
 	}
+
+	// The invocations row itself should carry the agent_id (column added in
+	// migration 006), and the column should be filterable.
+	got, err := svc.Get(context.Background(), resp.InvocationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentID == nil || *got.AgentID != "agent-007" {
+		t.Fatalf("expected invocation.agent_id=agent-007, got %v", got.AgentID)
+	}
+	list, err := svc.List(context.Background(), invocation.InvocationListFilter{AgentID: "agent-007", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list.Total != 1 || len(list.Items) != 1 || list.Items[0].InvocationID != resp.InvocationID {
+		t.Fatalf("expected exactly the auth'd invocation when filtering by agent_id, got %+v", list)
+	}
 }
 
 func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
@@ -126,7 +143,7 @@ func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 	rules := stubRulesStore{rules: []invocation.ApprovalRule{{
 		ID: "rule_legacy", Action: invocation.RuleActionAutoApprove,
 		ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"},
-		UserPattern: "legacy-request-id", Enabled: true,
+		AgentIDPattern: "legacy-request-id", Enabled: true,
 	}}}
 	svc := invocation.NewService(
 		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -37,6 +37,7 @@ type Invocation struct {
 	Status         Status     `json:"status"`
 	Approval       *Approval  `json:"approval"`
 	MatchedRuleID  *string    `json:"matched_rule_id,omitempty"`
+	AgentID        *string    `json:"agent_id,omitempty"`
 	Input          []byte     `json:"-"`
 	Response       []byte     `json:"-"`
 	Error          []byte     `json:"-"`
@@ -53,11 +54,12 @@ type Event struct {
 }
 
 type InvocationListFilter struct {
-	Offset uint64
-	Limit  uint64
-	Server string
-	Tool   string
-	Status string
+	Offset  uint64
+	Limit   uint64
+	Server  string
+	Tool    string
+	Status  string
+	AgentID string
 }
 
 type EventListFilter struct {
@@ -110,6 +112,7 @@ type InvocationResponse struct {
 	Status        Status          `json:"status"`
 	Approval      *Approval       `json:"approval"`
 	MatchedRuleID *string         `json:"matched_rule_id,omitempty"`
+	AgentID       *string         `json:"agent_id,omitempty"`
 	RequestID     *string         `json:"request_id,omitempty"`
 	Input         json.RawMessage `json:"input,omitempty"`
 	SubmittedAt   time.Time       `json:"submitted_at"`

--- a/internal/invocation/rules.go
+++ b/internal/invocation/rules.go
@@ -16,7 +16,7 @@ type ApprovalRule struct {
 	Action         string   // one of the RuleAction* constants
 	ServerPatterns []string // empty slice = match any server
 	ToolPatterns   []string // empty slice = match any tool
-	UserPattern    string   // "*" or "" = match any user
+	AgentIDPattern string   // "*" or "" = match any agent
 	Enabled        bool
 }
 
@@ -28,7 +28,9 @@ type rulesStore interface {
 
 // matchRule returns the first enabled rule that matches the given invocation
 // parameters, or nil if no rule matches (fall back to human approval).
-func matchRule(rules []ApprovalRule, server, tool, user string) *ApprovalRule {
+// The agentID is the authenticated agent identity (empty when auth is
+// disabled — callers fall back to request_id for parity with pre-auth behavior).
+func matchRule(rules []ApprovalRule, server, tool, agentID string) *ApprovalRule {
 	for i := range rules {
 		r := &rules[i]
 		if !r.Enabled {
@@ -40,7 +42,7 @@ func matchRule(rules []ApprovalRule, server, tool, user string) *ApprovalRule {
 		if !matchPatterns(r.ToolPatterns, tool) {
 			continue
 		}
-		if !matchUserPattern(r.UserPattern, user) {
+		if !matchAgentIDPattern(r.AgentIDPattern, agentID) {
 			continue
 		}
 		return r
@@ -62,7 +64,8 @@ func matchPatterns(patterns []string, value string) bool {
 	return false
 }
 
-// matchUserPattern returns true when the rule's user pattern matches user.
-func matchUserPattern(pattern, user string) bool {
-	return pattern == "" || pattern == "*" || pattern == user
+// matchAgentIDPattern returns true when the rule's agent_id pattern matches the
+// authenticated agent identity. An empty or "*" pattern matches any agent.
+func matchAgentIDPattern(pattern, agentID string) bool {
+	return pattern == "" || pattern == "*" || pattern == agentID
 }

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -94,6 +94,11 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		return InvocationResponse{}, err
 	}
 
+	// agentID is the authenticated agent identity from middleware. When auth
+	// is disabled the field is empty and we fall back to request_id for rule
+	// matching to preserve pre-auth behavior.
+	agentID := auth.AgentIDFromContext(ctx)
+
 	now := time.Now().UTC()
 	inv := Invocation{
 		InvocationID:   "inv_" + uuid.NewString(),
@@ -105,14 +110,12 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		Input:          inputJSON,
 		SubmittedAt:    now,
 	}
+	if agentID != "" {
+		inv.AgentID = &agentID
+	}
 	if err := s.invocations.Create(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
-
-	// agentID is the authenticated agent identity from middleware. When auth
-	// is disabled the field is empty and we fall back to request_id for rule
-	// matching to preserve pre-auth behavior.
-	agentID := auth.AgentIDFromContext(ctx)
 
 	// Determine disposition: check rules first (fine-grained), then fall back to policy (global).
 	// Both resolve to a policy.Decision so the rest of the flow is uniform.
@@ -430,6 +433,9 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	if err != nil {
 		return InvocationResponse{}, err
 	}
+	// Evaluate rules against (source, tool, user) — same logic as Invoke.
+	agentID := auth.AgentIDFromContext(ctx)
+
 	now := time.Now().UTC()
 	inv := Invocation{
 		InvocationID:   "inv_" + uuid.NewString(),
@@ -441,12 +447,12 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 		Input:          inputJSON,
 		SubmittedAt:    now,
 	}
+	if agentID != "" {
+		inv.AgentID = &agentID
+	}
 	if err := s.invocations.Create(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
-
-	// Evaluate rules against (source, tool, user) — same logic as Invoke.
-	agentID := auth.AgentIDFromContext(ctx)
 	ruleAction := ""
 	if s.rules != nil {
 		if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
@@ -671,7 +677,7 @@ func (s *Service) Events(ctx context.Context, invocationID string, filter EventL
 }
 
 func (s *Service) toResponse(inv Invocation) InvocationResponse {
-	resp := InvocationResponse{InvocationID: inv.InvocationID, ServerName: inv.Upstream, ToolName: inv.Tool, Status: inv.Status, Approval: inv.Approval, MatchedRuleID: inv.MatchedRuleID, RequestID: inv.RequestID, SubmittedAt: inv.SubmittedAt, CompletedAt: inv.CompletedAt}
+	resp := InvocationResponse{InvocationID: inv.InvocationID, ServerName: inv.Upstream, ToolName: inv.Tool, Status: inv.Status, Approval: inv.Approval, MatchedRuleID: inv.MatchedRuleID, AgentID: inv.AgentID, RequestID: inv.RequestID, SubmittedAt: inv.SubmittedAt, CompletedAt: inv.CompletedAt}
 	if len(inv.Input) > 0 {
 		resp.Input = json.RawMessage(inv.Input)
 	}

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 5 {
+	if len(migrations) != 7 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -58,6 +58,8 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{3, "003_oauth_tables.sql"},
 		{4, "004_rules_table.sql"},
 		{5, "005_matched_rule_id.sql"},
+		{6, "006_invocation_agent_id.sql"},
+		{7, "007_rename_user_pattern.sql"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -68,11 +70,14 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 4 {
+	if len(pending) != 6 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	if pending[0].Version != 2 || pending[1].Version != 3 || pending[2].Version != 4 || pending[3].Version != 5 {
-		t.Fatalf("pending versions = %d, %d, %d, %d", pending[0].Version, pending[1].Version, pending[2].Version, pending[3].Version)
+	wantVersions := []int{2, 3, 4, 5, 6, 7}
+	for i, want := range wantVersions {
+		if pending[i].Version != want {
+			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)
+		}
 	}
 }
 

--- a/internal/store/migrations/006_invocation_agent_id.go
+++ b/internal/store/migrations/006_invocation_agent_id.go
@@ -1,0 +1,12 @@
+package migrations
+
+func migration006() Definition {
+	return Definition{
+		Version: 6,
+		Name:    "006_invocation_agent_id.sql",
+		Steps: []Step{
+			Raw("add agent_id to invocations", `ALTER TABLE invocations ADD COLUMN agent_id TEXT`),
+			Raw("create invocations agent_id index", `CREATE INDEX IF NOT EXISTS idx_invocations_agent_id ON invocations(agent_id)`),
+		},
+	}
+}

--- a/internal/store/migrations/007_rename_user_pattern.go
+++ b/internal/store/migrations/007_rename_user_pattern.go
@@ -1,0 +1,14 @@
+package migrations
+
+func migration007() Definition {
+	return Definition{
+		Version: 7,
+		Name:    "007_rename_user_pattern.sql",
+		Steps: []Step{
+			// Rename approval_rules.user_pattern -> agent_id_pattern.
+			// SQLite supports RENAME COLUMN since 3.25.0; Postgres natively.
+			Raw("rename approval_rules.user_pattern to agent_id_pattern",
+				`ALTER TABLE approval_rules RENAME COLUMN user_pattern TO agent_id_pattern`),
+		},
+	}
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -39,5 +39,7 @@ func All() []Definition {
 		migration003(),
 		migration004(),
 		migration005(),
+		migration006(),
+		migration007(),
 	}
 }

--- a/internal/store/rules.go
+++ b/internal/store/rules.go
@@ -15,12 +15,13 @@ import (
 // Rule is the store-level representation of an approval rule.
 // ServerPatterns and ToolPatterns are serialized as JSON arrays in the
 // server_pattern / tool_pattern TEXT columns; an empty slice means "match all".
+// AgentIDPattern is the literal authenticated agent_id (or "*"/"" for any).
 type Rule struct {
 	ID             string
 	Action         string
 	ServerPatterns []string
 	ToolPatterns   []string
-	UserPattern    string
+	AgentIDPattern string
 	Description    string
 	Enabled        bool
 	Order          int
@@ -43,7 +44,7 @@ func NewRulesRepoWithDialect(db *sql.DB, dialect Dialect) *RulesRepo {
 }
 
 var ruleColumns = []string{
-	"id", "action", "server_pattern", "tool_pattern", "user_pattern",
+	"id", "action", "server_pattern", "tool_pattern", "agent_id_pattern",
 	"description", "enabled", "rule_order", "created_at", "updated_at",
 }
 
@@ -56,7 +57,7 @@ func (r *RulesRepo) Create(ctx context.Context, rule Rule) error {
 	query, args, err := r.sb.Insert("approval_rules").
 		Columns(ruleColumns...).
 		Values(
-			rule.ID, rule.Action, serverJSON, toolJSON, rule.UserPattern,
+			rule.ID, rule.Action, serverJSON, toolJSON, rule.AgentIDPattern,
 			emptyToNil(rule.Description), boolToInt(rule.Enabled), rule.Order, now, now,
 		).ToSql()
 	if err != nil {
@@ -126,7 +127,7 @@ func (r *RulesRepo) Update(ctx context.Context, rule Rule) error {
 		Set("action", rule.Action).
 		Set("server_pattern", serverJSON).
 		Set("tool_pattern", toolJSON).
-		Set("user_pattern", rule.UserPattern).
+		Set("agent_id_pattern", rule.AgentIDPattern).
 		Set("description", emptyToNil(rule.Description)).
 		Set("enabled", boolToInt(rule.Enabled)).
 		Set("updated_at", now).
@@ -267,7 +268,7 @@ func scanRule(scanner interface{ Scan(dest ...any) error }) (Rule, error) {
 	var description sql.NullString
 	var enabled int
 	if err := scanner.Scan(
-		&rule.ID, &rule.Action, &serverJSON, &toolJSON, &rule.UserPattern,
+		&rule.ID, &rule.Action, &serverJSON, &toolJSON, &rule.AgentIDPattern,
 		&description, &enabled, &rule.Order, &rule.CreatedAt, &rule.UpdatedAt,
 	); err != nil {
 		return Rule{}, err
@@ -304,7 +305,7 @@ func (r *RulesRepo) ListApprovalRules(ctx context.Context) ([]invocation.Approva
 			Action:         rule.Action,
 			ServerPatterns: rule.ServerPatterns,
 			ToolPatterns:   rule.ToolPatterns,
-			UserPattern:    rule.UserPattern,
+			AgentIDPattern: rule.AgentIDPattern,
 			Enabled:        rule.Enabled,
 		})
 	}
@@ -357,7 +358,7 @@ func (r *RulesRepo) InsertBefore(ctx context.Context, anchorID string, rule Rule
 	insQ, insArgs, err := r.sb.Insert("approval_rules").
 		Columns(ruleColumns...).
 		Values(
-			rule.ID, rule.Action, serverJSON, toolJSON, rule.UserPattern,
+			rule.ID, rule.Action, serverJSON, toolJSON, rule.AgentIDPattern,
 			emptyToNil(rule.Description), boolToInt(rule.Enabled), rule.Order, now, now,
 		).ToSql()
 	if err != nil {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -82,9 +82,9 @@ func (r *InvocationRepo) Create(ctx context.Context, inv invocation.Invocation) 
 		approval = string(b)
 	}
 	query, args, err := r.sb.Insert("invocations").Columns(
-		"invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id",
+		"invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id",
 	).Values(
-		inv.InvocationID, inv.RequestID, inv.IdempotencyKey, inv.Tool, inv.Upstream, inv.Status, approval, string(inv.Input), nullableString(inv.Response), nullableString(inv.Error), inv.SubmittedAt, inv.CompletedAt, inv.MatchedRuleID,
+		inv.InvocationID, inv.RequestID, inv.IdempotencyKey, inv.Tool, inv.Upstream, inv.Status, approval, string(inv.Input), nullableString(inv.Response), nullableString(inv.Error), inv.SubmittedAt, inv.CompletedAt, inv.MatchedRuleID, inv.AgentID,
 	).ToSql()
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (r *InvocationRepo) UpdateResult(ctx context.Context, inv invocation.Invoca
 }
 
 func (r *InvocationRepo) Get(ctx context.Context, id string) (invocation.Invocation, error) {
-	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id").From("invocations").Where(sq.Eq{"invocation_id": id}).ToSql()
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").From("invocations").Where(sq.Eq{"invocation_id": id}).ToSql()
 	if err != nil {
 		return invocation.Invocation{}, err
 	}
@@ -117,7 +117,7 @@ func (r *InvocationRepo) Get(ctx context.Context, id string) (invocation.Invocat
 }
 
 func (r *InvocationRepo) GetByIdempotencyKey(ctx context.Context, key string) (invocation.Invocation, error) {
-	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id").From("invocations").Where(sq.Eq{"idempotency_key": key}).ToSql()
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").From("invocations").Where(sq.Eq{"idempotency_key": key}).ToSql()
 	if err != nil {
 		return invocation.Invocation{}, err
 	}
@@ -129,7 +129,7 @@ func (r *InvocationRepo) List(ctx context.Context, filter invocation.InvocationL
 	if filter.Limit == 0 {
 		filter.Limit = 50
 	}
-	builder := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id").From("invocations")
+	builder := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").From("invocations")
 	countBuilder := r.sb.Select("COUNT(*)").From("invocations")
 	builder, countBuilder = applyInvocationFilter(builder, countBuilder, filter)
 	query, args, err := builder.OrderBy("submitted_at DESC").Limit(filter.Limit).Offset(filter.Offset).ToSql()
@@ -524,7 +524,8 @@ func scanInvocation(scanner interface{ Scan(dest ...any) error }) (invocation.In
 	var requestJSON, responseJSON, errorJSON sql.NullString
 	var completedAt sql.NullTime
 	var matchedRuleID sql.NullString
-	if err := scanner.Scan(&inv.InvocationID, &requestID, &idempotencyKey, &inv.Tool, &inv.Upstream, &inv.Status, &approval, &requestJSON, &responseJSON, &errorJSON, &inv.SubmittedAt, &completedAt, &matchedRuleID); err != nil {
+	var agentID sql.NullString
+	if err := scanner.Scan(&inv.InvocationID, &requestID, &idempotencyKey, &inv.Tool, &inv.Upstream, &inv.Status, &approval, &requestJSON, &responseJSON, &errorJSON, &inv.SubmittedAt, &completedAt, &matchedRuleID, &agentID); err != nil {
 		return invocation.Invocation{}, err
 	}
 	if requestID.Valid {
@@ -552,6 +553,9 @@ func scanInvocation(scanner interface{ Scan(dest ...any) error }) (invocation.In
 	}
 	if matchedRuleID.Valid {
 		inv.MatchedRuleID = &matchedRuleID.String
+	}
+	if agentID.Valid {
+		inv.AgentID = &agentID.String
 	}
 	return inv, nil
 }
@@ -625,6 +629,10 @@ func applyInvocationFilter(builder sq.SelectBuilder, countBuilder sq.SelectBuild
 	if filter.Status != "" {
 		builder = builder.Where(sq.Eq{"status": filter.Status})
 		countBuilder = countBuilder.Where(sq.Eq{"status": filter.Status})
+	}
+	if filter.AgentID != "" {
+		builder = builder.Where(sq.Eq{"agent_id": filter.AgentID})
+		countBuilder = countBuilder.Where(sq.Eq{"agent_id": filter.AgentID})
 	}
 	return builder, countBuilder
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -41,8 +41,8 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 5 {
-		t.Fatalf("expected 5 migrations, got %d", count)
+	if count != 7 {
+		t.Fatalf("expected 7 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 5 {
-		t.Fatalf("expected 5 migrations after double init, got %d", count)
+	if count != 7 {
+		t.Fatalf("expected 7 migrations after double init, got %d", count)
 	}
 }
 
@@ -170,6 +170,61 @@ func TestInvocationRepo_CRUD(t *testing.T) {
 	}
 	if got3.InvocationID != "inv-2" {
 		t.Errorf("idem key mismatch: %s", got3.InvocationID)
+	}
+}
+
+func TestInvocationRepo_AgentIDPersistedAndFilterable(t *testing.T) {
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+	if err := InitDB(db); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	repo := NewInvocationRepo(db)
+	ctx := context.Background()
+
+	// One row with an agent, one without — confirms NULL-friendly column.
+	withAgent := invocation.Invocation{
+		InvocationID: "inv-agent",
+		Tool:         "t", Upstream: "u", Status: "received",
+		Input:       []byte(`{}`),
+		AgentID:     strPtr("agent-007"),
+		SubmittedAt: time.Now().UTC(),
+	}
+	noAgent := invocation.Invocation{
+		InvocationID: "inv-anon",
+		Tool:         "t", Upstream: "u", Status: "received",
+		Input:       []byte(`{}`),
+		SubmittedAt: time.Now().UTC(),
+	}
+	if err := repo.Create(ctx, withAgent); err != nil {
+		t.Fatalf("create withAgent: %v", err)
+	}
+	if err := repo.Create(ctx, noAgent); err != nil {
+		t.Fatalf("create noAgent: %v", err)
+	}
+
+	got, err := repo.Get(ctx, "inv-agent")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AgentID == nil || *got.AgentID != "agent-007" {
+		t.Fatalf("agent_id round-trip failed: %+v", got.AgentID)
+	}
+	gotAnon, err := repo.Get(ctx, "inv-anon")
+	if err != nil {
+		t.Fatalf("Get anon: %v", err)
+	}
+	if gotAnon.AgentID != nil {
+		t.Fatalf("expected nil agent_id, got %q", *gotAnon.AgentID)
+	}
+
+	// Filter by agent_id returns only the matching row.
+	invs, total, err := repo.List(ctx, invocation.InvocationListFilter{AgentID: "agent-007", Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 1 || len(invs) != 1 || invs[0].InvocationID != "inv-agent" {
+		t.Fatalf("unexpected filter result: total=%d items=%+v", total, invs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Builds on the inbound OAuth bearer auth (#6) by surfacing the authenticated **agent identity** as a first-class column on `invocations` and clarifying the rules schema by renaming `approval_rules.user_pattern` to `approval_rules.agent_id_pattern`.

## Schema changes

- **Migration 006** — `ALTER TABLE invocations ADD COLUMN agent_id TEXT` (nullable; existing rows stay valid). Adds index `idx_invocations_agent_id`.
- **Migration 007** — `ALTER TABLE approval_rules RENAME COLUMN user_pattern TO agent_id_pattern`. Works on both SQLite (3.25+) and Postgres natively.

## Code changes

- `invocation.Invocation`, `InvocationResponse`, `InvocationListFilter` gain `AgentID`.
- `store.InvocationRepo` Create/Get/GetByIdempotencyKey/List read & write `agent_id`. `UpdateResult` is unchanged (agent_id is set once, at creation).
- `Service.Invoke` and `Service.Submit` populate `inv.AgentID` from `auth.AgentIDFromContext(ctx)` before insert.
- Rename: `store.Rule.UserPattern` → `AgentIDPattern`; `invocation.ApprovalRule.UserPattern` → `AgentIDPattern`; `AdminRule(Input).UserPattern` → `AgentIDPattern` (JSON tag `agent_id_pattern`); helper `matchUserPattern` → `matchAgentIDPattern`. Dashboard JSON payload key updated to `agent_id_pattern`.

## Behavior preserved

- When auth is disabled (no identity on context), `agent_id` is `NULL` on insert and rule matching falls back to `request_id`, exactly as before.
- Token validation, Auth0 config, debug skip-verify, and middleware are untouched.

## API/UX notes (not breaking anything internal, but worth flagging)

- The admin rules JSON API field renamed from `user_pattern` to `agent_id_pattern`. There are no external clients today; the dashboard JS was updated alongside.
- Dashboard input element ids (`#rule-user`, `#inv-rule-user`) and the "for all users" placeholder text were left as-is to keep the diff focused; cosmetic UI rename can follow.

## Tests

- New: `TestInvocationRepo_AgentIDPersistedAndFilterable` (round-trip + NULL + `AgentID` filter).
- Extended: `TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents` now also asserts `Get` and `List(AgentID=…)` return the populated column end-to-end.
- Migration count assertions bumped to 7.
- All target suites pass: `internal/store`, `internal/auth`, `internal/api`, and the agent_id invocation tests.

## Out of scope (follow-ups noted in thread)

- Backfilling `agent_id` for pre-existing rows from event payloads.
- HTTP query-param exposure of the new `AgentID` filter on `GET /invocations`.
- Glob/list support on `agent_id_pattern` (today still exact-string match — one rule per agent).
- Capturing the operator identity (`Approval.ActorID`) on approve/deny.