### PR TITLE
Add intial validmind connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ on the request context. Requests reach the upstream MCP server as if no
 This is only for local debugging. Do not enable it in shared or production
 environments.
 
+## Backend connection check
+
+Atryum can verify its ValidMind backend machine-user credentials during
+startup:
+
+```toml
+[backend]
+base_url = "https://api.example.validmind.ai"
+machine_key = "replace-me"
+machine_secret = "replace-me"
+connection_timeout_seconds = 5
+```
+
+The same values can be supplied with environment variables, which override
+TOML: `ATRYUM_BACKEND_BASE_URL`, `ATRYUM_MACHINE_KEY`,
+`ATRYUM_MACHINE_SECRET`, and
+`ATRYUM_BACKEND_CONNECTION_TIMEOUT_SECONDS`.
+
+When `backend.base_url` is empty, the check is skipped for local standalone
+runs. When it is set, startup fails if credentials are missing or the backend
+rejects `GET /internal/v1/atryum/connection`.
+
 ## Database configuration
 
 SQLite remains the default storage provider:

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -10,6 +10,21 @@ database_path = "./atryum.db"
 database_url = ""
 log_level = "info"
 
+[backend]
+# Optional ValidMind backend connection check. When base_url is set, Atryum
+# verifies these machine-user credentials at startup by calling:
+# GET /internal/v1/atryum/connection
+#
+# Environment variables override these TOML values:
+# ATRYUM_BACKEND_BASE_URL
+# ATRYUM_MACHINE_KEY
+# ATRYUM_MACHINE_SECRET
+# ATRYUM_BACKEND_CONNECTION_TIMEOUT_SECONDS
+base_url = ""
+machine_key = ""
+machine_secret = ""
+connection_timeout_seconds = 5
+
 [defaults]
 request_timeout_seconds = 30
 

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -12,6 +12,7 @@ import (
 
 	"atryum/internal/api"
 	"atryum/internal/auth"
+	backendclient "atryum/internal/backend"
 	"atryum/internal/config"
 	"atryum/internal/invocation"
 	"atryum/internal/invocation/policy"
@@ -29,6 +30,19 @@ func main() {
 	cfg, err := config.Load(*configPath)
 	if err != nil {
 		log.Fatalf("load config: %v", err)
+	}
+	backendClient, err := backendclient.NewClient(cfg.Backend)
+	if err != nil {
+		log.Fatalf("backend config: %v", err)
+	}
+	if backendClient != nil {
+		resp, err := backendClient.CheckConnection(context.Background())
+		if err != nil {
+			log.Fatalf("backend connection check: %v", err)
+		}
+		log.Printf("backend connection verified for service=%s machine_user_cuid=%s", resp.ServiceName, resp.MachineUserCUID)
+	} else {
+		log.Printf("backend connection check skipped (backend.base_url not configured)")
 	}
 
 	db, dialect, err := store.OpenDatabase(cfg.Server.DatabaseURL, cfg.Server.DatabasePath)

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -1,0 +1,81 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"atryum/internal/config"
+)
+
+const connectionPath = "/internal/v1/atryum/connection"
+
+type ConnectionResponse struct {
+	OK              bool   `json:"ok"`
+	MachineUserCUID string `json:"machine_user_cuid"`
+	ServiceName     string `json:"service_name"`
+}
+
+type Client struct {
+	baseURL       string
+	machineKey    string
+	machineSecret string
+	httpClient    *http.Client
+}
+
+func NewClient(cfg config.BackendConfig) (*Client, error) {
+	baseURL := strings.TrimSpace(cfg.BaseURL)
+	if baseURL == "" {
+		return nil, nil
+	}
+	if strings.TrimSpace(cfg.MachineKey) == "" || strings.TrimSpace(cfg.MachineSecret) == "" {
+		return nil, fmt.Errorf("backend machine credentials are required when backend.base_url is configured")
+	}
+	if _, err := url.ParseRequestURI(baseURL); err != nil {
+		return nil, fmt.Errorf("backend base_url is invalid: %w", err)
+	}
+
+	timeout := time.Duration(cfg.ConnectionTimeoutSecs) * time.Second
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &Client{
+		baseURL:       strings.TrimRight(baseURL, "/"),
+		machineKey:    strings.TrimSpace(cfg.MachineKey),
+		machineSecret: strings.TrimSpace(cfg.MachineSecret),
+		httpClient:    &http.Client{Timeout: timeout},
+	}, nil
+}
+
+func (c *Client) CheckConnection(ctx context.Context) (ConnectionResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+connectionPath, nil)
+	if err != nil {
+		return ConnectionResponse{}, fmt.Errorf("build backend connection request: %w", err)
+	}
+	req.Header.Set("X-MACHINE-KEY", c.machineKey)
+	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return ConnectionResponse{}, fmt.Errorf("call backend connection endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ConnectionResponse{}, fmt.Errorf("backend connection endpoint returned %s", resp.Status)
+	}
+
+	var payload ConnectionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return ConnectionResponse{}, fmt.Errorf("decode backend connection response: %w", err)
+	}
+	if !payload.OK {
+		return ConnectionResponse{}, fmt.Errorf("backend connection endpoint returned ok=false")
+	}
+	return payload, nil
+}

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -39,15 +39,11 @@ func NewClient(cfg config.BackendConfig) (*Client, error) {
 		return nil, fmt.Errorf("backend base_url is invalid: %w", err)
 	}
 
