### PR TITLE
Invocations API

### DIFF
--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -28,6 +28,14 @@ connection_timeout_seconds = 5
 [defaults]
 request_timeout_seconds = 30
 
+# Static API key/secret pair that protects the read-only invocation reporting
+# endpoints (GET /invocations/{agent_id}, GET /agent_ids). Callers must send
+# both `X-API-Key` and `X-API-Secret` headers matching these values. When
+# either field is empty, those endpoints refuse every request with 503.
+[api_key]
+key = ""
+secret = ""
+
 # Local-only auth debug mode. When true, the Authorization header is ignored
 # entirely on /mcp/: no bearer token is required and no identity is set on
 # the request context. Never enable outside local debugging.

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -95,6 +95,12 @@ func main() {
 	} else {
 		log.Printf("inbound auth disabled (no [[auth]] section configured)")
 	}
+	handler.SetAPIKeyAuth(cfg.APIKey)
+	if cfg.APIKey.Enabled() {
+		log.Printf("api key auth enabled for /invocations/{agent_id} and /agent_ids")
+	} else {
+		log.Printf("api key auth NOT configured: /invocations/{agent_id} and /agent_ids will refuse all requests")
+	}
 	authDebugSkipVerify := cfg.AuthDebug.SkipVerify || truthyEnv("ATRYUM_AUTH_DEBUG_SKIP_VERIFY")
 	if authDebugSkipVerify {
 		handler.SetAuthDebugSkipVerify(true)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -34,6 +34,7 @@ type service interface {
 	ResolveToolServer(ctx context.Context, toolName string) (string, error)
 	Get(ctx context.Context, id string) (invocation.InvocationResponse, error)
 	List(ctx context.Context, filter invocation.InvocationListFilter) (invocation.InvocationListResponse, error)
+	ListAgentIDs(ctx context.Context) ([]string, error)
 	Events(ctx context.Context, invocationID string, filter invocation.EventListFilter) (invocation.EventListResponse, error)
 	Approve(ctx context.Context, invocationID string) error
 	Deny(ctx context.Context, invocationID string, message string) error
@@ -77,6 +78,7 @@ type Handler struct {
 	debug          bool
 	authDebugSkip  bool
 	authValidator  *auth.Validator
+	apiKeyAuth     auth.APIKeyConfig
 }
 
 type PolicyStatusResponse struct {
@@ -242,6 +244,12 @@ func (h *Handler) SetAuthDebugSkipVerify(enabled bool) {
 	h.authDebugSkip = enabled
 }
 
+// SetAPIKeyAuth installs the static api-key/secret pair used to protect the
+// read-only invocation reporting endpoints.
+func (h *Handler) SetAPIKeyAuth(cfg auth.APIKeyConfig) {
+	h.apiKeyAuth = cfg
+}
+
 // protectedResourceMetadata serves the OAuth 2.0 protected-resource metadata
 // (RFC 9728) document so MCP clients can discover the authorization server.
 // The resource URL is computed from the incoming request so deployments
@@ -271,6 +279,9 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/admin/policy", h.adminPolicy)
 	mux.HandleFunc("/api/v1/external/invocations", h.externalInvocations)
 	mux.HandleFunc("/api/v1/external/invocations/", h.externalInvocationDetail)
+	apiKeyMW := auth.APIKeyMiddleware(h.apiKeyAuth)
+	mux.Handle("/agent_ids", apiKeyMW(http.HandlerFunc(h.agentIDs)))
+	mux.Handle("/invocations/", apiKeyMW(http.HandlerFunc(h.invocationsByAgentID)))
 	mux.HandleFunc("/ui", h.uiIndex)
 	mux.Handle("/ui/", http.StripPrefix("/ui/", h.spaFileServer()))
 	mux.HandleFunc("/", h.root)
@@ -522,6 +533,78 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 		w.WriteHeader(status)
 		_, _ = w.Write(forwarded.Body)
 	}
+}
+
+// agentIDs returns the distinct agent IDs that have submitted invocations.
+// Protected by the API key middleware.
+func (h *Handler) agentIDs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	ids, err := h.svc.ListAgentIDs(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if ids == nil {
+		ids = []string{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": ids})
+}
+
+// invocationsByAgentID returns a paginated list of invocations for the given
+// agent_id. Supports optional `start_date` and `end_date` query parameters
+// (RFC3339). Protected by the API key middleware.
+func (h *Handler) invocationsByAgentID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	agentID := strings.Trim(strings.TrimPrefix(r.URL.Path, "/invocations/"), "/")
+	if agentID == "" {
+		writeError(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
+	filter := invocation.InvocationListFilter{
+		Offset:  readUintQuery(r, "offset", 0),
+		Limit:   readUintQuery(r, "limit", 50),
+		AgentID: agentID,
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("start_date")); raw != "" {
+		t, err := parseDateParam(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid start_date: "+err.Error())
+			return
+		}
+		filter.StartDate = &t
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("end_date")); raw != "" {
+		t, err := parseDateParam(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid end_date: "+err.Error())
+			return
+		}
+		filter.EndDate = &t
+	}
+	resp, err := h.svc.List(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// parseDateParam accepts RFC3339 timestamps as well as YYYY-MM-DD dates
+// (interpreted as UTC midnight).
+func parseDateParam(value string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.Parse("2006-01-02", value); err == nil {
+		return t.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("expected RFC3339 timestamp or YYYY-MM-DD date")
 }
 
 func (h *Handler) adminInvocations(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -46,6 +46,9 @@ func (s *stubService) Get(context.Context, string) (invocation.InvocationRespons
 func (s *stubService) List(context.Context, invocation.InvocationListFilter) (invocation.InvocationListResponse, error) {
 	return invocation.InvocationListResponse{Items: []invocation.InvocationResponse{s.invoke}, Total: 1, Limit: 50}, nil
 }
+func (s *stubService) ListAgentIDs(context.Context) ([]string, error) {
+	return nil, nil
+}
 func (s *stubService) Events(context.Context, string, invocation.EventListFilter) (invocation.EventListResponse, error) {
 	return invocation.EventListResponse{}, nil
 }

--- a/internal/auth/apikey.go
+++ b/internal/auth/apikey.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// APIKeyConfig holds the static key/secret pair used to authenticate
+// machine-to-machine callers of the read-only invocation reporting endpoints.
+// Both fields must be non-empty for the middleware to enforce authentication;
+// if either is empty the middleware is disabled (no-op).
+type APIKeyConfig struct {
+	Key    string `toml:"key"`
+	Secret string `toml:"secret"`
+}
+
+// Enabled reports whether the configured key/secret are usable.
+func (c APIKeyConfig) Enabled() bool {
+	return strings.TrimSpace(c.Key) != "" && strings.TrimSpace(c.Secret) != ""
+}
+
+const (
+	apiKeyHeader    = "X-API-Key"
+	apiSecretHeader = "X-API-Secret"
+)
+
+// APIKeyMiddleware returns an http middleware that requires callers to send
+// matching X-API-Key and X-API-Secret headers. When the config is not
+// enabled (missing key or secret), the middleware refuses every request with
+// 503 so we never accidentally expose unauthenticated read endpoints.
+func APIKeyMiddleware(cfg APIKeyConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !cfg.Enabled() {
+				writeAPIKeyError(w, http.StatusServiceUnavailable, "api key auth is not configured")
+				return
+			}
+			gotKey := strings.TrimSpace(r.Header.Get(apiKeyHeader))
+			gotSecret := strings.TrimSpace(r.Header.Get(apiSecretHeader))
+			if gotKey == "" || gotSecret == "" {
+				writeAPIKeyError(w, http.StatusUnauthorized, "missing api key credentials")
+				return
+			}
+			keyOK := subtle.ConstantTimeCompare([]byte(gotKey), []byte(cfg.Key)) == 1
+			secretOK := subtle.ConstantTimeCompare([]byte(gotSecret), []byte(cfg.Secret)) == 1
+			if !keyOK || !secretOK {
+				writeAPIKeyError(w, http.StatusUnauthorized, "invalid api key credentials")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func writeAPIKeyError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{"message": message},
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,10 @@ type Config struct {
 	// facing /mcp/ routes remain anonymous.
 	Auth      []auth.Config   `toml:"auth"`
 	AuthDebug AuthDebugConfig `toml:"auth_debug"`
+	// APIKey protects the read-only reporting endpoints
+	// (GET /invocations/{agent_id}, GET /agent_ids). When key or secret is
+	// empty, those endpoints refuse every request.
+	APIKey auth.APIKeyConfig `toml:"api_key"`
 }
 
 // BackendConfig configures Atryum's startup connection check to the ValidMind

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -54,12 +54,14 @@ type Event struct {
 }
 
 type InvocationListFilter struct {
-	Offset  uint64
-	Limit   uint64
-	Server  string
-	Tool    string
-	Status  string
-	AgentID string
+	Offset    uint64
+	Limit     uint64
+	Server    string
+	Tool      string
+	Status    string
+	AgentID   string
+	StartDate *time.Time
+	EndDate   *time.Time
 }
 
 type EventListFilter struct {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -26,6 +26,7 @@ type invocationRepo interface {
 	Get(ctx context.Context, id string) (Invocation, error)
 	GetByIdempotencyKey(ctx context.Context, key string) (Invocation, error)
 	List(ctx context.Context, filter InvocationListFilter) ([]Invocation, int, error)
+	ListAgentIDs(ctx context.Context) ([]string, error)
 }
 
 type eventRepo interface {
@@ -650,6 +651,10 @@ func (s *Service) Get(ctx context.Context, id string) (InvocationResponse, error
 		return InvocationResponse{}, err
 	}
 	return s.toResponse(inv), nil
+}
+
+func (s *Service) ListAgentIDs(ctx context.Context) ([]string, error) {
+	return s.invocations.ListAgentIDs(ctx)
 }
 
 func (s *Service) List(ctx context.Context, filter InvocationListFilter) (InvocationListResponse, error) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -634,7 +634,45 @@ func applyInvocationFilter(builder sq.SelectBuilder, countBuilder sq.SelectBuild
 		builder = builder.Where(sq.Eq{"agent_id": filter.AgentID})
 		countBuilder = countBuilder.Where(sq.Eq{"agent_id": filter.AgentID})
 	}
+	if filter.StartDate != nil {
+		builder = builder.Where(sq.GtOrEq{"submitted_at": *filter.StartDate})
+		countBuilder = countBuilder.Where(sq.GtOrEq{"submitted_at": *filter.StartDate})
+	}
+	if filter.EndDate != nil {
+		builder = builder.Where(sq.LtOrEq{"submitted_at": *filter.EndDate})
+		countBuilder = countBuilder.Where(sq.LtOrEq{"submitted_at": *filter.EndDate})
+	}
 	return builder, countBuilder
+}
+
+// ListAgentIDs returns the distinct non-null/non-empty agent_id values
+// observed in the invocations table.
+func (r *InvocationRepo) ListAgentIDs(ctx context.Context) ([]string, error) {
+	query, args, err := r.sb.Select("DISTINCT agent_id").
+		From("invocations").
+		Where(sq.NotEq{"agent_id": nil}).
+		Where(sq.NotEq{"agent_id": ""}).
+		OrderBy("agent_id ASC").
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []string{}
+	for rows.Next() {
+		var agentID sql.NullString
+		if err := rows.Scan(&agentID); err != nil {
+			return nil, err
+		}
+		if agentID.Valid && agentID.String != "" {
+			out = append(out, agentID.String)
+		}
+	}
+	return out, rows.Err()
 }
 
 func countRows(ctx context.Context, db *sql.DB, builder sq.SelectBuilder) (int, error) {


### PR DESCRIPTION
Adds a GET /agent_ids which returns all the distinct agent_ids in the invocations table. Also adds a GET invocations/{AGENT_ID}

Testing
In the toml add an api key section with whatever values you want
```
[api_key]
key = "1e7f2d5dc5e94fb93f3c976752a72218"
secret = "6446afa56414d22388a988e521ffe497761d28079e57ab5d9b8492f887a57040"
```

 curl -i \
    -H 'X-API-Key: 1e7f2d5dc5e94fb93f3c976752a72218' \
    -H 'X-API-Secret: 6446afa56414d22388a988e521ffe497761d28079e57ab5d9b8492f887a57040' \
    'http://localhost:8080/agent_ids'

 curl -i \
    -H 'X-API-Key: 1e7f2d5dc5e94fb93f3c976752a72218' \
    -H 'X-API-Secret: 6446afa56414d22388a988e521ffe497761d28079e57ab5d9b8492f887a57040' \
    'http://localhost:8080/invocations/iHpItBjLturosPqnrIFT5S7HbX1IeIUS?limit=50&offset=0'

 curl -i \
    -H 'X-API-Key: 1e7f2d5dc5e94fb93f3c976752a72218' \
    -H 'X-API-Secret: 6446afa56414d22388a988e521ffe497761d28079e57ab5d9b8492f887a57040' \
    'http://localhost:8080/invocations/iHpItBjLturosPqnrIFT5S7HbX1IeIUS?start_date=2026-05-19T00:00:00Z&end_date=2026-05-20T00:00:00Z&limit=50'