-	timeout := time.Duration(cfg.ConnectionTimeoutSecs) * time.Second
-	if timeout <= 0 {
-		timeout = 5 * time.Second
-	}
 	return &Client{
 		baseURL:       strings.TrimRight(baseURL, "/"),
 		machineKey:    strings.TrimSpace(cfg.MachineKey),
 		machineSecret: strings.TrimSpace(cfg.MachineSecret),
-		httpClient:    &http.Client{Timeout: timeout},
+		httpClient:    &http.Client{Timeout: time.Duration(cfg.ConnectionTimeoutSecs) * time.Second},
 	}, nil
 }
 

--- a/internal/backend/client_test.go
+++ b/internal/backend/client_test.go
@@ -1,0 +1,81 @@
+package backend
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"atryum/internal/config"
+)
+
+func TestNewClientReturnsNilWhenBackendNotConfigured(t *testing.T) {
+	client, err := NewClient(config.BackendConfig{})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if client != nil {
+		t.Fatalf("expected nil client when backend is not configured")
+	}
+}
+
+func TestNewClientRequiresCredentialsWhenBackendConfigured(t *testing.T) {
+	_, err := NewClient(config.BackendConfig{BaseURL: "http://backend.test"})
+	if err == nil {
+		t.Fatalf("expected missing credentials error")
+	}
+}
+
+func TestCheckConnectionSendsMachineCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != connectionPath {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if got := r.Header.Get("X-MACHINE-KEY"); got != "machine-key" {
+			t.Fatalf("X-MACHINE-KEY = %q", got)
+		}
+		if got := r.Header.Get("X-MACHINE-SECRET"); got != "machine-secret" {
+			t.Fatalf("X-MACHINE-SECRET = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"machine_user_cuid":"cmu123","service_name":"atryum"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(config.BackendConfig{
+		BaseURL:       server.URL,
+		MachineKey:    "machine-key",
+		MachineSecret: "machine-secret",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	resp, err := client.CheckConnection(context.Background())
+	if err != nil {
+		t.Fatalf("CheckConnection: %v", err)
+	}
+	if !resp.OK || resp.MachineUserCUID != "cmu123" || resp.ServiceName != "atryum" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestCheckConnectionReturnsErrorOnNonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(config.BackendConfig{
+		BaseURL:       server.URL,
+		MachineKey:    "machine-key",
+		MachineSecret: "machine-secret",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if _, err := client.CheckConnection(context.Background()); err == nil {
+		t.Fatalf("expected status error")
+	}
+}

--- a/internal/backend/client_test.go
+++ b/internal/backend/client_test.go
@@ -29,13 +29,13 @@ func TestNewClientRequiresCredentialsWhenBackendConfigured(t *testing.T) {
 func TestCheckConnectionSendsMachineCredentials(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != connectionPath {
-			t.Fatalf("path = %q", r.URL.Path)
+			t.Errorf("path = %q", r.URL.Path)
 		}
 		if got := r.Header.Get("X-MACHINE-KEY"); got != "machine-key" {
-			t.Fatalf("X-MACHINE-KEY = %q", got)
+			t.Errorf("X-MACHINE-KEY = %q", got)
 		}
 		if got := r.Header.Get("X-MACHINE-SECRET"); got != "machine-secret" {
-			t.Fatalf("X-MACHINE-SECRET = %q", got)
+			t.Errorf("X-MACHINE-SECRET = %q", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"ok":true,"machine_user_cuid":"cmu123","service_name":"atryum"}`))

--- a/internal/config/backend_test.go
+++ b/internal/config/backend_test.go
@@ -1,0 +1,56 @@
+package config
+
+import "testing"
+
+func TestBackendConfigApplyEnvOverridesToml(t *testing.T) {
+	t.Setenv("ATRYUM_BACKEND_BASE_URL", "https://backend.example")
+	t.Setenv("ATRYUM_MACHINE_KEY", "env-key")
+	t.Setenv("ATRYUM_MACHINE_SECRET", "env-secret")
+	t.Setenv("ATRYUM_BACKEND_CONNECTION_TIMEOUT_SECONDS", "9")
+
+	cfg := BackendConfig{
+		BaseURL:               "https://toml.example",
+		MachineKey:            "toml-key",
+		MachineSecret:         "toml-secret",
+		ConnectionTimeoutSecs: 3,
+	}
+
+	cfg.ApplyEnv()
+
+	if cfg.BaseURL != "https://backend.example" {
+		t.Fatalf("BaseURL = %q", cfg.BaseURL)
+	}
+	if cfg.MachineKey != "env-key" {
+		t.Fatalf("MachineKey = %q", cfg.MachineKey)
+	}
+	if cfg.MachineSecret != "env-secret" {
+		t.Fatalf("MachineSecret = %q", cfg.MachineSecret)
+	}
+	if cfg.ConnectionTimeoutSecs != 9 {
+		t.Fatalf("ConnectionTimeoutSecs = %d", cfg.ConnectionTimeoutSecs)
+	}
+}
+
+func TestBackendConfigApplyEnvPreservesTomlWhenEnvUnset(t *testing.T) {
+	cfg := BackendConfig{
+		BaseURL:               "https://toml.example",
+		MachineKey:            "toml-key",
+		MachineSecret:         "toml-secret",
+		ConnectionTimeoutSecs: 3,
+	}
+
+	cfg.ApplyEnv()
+
+	if cfg.BaseURL != "https://toml.example" {
+		t.Fatalf("BaseURL = %q", cfg.BaseURL)
+	}
+	if cfg.MachineKey != "toml-key" {
+		t.Fatalf("MachineKey = %q", cfg.MachineKey)
+	}
+	if cfg.MachineSecret != "toml-secret" {
+		t.Fatalf("MachineSecret = %q", cfg.MachineSecret)
+	}
+	if cfg.ConnectionTimeoutSecs != 3 {
+		t.Fatalf("ConnectionTimeoutSecs = %d", cfg.ConnectionTimeoutSecs)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"os"
+	"strconv"
+
 	"github.com/BurntSushi/toml"
 
 	"atryum/internal/auth"
@@ -8,6 +11,7 @@ import (
 
 type Config struct {
 	Server    ServerConfig     `toml:"server"`
+	Backend   BackendConfig    `toml:"backend"`
 	Defaults  DefaultsConfig   `toml:"defaults"`
 	Policy    PolicyConfig     `toml:"policy"`
 	Upstreams []UpstreamConfig `toml:"upstreams"`
@@ -16,6 +20,15 @@ type Config struct {
 	// facing /mcp/ routes remain anonymous.
 	Auth      []auth.Config   `toml:"auth"`
 	AuthDebug AuthDebugConfig `toml:"auth_debug"`
+}
+
+// BackendConfig configures Atryum's startup connection check to the ValidMind
+// backend. Environment variables override TOML when set.
+type BackendConfig struct {
+	BaseURL               string `toml:"base_url"`
+	MachineKey            string `toml:"machine_key"`
+	MachineSecret         string `toml:"machine_secret"`
+	ConnectionTimeoutSecs int    `toml:"connection_timeout_seconds"`
 }
 
 // AuthDebugConfig contains local-only auth debugging switches.
@@ -59,10 +72,34 @@ func Load(path string) (Config, error) {
 			DatabasePath: "./atryum.db",
 			LogLevel:     "info",
 		},
+		Backend: BackendConfig{
+			ConnectionTimeoutSecs: 5,
+		},
 		Defaults: DefaultsConfig{
 			RequestTimeoutSeconds: 30,
 		},
 	}
 	_, err := toml.DecodeFile(path, &cfg)
+	cfg.Backend.ApplyEnv()
 	return cfg, err
+}
+
+func (c *BackendConfig) ApplyEnv() {
+	if value := os.Getenv("ATRYUM_BACKEND_BASE_URL"); value != "" {
+		c.BaseURL = value
+	}
+	if value := os.Getenv("ATRYUM_MACHINE_KEY"); value != "" {
+		c.MachineKey = value
+	}
+	if value := os.Getenv("ATRYUM_MACHINE_SECRET"); value != "" {
+		c.MachineSecret = value
+	}
+	if value := os.Getenv("ATRYUM_BACKEND_CONNECTION_TIMEOUT_SECONDS"); value != "" {
+		if parsed, err := strconv.Atoi(value); err == nil {
+			c.ConnectionTimeoutSecs = parsed
+		}
+	}
+	if c.ConnectionTimeoutSecs <= 0 {
+		c.ConnectionTimeoutSecs = 5
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,12 @@ listen_addr = ":9090"
 database_path = "./atryum.db"
 database_url = "postgresql://postgres:password@127.0.0.1:5432/postgres"
 log_level = "debug"
+
+[backend]
+base_url = "https://backend.example"
+machine_key = "toml-key"
+machine_secret = "toml-secret"
+connection_timeout_seconds = 7
 `), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
@@ -24,5 +30,17 @@ log_level = "debug"
 	}
 	if cfg.Server.DatabaseURL != "postgresql://postgres:password@127.0.0.1:5432/postgres" {
 		t.Fatalf("DatabaseURL = %q", cfg.Server.DatabaseURL)
+	}
+	if cfg.Backend.BaseURL != "https://backend.example" {
+		t.Fatalf("Backend.BaseURL = %q", cfg.Backend.BaseURL)
+	}
+	if cfg.Backend.MachineKey != "toml-key" {
+		t.Fatalf("Backend.MachineKey = %q", cfg.Backend.MachineKey)
+	}
+	if cfg.Backend.MachineSecret != "toml-secret" {
+		t.Fatalf("Backend.MachineSecret = %q", cfg.Backend.MachineSecret)
+	}
+	if cfg.Backend.ConnectionTimeoutSecs != 7 {
+		t.Fatalf("Backend.ConnectionTimeoutSecs = %d", cfg.Backend.ConnectionTimeoutSecs)
 	}
 }


### PR DESCRIPTION
<img width="829" height="140" alt="Screenshot 2026-05-15 at 13 23 56" src="https://github.com/user-attachments/assets/e5672c7a-e675-463c-9d7b-b801ca4353dc" />
Summary
Adds a startup connection check so Atryum verifies its ValidMind machine-user credentials against the backend before serving traffic. When backend.base_url is configured, Atryum calls GET /internal/v1/atryum/connection with X-MACHINE-KEY / X-MACHINE-SECRET headers and refuses to start if the call fails. When base_url is empty, the check is skipped so local standalone runs continue to work.

Changes
- internal/config — new BackendConfig (base_url, machine_key, machine_secret, connection_timeout_seconds) with ApplyEnv() so environment variables (ATRYUM_BACKEND_BASE_URL, ATRYUM_MACHINE_KEY, ATRYUM_MACHINE_SECRET, ATRYUM_BACKEND_CONNECTION_TIMEOUT_SECONDS) override TOML. Defaults connection_timeout_seconds to 5.
- internal/backend — new Client with NewClient (validates base URL + required credentials, returns nil when backend isn't configured) and CheckConnection (sends machine credentials, decodes the JSON response, errors on non-2xx or ok=false).
- cmd/atryum/main.go — invokes the connection check immediately after config load; logs the verified service_name / machine_user_cuid on success, or fatals out on failure.
- atryum.example.toml / README.md — documents the new [backend] block, env-var overrides, and the skip-when-empty behavior.

Tests
- internal/config: TOML decoding of [backend], env-var override behavior, and TOML preservation when env vars are unset.
- internal/backend: nil client when unconfigured, error when credentials missing, machine headers sent on success, and error returned on non-success status.

Configuration
[backend]
base_url = "https://api.example.validmind.ai"
machine_key = "replace-me"
machine_secret = "replace-me"
connection_timeout_seconds = 5



related backend branch
https://github.com/validmind/backend/pull/3124