### PR TITLE
sc-16270: surface agent identity in invocations UI

### DIFF
--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -60,6 +60,7 @@ func main() {
 	serverRepo := store.NewServerRepoWithDialect(db, dialect)
 	oauthRepo := store.NewOAuthRepoWithDialect(db, dialect)
 	rulesRepo := store.NewRulesRepoWithDialect(db, dialect)
+	agentClientRepo := store.NewAgentClientRepoWithDialect(db, dialect)
 	resolver := mcp.NewResolver(serverRepo, cfg)
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
 		log.Fatalf("bootstrap servers: %v", err)
@@ -82,8 +83,10 @@ func main() {
 	log.Printf("policy provider: %s", policyRegistry.Active().DisplayName())
 
 	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo)
+	service.SetAgentClientLookup(agentClientRepo)
 	serverAdmin := api.NewServerAdminService(serverRepo, oauthRepo, client, 5*time.Second)
 	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo)
+	handler.SetAgentClientRecorder(agentClientRepo)
 
 	authValidator, err := auth.NewValidator(cfg.Auth, nil)
 	if err != nil {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"atryum/internal/auth"
@@ -68,17 +69,41 @@ type rulesRepo interface {
 	InsertBefore(ctx context.Context, anchorID string, rule store.Rule) error
 }
 
+// agentClientRecorder lets the MCP initialize handler persist the clientInfo
+// + JWT subject the agent reported about itself.
+type agentClientRecorder interface {
+	RecordAgentClient(ctx context.Context, in store.AgentClient) error
+}
+
+// clientInfoSnapshot is what the agent reported in `initialize.clientInfo`.
+type clientInfoSnapshot struct {
+	Name    string
+	Version string
+	At      time.Time
+}
+
 type Handler struct {
-	svc            service
-	serverSvc      serverService
-	policyRegistry *policy.Registry
-	rulesRepo      rulesRepo
-	forwarder      mcpEnvelopeForwarder
-	staticHTTP     http.Handler
-	debug          bool
-	authDebugSkip  bool
-	authValidator  *auth.Validator
-	apiKeyAuth     auth.APIKeyConfig
+	svc                 service
+	serverSvc           serverService
+	policyRegistry      *policy.Registry
+	rulesRepo           rulesRepo
+	forwarder           mcpEnvelopeForwarder
+	staticHTTP          http.Handler
+	debug               bool
+	authDebugSkip       bool
+	authValidator       *auth.Validator
+	apiKeyAuth          auth.APIKeyConfig
+	agentClientRecorder agentClientRecorder
+
+	// clientInfoCache remembers the most recent `initialize.clientInfo`
+	// per "session key" so that subsequent tools/call requests on the same
+	// HTTP session can attach client_name / client_version even when no
+	// JWT-based agent_id is available. The key prefers the standard MCP
+	// session header (`Mcp-Session-Id`); when absent it falls back to
+	// remote IP + User-Agent which is good enough to disambiguate agents
+	// on a developer machine.
+	clientInfoMu    sync.RWMutex
+	clientInfoCache map[string]clientInfoSnapshot
 }
 
 type PolicyStatusResponse struct {
@@ -241,7 +266,7 @@ func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Reg
 	if f, ok := svc.(mcpEnvelopeForwarder); ok {
 		forwarder = f
 	}
-	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
+	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug, clientInfoCache: make(map[string]clientInfoSnapshot)}
 }
 
 // SetAuthValidator installs the inbound auth validator. When non-nil, the
@@ -249,6 +274,14 @@ func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Reg
 // /mcp/ anonymous.
 func (h *Handler) SetAuthValidator(v *auth.Validator) {
 	h.authValidator = v
+}
+
+// SetAgentClientRecorder installs an optional store used to remember the
+// MCP `initialize` clientInfo (name+version) and JWT subject for each
+// authenticated agent_id so the invocations UI can show what kind of agent
+// is making each call.
+func (h *Handler) SetAgentClientRecorder(r agentClientRecorder) {
+	h.agentClientRecorder = r
 }
 
 func (h *Handler) SetAuthDebugSkipVerify(enabled bool) {
@@ -458,6 +491,7 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 
 	switch req.Method {
 	case "initialize":
+		h.recordInitializeClientInfo(r, req.Params)
 		result := map[string]any{
 			"protocolVersion": protocolVersion,
 			"serverInfo": map[string]any{
@@ -506,6 +540,13 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 		toolReq := invocation.CreateInvocationRequest{Server: callServer, Tool: params.Name, Input: params.Arguments}
 		if requestID != "" {
 			toolReq.RequestID = stringPtr(requestID)
+		}
+		// Carry forward the harness-reported clientInfo captured at
+		// `initialize` time on this same session. Lets the invocations UI
+		// show Agent context even when /mcp/ is anonymous (no [[auth]]).
+		if snap, ok := h.lookupClientInfo(r); ok {
+			toolReq.ClientName = snap.Name
+			toolReq.ClientVersion = snap.Version
 		}
 		resp, err := h.svc.Invoke(r.Context(), toolReq)
 		if err != nil {
@@ -1783,6 +1824,105 @@ func normalizeToolCallResult(raw json.RawMessage, isError bool) any {
 		}
 	}
 	return map[string]any{"content": []map[string]any{{"type": "text", "text": string(raw)}}, "isError": isError}
+}
+
+// recordInitializeClientInfo captures the MCP `initialize.clientInfo` so it
+// can later be attached to invocations. It:
+//   - Always stashes the snapshot in the in-memory session cache keyed by
+//     `Mcp-Session-Id` (or remote-addr + UA fallback) so anonymous /mcp/
+//     callers still get an Agent column populated for follow-up tools/call
+//     requests on the same session.
+//   - Additionally upserts into the agent_clients table when both an
+//     authenticated agent_id and a configured recorder are present.
+//
+// Best-effort throughout: parse errors or repo failures must not break the
+// initialize handshake.
+func (h *Handler) recordInitializeClientInfo(r *http.Request, params json.RawMessage) {
+	var payload struct {
+		ClientInfo struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"clientInfo"`
+	}
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &payload)
+	}
+	name := strings.TrimSpace(payload.ClientInfo.Name)
+	version := strings.TrimSpace(payload.ClientInfo.Version)
+	if name == "" && version == "" {
+		return
+	}
+	snap := clientInfoSnapshot{Name: name, Version: version, At: time.Now().UTC()}
+	if key := sessionKeyFromRequest(r); key != "" {
+		h.clientInfoMu.Lock()
+		h.clientInfoCache[key] = snap
+		// Bound the cache so a noisy fleet of agents can't grow it
+		// unboundedly. 1024 entries is plenty for a dev / single-tenant
+		// instance; oldest evicted opportunistically.
+		if len(h.clientInfoCache) > 1024 {
+			var oldestKey string
+			var oldestAt time.Time
+			for k, v := range h.clientInfoCache {
+				if oldestKey == "" || v.At.Before(oldestAt) {
+					oldestKey, oldestAt = k, v.At
+				}
+			}
+			delete(h.clientInfoCache, oldestKey)
+		}
+		h.clientInfoMu.Unlock()
+	}
+
+	if h.agentClientRecorder == nil {
+		return
+	}
+	identity, ok := auth.IdentityFromContext(r.Context())
+	if !ok || strings.TrimSpace(identity.AgentID) == "" {
+		return
+	}
+	rec := store.AgentClient{
+		AgentID:       identity.AgentID,
+		ClientName:    name,
+		ClientVersion: version,
+		Subject:       identity.Subject,
+		Issuer:        identity.Issuer,
+		LastSeenAt:    time.Now().UTC(),
+	}
+	if err := h.agentClientRecorder.RecordAgentClient(r.Context(), rec); err != nil {
+		h.debugf("record agent client agent_id=%q err=%v", identity.AgentID, err)
+	}
+}
+
+// lookupClientInfo returns any clientInfo captured for the request's session
+// key (set on a prior `initialize` call). Used so that anonymous tools/call
+// requests can still carry through "Amp 0.0.1234"-style context.
+func (h *Handler) lookupClientInfo(r *http.Request) (clientInfoSnapshot, bool) {
+	key := sessionKeyFromRequest(r)
+	if key == "" {
+		return clientInfoSnapshot{}, false
+	}
+	h.clientInfoMu.RLock()
+	snap, ok := h.clientInfoCache[key]
+	h.clientInfoMu.RUnlock()
+	return snap, ok
+}
+
+// sessionKeyFromRequest produces a best-effort identifier for the agent
+// session originating this HTTP request. Prefers the standard MCP
+// `Mcp-Session-Id` header when the client sets it; falls back to remote
+// IP + User-Agent which is usually distinct enough for local dev.
+func sessionKeyFromRequest(r *http.Request) string {
+	if v := strings.TrimSpace(r.Header.Get("Mcp-Session-Id")); v != "" {
+		return "sid:" + v
+	}
+	host := r.RemoteAddr
+	if i := strings.LastIndex(host, ":"); i > -1 {
+		host = host[:i]
+	}
+	ua := strings.TrimSpace(r.Header.Get("User-Agent"))
+	if host == "" && ua == "" {
+		return ""
+	}
+	return "addr:" + host + "|ua:" + ua
 }
 
 func compactRequestID(id json.RawMessage) string {

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -117,6 +117,150 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	}
 }
 
+// stubAgentClientLookup returns canned clientInfo for a specific agent so we
+// can verify Service.Get/List enrich the response.
+type stubAgentClientLookup struct {
+	agentID string
+	info    invocation.AgentClientInfo
+}
+
+func (s stubAgentClientLookup) LookupAgentClient(_ context.Context, agentID string) (invocation.AgentClientInfo, bool) {
+	if agentID == s.agentID {
+		return s.info, true
+	}
+	return invocation.AgentClientInfo{}, false
+}
+
+func TestServiceEnrichesResponsesWithAgentClientInfo(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+	}))
+	defer upstream.Close()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Config{
+		Defaults:  config.DefaultsConfig{RequestTimeoutSeconds: 5},
+		Upstreams: []config.UpstreamConfig{{Name: "demo", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+	}
+	resolver := mcp.NewResolver(store.NewServerRepo(db), cfg)
+	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := invocation.NewService(
+		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
+		mcp.NewHTTPClient(), policy.AlwaysApproveProvider{},
+		5*time.Second, nil,
+	)
+	svc.SetAgentClientLookup(stubAgentClientLookup{
+		agentID: "agent-007",
+		info: invocation.AgentClientInfo{
+			ClientName:    "amp",
+			ClientVersion: "0.0.1234",
+			Subject:       "user-42",
+		},
+	})
+
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-007", Issuer: "https://idp.test"})
+	resp, err := svc.Invoke(ctx, invocation.CreateInvocationRequest{
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 1},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	// Get should populate AgentClientName/Version/UserID from the lookup.
+	got, err := svc.Get(context.Background(), resp.InvocationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentClientName == nil || *got.AgentClientName != "amp" {
+		t.Fatalf("AgentClientName = %v, want amp", got.AgentClientName)
+	}
+	if got.AgentClientVersion == nil || *got.AgentClientVersion != "0.0.1234" {
+		t.Fatalf("AgentClientVersion = %v, want 0.0.1234", got.AgentClientVersion)
+	}
+	if got.UserID == nil || *got.UserID != "user-42" {
+		t.Fatalf("UserID = %v, want user-42", got.UserID)
+	}
+
+	// List should enrich each item too.
+	list, err := svc.List(context.Background(), invocation.InvocationListFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) == 0 {
+		t.Fatal("expected at least one item in list")
+	}
+	item := list.Items[0]
+	if item.AgentClientName == nil || *item.AgentClientName != "amp" {
+		t.Fatalf("list item AgentClientName = %v, want amp", item.AgentClientName)
+	}
+}
+
+// Anonymous (no [[auth]]) callers should still surface MCP clientInfo on
+// the invocation row when the API layer passes it through.
+func TestInvokeWithoutAgentIDPersistsClientInfoFromRequest(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+	}))
+	defer upstream.Close()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Config{
+		Defaults:  config.DefaultsConfig{RequestTimeoutSeconds: 5},
+		Upstreams: []config.UpstreamConfig{{Name: "demo", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+	}
+	resolver := mcp.NewResolver(store.NewServerRepo(db), cfg)
+	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	svc := invocation.NewService(
+		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
+		mcp.NewHTTPClient(), policy.AlwaysApproveProvider{},
+		5*time.Second, nil,
+	)
+
+	resp, err := svc.Invoke(context.Background(), invocation.CreateInvocationRequest{
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 1},
+		ClientName: "amp", ClientVersion: "0.0.1234",
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.AgentID != nil {
+		t.Fatalf("expected no agent_id, got %v", resp.AgentID)
+	}
+	if resp.AgentClientName == nil || *resp.AgentClientName != "amp" {
+		t.Fatalf("AgentClientName = %v, want amp", resp.AgentClientName)
+	}
+	if resp.AgentClientVersion == nil || *resp.AgentClientVersion != "0.0.1234" {
+		t.Fatalf("AgentClientVersion = %v, want 0.0.1234", resp.AgentClientVersion)
+	}
+
+	got, err := svc.Get(context.Background(), resp.InvocationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentClientName == nil || *got.AgentClientName != "amp" {
+		t.Fatalf("Get AgentClientName = %v, want amp", got.AgentClientName)
+	}
+}
+
 func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -38,11 +38,17 @@ type Invocation struct {
 	Approval       *Approval  `json:"approval"`
 	MatchedRuleID  *string    `json:"matched_rule_id,omitempty"`
 	AgentID        *string    `json:"agent_id,omitempty"`
-	Input          []byte     `json:"-"`
-	Response       []byte     `json:"-"`
-	Error          []byte     `json:"-"`
-	SubmittedAt    time.Time  `json:"submitted_at"`
-	CompletedAt    *time.Time `json:"completed_at,omitempty"`
+	// ClientName / ClientVersion mirror the MCP `initialize.clientInfo`
+	// the harness reported on the connection that issued this invocation.
+	// Captured even when auth is disabled (no agent_id) so the UI can still
+	// show "Amp 0.0.1234" for anonymous traffic.
+	ClientName    *string    `json:"client_name,omitempty"`
+	ClientVersion *string    `json:"client_version,omitempty"`
+	Input         []byte     `json:"-"`
+	Response      []byte     `json:"-"`
+	Error         []byte     `json:"-"`
+	SubmittedAt   time.Time  `json:"submitted_at"`
+	CompletedAt   *time.Time `json:"completed_at,omitempty"`
 }
 
 type Event struct {
@@ -81,6 +87,11 @@ type CreateInvocationRequest struct {
 	Input          map[string]any `json:"input"`
 	RequestID      *string        `json:"request_id,omitempty"`
 	IdempotencyKey *string        `json:"idempotency_key,omitempty"`
+	// ClientName / ClientVersion let the caller pass through the harness's
+	// MCP `initialize.clientInfo` for this specific call. Used to populate
+	// the per-row fallback for anonymous (no agent_id) invocations.
+	ClientName    string `json:"-"`
+	ClientVersion string `json:"-"`
 }
 
 // ExternalSubmitRequest is used by callers that execute the tool themselves
@@ -115,12 +126,22 @@ type InvocationResponse struct {
 	Approval      *Approval       `json:"approval"`
 	MatchedRuleID *string         `json:"matched_rule_id,omitempty"`
 	AgentID       *string         `json:"agent_id,omitempty"`
-	RequestID     *string         `json:"request_id,omitempty"`
-	Input         json.RawMessage `json:"input,omitempty"`
-	SubmittedAt   time.Time       `json:"submitted_at"`
-	CompletedAt   *time.Time      `json:"completed_at,omitempty"`
-	Result        json.RawMessage `json:"result,omitempty"`
-	Error         json.RawMessage `json:"error,omitempty"`
+	// AgentClientName / AgentClientVersion identify the MCP client software
+	// (e.g. "amp", "cursor", "claude-code") captured from the most recent
+	// `initialize` handshake associated with this AgentID. They describe the
+	// agent type/harness, not the human user.
+	AgentClientName    *string `json:"agent_client_name,omitempty"`
+	AgentClientVersion *string `json:"agent_client_version,omitempty"`
+	// UserID is the JWT subject claim (`sub`) captured alongside the agent's
+	// most recent `initialize` — the human/service principal behind the agent
+	// when available.
+	UserID          *string         `json:"user_id,omitempty"`
+	RequestID       *string         `json:"request_id,omitempty"`
+	Input           json.RawMessage `json:"input,omitempty"`
+	SubmittedAt     time.Time       `json:"submitted_at"`
+	CompletedAt     *time.Time      `json:"completed_at,omitempty"`
+	Result          json.RawMessage `json:"result,omitempty"`
+	Error           json.RawMessage `json:"error,omitempty"`
 }
 
 type InvocationListResponse struct {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -45,16 +45,30 @@ type upstreamClient interface {
 	ForwardEnvelope(ctx context.Context, upstream mcp.Upstream, envelope mcp.Envelope, protocolVersion string) (mcp.ForwardResult, error)
 }
 
+// AgentClientInfo describes the MCP client (and JWT subject) most recently
+// associated with an authenticated agent_id. Used purely to enrich the
+// invocations UI / API responses with display context — never for policy.
+type AgentClientInfo struct {
+	ClientName    string
+	ClientVersion string
+	Subject       string
+}
+
+type agentClientLookup interface {
+	LookupAgentClient(ctx context.Context, agentID string) (AgentClientInfo, bool)
+}
+
 type Service struct {
-	invocations      invocationRepo
-	events           eventRepo
-	resolver         resolver
-	client           upstreamClient
-	policy           policy.Provider
-	rules            rulesStore // nil = no rule evaluation
-	defaultTimeout   time.Duration
-	mu               sync.Mutex
-	pendingApprovals map[string]chan approvalDecision
+	invocations       invocationRepo
+	events            eventRepo
+	resolver          resolver
+	client            upstreamClient
+	policy            policy.Provider
+	rules             rulesStore // nil = no rule evaluation
+	agentClients      agentClientLookup
+	defaultTimeout    time.Duration
+	mu                sync.Mutex
+	pendingApprovals  map[string]chan approvalDecision
 }
 
 func NewService(inv invocationRepo, evt eventRepo, resolver resolver, client upstreamClient, policyProvider policy.Provider, defaultTimeout time.Duration, rules rulesStore) *Service {
@@ -68,6 +82,13 @@ func NewService(inv invocationRepo, evt eventRepo, resolver resolver, client ups
 		defaultTimeout:   defaultTimeout,
 		pendingApprovals: make(map[string]chan approvalDecision),
 	}
+}
+
+// SetAgentClientLookup installs an optional resolver from agent_id to the
+// captured MCP clientInfo + JWT subject. When nil, the corresponding fields
+// in InvocationResponse are simply left unset.
+func (s *Service) SetAgentClientLookup(lookup agentClientLookup) {
+	s.agentClients = lookup
 }
 
 func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (InvocationResponse, error) {
@@ -113,6 +134,14 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 	}
 	if agentID != "" {
 		inv.AgentID = &agentID
+	}
+	if req.ClientName != "" {
+		v := req.ClientName
+		inv.ClientName = &v
+	}
+	if req.ClientVersion != "" {
+		v := req.ClientVersion
+		inv.ClientVersion = &v
 	}
 	if err := s.invocations.Create(ctx, inv); err != nil {
 		return InvocationResponse{}, err
@@ -443,10 +472,19 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 		RequestID:      req.RequestID,
 		IdempotencyKey: req.IdempotencyKey,
 		Tool:           req.Tool,
-		Upstream:       source,
-		Status:         StatusReceived,
-		Input:          inputJSON,
-		SubmittedAt:    now,
+		// Upstream is intentionally left empty for external/non-MCP
+		// invocations — the harness ran the tool itself, there is no
+		// MCP server in the loop. The UI renders an empty server as
+		// "none". The harness identity is recorded as ClientName below
+		// so it shows up in the Agent column instead.
+		Upstream:    "",
+		Status:      StatusReceived,
+		Input:       inputJSON,
+		SubmittedAt: now,
+	}
+	if source != "" && source != "external" {
+		s := source
+		inv.ClientName = &s
 	}
 	if agentID != "" {
 		inv.AgentID = &agentID
@@ -650,7 +688,9 @@ func (s *Service) Get(ctx context.Context, id string) (InvocationResponse, error
 	if err != nil {
 		return InvocationResponse{}, err
 	}
-	return s.toResponse(inv), nil
+	resp := s.toResponse(inv)
+	s.enrichAgentClient(ctx, &resp)
+	return resp, nil
 }
 
 func (s *Service) ListAgentIDs(ctx context.Context) ([]string, error) {
@@ -662,11 +702,56 @@ func (s *Service) List(ctx context.Context, filter InvocationListFilter) (Invoca
 	if err != nil {
 		return InvocationListResponse{}, err
 	}
+	// Cache lookups per agent_id so we don't hit the repo N times for the
+	// common "all rows are from the same agent" case.
+	cache := map[string]AgentClientInfo{}
 	out := make([]InvocationResponse, 0, len(invocations))
 	for _, inv := range invocations {
-		out = append(out, s.toResponse(inv))
+		resp := s.toResponse(inv)
+		s.enrichAgentClientCached(ctx, &resp, cache)
+		out = append(out, resp)
 	}
 	return InvocationListResponse{Items: out, Total: total, Offset: filter.Offset, Limit: normalizedLimit(filter.Limit, 50)}, nil
+}
+
+func (s *Service) enrichAgentClient(ctx context.Context, resp *InvocationResponse) {
+	s.enrichAgentClientCached(ctx, resp, nil)
+}
+
+func (s *Service) enrichAgentClientCached(ctx context.Context, resp *InvocationResponse, cache map[string]AgentClientInfo) {
+	if s.agentClients == nil || resp.AgentID == nil || *resp.AgentID == "" {
+		return
+	}
+	id := *resp.AgentID
+	var info AgentClientInfo
+	var ok bool
+	if cache != nil {
+		if cached, hit := cache[id]; hit {
+			info = cached
+			ok = cached.ClientName != "" || cached.ClientVersion != "" || cached.Subject != ""
+		}
+	}
+	if !ok && cache != nil {
+		info, ok = s.agentClients.LookupAgentClient(ctx, id)
+		cache[id] = info
+	} else if !ok {
+		info, ok = s.agentClients.LookupAgentClient(ctx, id)
+	}
+	if !ok {
+		return
+	}
+	if resp.AgentClientName == nil && info.ClientName != "" {
+		v := info.ClientName
+		resp.AgentClientName = &v
+	}
+	if resp.AgentClientVersion == nil && info.ClientVersion != "" {
+		v := info.ClientVersion
+		resp.AgentClientVersion = &v
+	}
+	if resp.UserID == nil && info.Subject != "" {
+		v := info.Subject
+		resp.UserID = &v
+	}
 }
 
 func (s *Service) Events(ctx context.Context, invocationID string, filter EventListFilter) (EventListResponse, error) {
@@ -683,6 +768,15 @@ func (s *Service) Events(ctx context.Context, invocationID string, filter EventL
 
 func (s *Service) toResponse(inv Invocation) InvocationResponse {
 	resp := InvocationResponse{InvocationID: inv.InvocationID, ServerName: inv.Upstream, ToolName: inv.Tool, Status: inv.Status, Approval: inv.Approval, MatchedRuleID: inv.MatchedRuleID, AgentID: inv.AgentID, RequestID: inv.RequestID, SubmittedAt: inv.SubmittedAt, CompletedAt: inv.CompletedAt}
+	// Per-row clientInfo (captured from the connection that made this exact
+	// call) is the most accurate value. The agent_clients lookup in
+	// enrichAgentClient* only fills these in when they are still nil.
+	if inv.ClientName != nil {
+		resp.AgentClientName = inv.ClientName
+	}
+	if inv.ClientVersion != nil {
+		resp.AgentClientVersion = inv.ClientVersion
+	}
 	if len(inv.Input) > 0 {
 		resp.Input = json.RawMessage(inv.Input)
 	}

--- a/internal/store/agent_clients.go
+++ b/internal/store/agent_clients.go
@@ -1,0 +1,144 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+
+	"atryum/internal/invocation"
+)
+
+// AgentClient is what an agent identifies itself as via MCP `initialize`
+// (clientInfo) plus the JWT-derived subject/issuer captured at the same time.
+// Atryum stores the most recently observed values per agent_id so the
+// invocations UI can show context like "Amp 0.0.1234", subject (user id), etc.
+type AgentClient struct {
+	AgentID       string
+	ClientName    string
+	ClientVersion string
+	Subject       string
+	Issuer        string
+	LastSeenAt    time.Time
+}
+
+type AgentClientRepo struct {
+	db      *sql.DB
+	sb      sq.StatementBuilderType
+	dialect Dialect
+}
+
+func NewAgentClientRepo(db *sql.DB) *AgentClientRepo {
+	return NewAgentClientRepoWithDialect(db, DialectSQLite)
+}
+
+func NewAgentClientRepoWithDialect(db *sql.DB, dialect Dialect) *AgentClientRepo {
+	return &AgentClientRepo{db: db, sb: statementBuilderForDialect(dialect), dialect: dialect}
+}
+
+// Upsert inserts or updates the latest-seen client info for the agent. Only
+// non-empty fields on `in` overwrite the existing row (so a tools/list
+// initialize that lacks clientInfo doesn't clobber a previously captured one).
+func (r *AgentClientRepo) Upsert(ctx context.Context, in AgentClient) error {
+	if in.AgentID == "" {
+		return errors.New("agent_id is required")
+	}
+	if in.LastSeenAt.IsZero() {
+		in.LastSeenAt = time.Now().UTC()
+	}
+	existing, err := r.Get(ctx, in.AgentID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	merged := AgentClient{
+		AgentID:       in.AgentID,
+		ClientName:    pickString(in.ClientName, existing.ClientName),
+		ClientVersion: pickString(in.ClientVersion, existing.ClientVersion),
+		Subject:       pickString(in.Subject, existing.Subject),
+		Issuer:        pickString(in.Issuer, existing.Issuer),
+		LastSeenAt:    in.LastSeenAt,
+	}
+	// Use delete+insert to stay dialect-agnostic for upserts.
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	delQ, delArgs, err := r.sb.Delete("agent_clients").Where(sq.Eq{"agent_id": in.AgentID}).ToSql()
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, delQ, delArgs...); err != nil {
+		return err
+	}
+	insQ, insArgs, err := r.sb.Insert("agent_clients").
+		Columns("agent_id", "client_name", "client_version", "subject", "issuer", "last_seen_at").
+		Values(merged.AgentID, nullableStr(merged.ClientName), nullableStr(merged.ClientVersion), nullableStr(merged.Subject), nullableStr(merged.Issuer), merged.LastSeenAt).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, insQ, insArgs...); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (r *AgentClientRepo) Get(ctx context.Context, agentID string) (AgentClient, error) {
+	q, args, err := r.sb.Select("agent_id", "client_name", "client_version", "subject", "issuer", "last_seen_at").
+		From("agent_clients").Where(sq.Eq{"agent_id": agentID}).ToSql()
+	if err != nil {
+		return AgentClient{}, err
+	}
+	row := r.db.QueryRowContext(ctx, q, args...)
+	var out AgentClient
+	var name, version, subject, issuer sql.NullString
+	if err := row.Scan(&out.AgentID, &name, &version, &subject, &issuer, &out.LastSeenAt); err != nil {
+		return AgentClient{}, err
+	}
+	out.ClientName = name.String
+	out.ClientVersion = version.String
+	out.Subject = subject.String
+	out.Issuer = issuer.String
+	return out, nil
+}
+
+func nullableStr(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+func pickString(primary, fallback string) string {
+	if primary != "" {
+		return primary
+	}
+	return fallback
+}
+
+// RecordAgentClient satisfies the handler-side agentClientRecorder interface.
+func (r *AgentClientRepo) RecordAgentClient(ctx context.Context, in AgentClient) error {
+	return r.Upsert(ctx, in)
+}
+
+// LookupAgentClient satisfies the invocation.Service agentClientLookup
+// interface and returns the captured clientInfo + JWT subject for the agent.
+// Missing rows / errors yield (zero, false) so the caller can leave the
+// optional response fields unset.
+func (r *AgentClientRepo) LookupAgentClient(ctx context.Context, agentID string) (invocation.AgentClientInfo, bool) {
+	if agentID == "" {
+		return invocation.AgentClientInfo{}, false
+	}
+	row, err := r.Get(ctx, agentID)
+	if err != nil {
+		return invocation.AgentClientInfo{}, false
+	}
+	return invocation.AgentClientInfo{
+		ClientName:    row.ClientName,
+		ClientVersion: row.ClientVersion,
+		Subject:       row.Subject,
+	}, true
+}

--- a/internal/store/agent_clients_test.go
+++ b/internal/store/agent_clients_test.go
@@ -1,0 +1,77 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"atryum/internal/store"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestAgentClientRepo_UpsertAndLookup(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	repo := store.NewAgentClientRepo(db)
+	ctx := context.Background()
+
+	// Initial insert.
+	if err := repo.Upsert(ctx, store.AgentClient{
+		AgentID:       "agent-007",
+		ClientName:    "amp",
+		ClientVersion: "0.0.1234",
+		Subject:       "user-42",
+		Issuer:        "https://idp.test",
+		LastSeenAt:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("upsert insert: %v", err)
+	}
+
+	got, err := repo.Get(ctx, "agent-007")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ClientName != "amp" || got.ClientVersion != "0.0.1234" || got.Subject != "user-42" || got.Issuer != "https://idp.test" {
+		t.Fatalf("get returned %+v", got)
+	}
+
+	// Partial upsert: a later initialize without clientInfo must not wipe
+	// previously captured name/version.
+	if err := repo.Upsert(ctx, store.AgentClient{
+		AgentID:    "agent-007",
+		Subject:    "user-42",
+		Issuer:     "https://idp.test",
+		LastSeenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("upsert update: %v", err)
+	}
+	got, err = repo.Get(ctx, "agent-007")
+	if err != nil {
+		t.Fatalf("get after partial upsert: %v", err)
+	}
+	if got.ClientName != "amp" || got.ClientVersion != "0.0.1234" {
+		t.Fatalf("partial upsert clobbered clientInfo: %+v", got)
+	}
+
+	// Lookup adapter used by invocation.Service should return the same data.
+	info, ok := repo.LookupAgentClient(ctx, "agent-007")
+	if !ok {
+		t.Fatal("LookupAgentClient missed known agent")
+	}
+	if info.ClientName != "amp" || info.ClientVersion != "0.0.1234" || info.Subject != "user-42" {
+		t.Fatalf("LookupAgentClient = %+v", info)
+	}
+
+	// Unknown agents must yield (zero, false), not an error.
+	if _, ok := repo.LookupAgentClient(ctx, "nobody"); ok {
+		t.Fatal("LookupAgentClient returned true for unknown agent")
+	}
+}

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 8 {
+	if len(migrations) != 10 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -61,6 +61,8 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{6, "006_invocation_agent_id.sql"},
 		{7, "007_rename_user_pattern.sql"},
 		{8, "008_oauth_client_registration.sql"},
+		{9, "009_agent_clients.sql"},
+		{10, "010_invocation_client_info.sql"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -71,10 +73,10 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 7 {
+	if len(pending) != 9 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	wantVersions := []int{2, 3, 4, 5, 6, 7, 8}
+	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10}
 	for i, want := range wantVersions {
 		if pending[i].Version != want {
 			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)

--- a/internal/store/migrations/009_agent_clients.go
+++ b/internal/store/migrations/009_agent_clients.go
@@ -1,0 +1,29 @@
+package migrations
+
+func migration009() Definition {
+	return Definition{
+		Version: 9,
+		Name:    "009_agent_clients.sql",
+		Steps: []Step{
+			RawDialect(
+				"create agent_clients table",
+				`CREATE TABLE IF NOT EXISTS agent_clients (
+					agent_id        TEXT PRIMARY KEY,
+					client_name     TEXT,
+					client_version  TEXT,
+					subject         TEXT,
+					issuer          TEXT,
+					last_seen_at    TIMESTAMP NOT NULL
+				)`,
+				`CREATE TABLE IF NOT EXISTS agent_clients (
+					agent_id        TEXT PRIMARY KEY,
+					client_name     TEXT,
+					client_version  TEXT,
+					subject         TEXT,
+					issuer          TEXT,
+					last_seen_at    TIMESTAMPTZ NOT NULL
+				)`,
+			),
+		},
+	}
+}

--- a/internal/store/migrations/010_invocation_client_info.go
+++ b/internal/store/migrations/010_invocation_client_info.go
@@ -1,0 +1,12 @@
+package migrations
+
+func migration010() Definition {
+	return Definition{
+		Version: 10,
+		Name:    "010_invocation_client_info.sql",
+		Steps: []Step{
+			Raw("add client_name to invocations", `ALTER TABLE invocations ADD COLUMN client_name TEXT`),
+			Raw("add client_version to invocations", `ALTER TABLE invocations ADD COLUMN client_version TEXT`),
+		},
+	}
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -42,5 +42,7 @@ func All() []Definition {
 		migration006(),
 		migration007(),
 		migration008(),
+		migration009(),
+		migration010(),
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -82,9 +82,9 @@ func (r *InvocationRepo) Create(ctx context.Context, inv invocation.Invocation) 
 		approval = string(b)
 	}
 	query, args, err := r.sb.Insert("invocations").Columns(
-		"invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id",
+		"invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "client_name", "client_version",
 	).Values(
-		inv.InvocationID, inv.RequestID, inv.IdempotencyKey, inv.Tool, inv.Upstream, inv.Status, approval, string(inv.Input), nullableString(inv.Response), nullableString(inv.Error), inv.SubmittedAt, inv.CompletedAt, inv.MatchedRuleID, inv.AgentID,
+		inv.InvocationID, inv.RequestID, inv.IdempotencyKey, inv.Tool, inv.Upstream, inv.Status, approval, string(inv.Input), nullableString(inv.Response), nullableString(inv.Error), inv.SubmittedAt, inv.CompletedAt, inv.MatchedRuleID, inv.AgentID, inv.ClientName, inv.ClientVersion,
 	).ToSql()
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (r *InvocationRepo) UpdateResult(ctx context.Context, inv invocation.Invoca
 }
 
 func (r *InvocationRepo) Get(ctx context.Context, id string) (invocation.Invocation, error) {
-	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").From("invocations").Where(sq.Eq{"invocation_id": id}).ToSql()
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "client_name", "client_version").From("invocations").Where(sq.Eq{"invocation_id": id}).ToSql()
 	if err != nil {
 		return invocation.Invocation{}, err
 	}
@@ -117,7 +117,7 @@ func (r *InvocationRepo) Get(ctx context.Context, id string) (invocation.Invocat
 }
 
 func (r *InvocationRepo) GetByIdempotencyKey(ctx context.Context, key string) (invocation.Invocation, error) {
-	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").From("invocations").Where(sq.Eq{"idempotency_key": key}).ToSql()
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "client_name", "client_version").From("invocations").Where(sq.Eq{"idempotency_key": key}).ToSql()
 	if err != nil {
 		return invocation.Invocation{}, err
 	}
@@ -129,7 +129,7 @@ func (r *InvocationRepo) List(ctx context.Context, filter invocation.InvocationL
 	if filter.Limit == 0 {
 		filter.Limit = 50
 	}
-	builder := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").From("invocations")
+	builder := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "client_name", "client_version").From("invocations")
 	countBuilder := r.sb.Select("COUNT(*)").From("invocations")
 	builder, countBuilder = applyInvocationFilter(builder, countBuilder, filter)
 	query, args, err := builder.OrderBy("submitted_at DESC").Limit(filter.Limit).Offset(filter.Offset).ToSql()
@@ -526,7 +526,8 @@ func scanInvocation(scanner interface{ Scan(dest ...any) error }) (invocation.In
 	var completedAt sql.NullTime
 	var matchedRuleID sql.NullString
 	var agentID sql.NullString
-	if err := scanner.Scan(&inv.InvocationID, &requestID, &idempotencyKey, &inv.Tool, &inv.Upstream, &inv.Status, &approval, &requestJSON, &responseJSON, &errorJSON, &inv.SubmittedAt, &completedAt, &matchedRuleID, &agentID); err != nil {
+	var clientName, clientVersion sql.NullString
+	if err := scanner.Scan(&inv.InvocationID, &requestID, &idempotencyKey, &inv.Tool, &inv.Upstream, &inv.Status, &approval, &requestJSON, &responseJSON, &errorJSON, &inv.SubmittedAt, &completedAt, &matchedRuleID, &agentID, &clientName, &clientVersion); err != nil {
 		return invocation.Invocation{}, err
 	}
 	if requestID.Valid {
@@ -557,6 +558,12 @@ func scanInvocation(scanner interface{ Scan(dest ...any) error }) (invocation.In
 	}
 	if agentID.Valid {
 		inv.AgentID = &agentID.String
+	}
+	if clientName.Valid {
+		inv.ClientName = &clientName.String
+	}
+	if clientVersion.Valid {
+		inv.ClientVersion = &clientVersion.String
 	}
 	return inv, nil
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -41,12 +41,12 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 8 {
-		t.Fatalf("expected 8 migrations, got %d", count)
+	if count != 10 {
+		t.Fatalf("expected 10 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
-	tables := []string{"invocations", "invocation_events", "mcp_servers", "oauth_credentials", "oauth_connect_sessions", "approval_rules"}
+	tables := []string{"invocations", "invocation_events", "mcp_servers", "oauth_credentials", "oauth_connect_sessions", "approval_rules", "agent_clients"}
 	for _, table := range tables {
 		var name string
 		if err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&name); err != nil {
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 8 {
-		t.Fatalf("expected 8 migrations after double init, got %d", count)
+	if count != 10 {
+		t.Fatalf("expected 10 migrations after double init, got %d", count)
 	}
 }
 

--- a/scripts/fake_agent.py
+++ b/scripts/fake_agent.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""
+fake_agent.py — pretend to be an agent talking to Atryum, so you can test
+the approval UI / invocation pipeline without running a real coding harness
+or MCP client.
+
+Two modes, mirroring the two real integrations Atryum supports today:
+
+  1. harness  — pretend to be a coding harness like Amp using the
+                /api/v1/external/invocations endpoints (the amp-plugin path,
+                see atryum/examples/amp-plugin/). Atryum does NOT execute
+                the tool; we (the fake harness) "execute" it locally and
+                PATCH the result back.
+
+  2. mcp      — pretend to be an MCP client talking JSON-RPC to
+                POST /mcp/{server}. Goes through initialize / tools/list /
+                tools/call and lets Atryum proxy to the upstream + mediate
+                approval.
+
+  3. demo     — runs a small scripted scenario over the harness path so you
+                can click through the UI and approve/deny things.
+
+Examples
+--------
+
+  # Submit one tool call as a fake "amp" harness and wait for approval:
+  python fake_agent.py harness --tool Bash --input '{"cmd":"ls"}'
+
+  # Submit one and auto-report a failure once approved:
+  python fake_agent.py harness --tool Bash --input '{"cmd":"boom"}' \\
+      --simulate-result fail
+
+  # Drive a scripted demo so you can play with /ui/:
+  python fake_agent.py demo
+
+  # Talk MCP JSON-RPC to the default safe server (calc-mcp):
+  python fake_agent.py mcp --list-tools
+  python fake_agent.py mcp --tool add --arguments '{"a":2,"b":3}'
+
+  # Pretend to be a specific harness:
+  python fake_agent.py mcp --client-name cursor --client-version 0.45.7 --list-tools
+
+  # Aggregate /mcp/ endpoint (every server's tools merged):
+  python fake_agent.py mcp '' --list-tools
+
+Config (env or flags):
+  ATRYUM_URL        base url, default http://localhost:8080
+  ATRYUM_MCP_SERVER default MCP server name, default "calc-mcp"
+  ATRYUM_SOURCE     pins the agent identity (harness --source / mcp clientInfo.name);
+                    when unset, a random identity is picked from a small set of
+                    realistic harness names (amp, cursor, claude-code, …)
+  ATRYUM_POLL_MS    poll interval ms while awaiting approval, default 1000
+  THREAD_ID         thread id surfaced in harness submissions
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+import uuid
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+DEFAULT_URL = os.environ.get("ATRYUM_URL", "http://localhost:8080")
+DEFAULT_POLL_MS = int(os.environ.get("ATRYUM_POLL_MS", "1000"))
+DEFAULT_THREAD_ID = os.environ.get("THREAD_ID", "")
+
+# Default MCP server to talk to. calc-mcp is a safe local sandbox; the real
+# upstreams (shortcut, github, etc.) are world-impacting so we don't want a
+# bare `mcp` invocation to land there by accident.
+DEFAULT_MCP_SERVER = os.environ.get("ATRYUM_MCP_SERVER", "calc-mcp")
+
+# Reasonable real-world agent/harness identities. Used as:
+#   - harness mode: --source (shows up as "upstream" column in atryum UI)
+#   - mcp mode:     clientInfo.name in the initialize handshake
+# Pick one at random per run so the UI shows a mix of agents instead of a
+# single monoculture "fake-agent" stream.
+AGENT_IDENTITIES: list[tuple[str, str]] = [
+    ("amp", "0.0.1759000000-g00000a"),
+    ("cursor", "0.45.7"),
+    ("claude-code", "1.0.32"),
+    ("cline", "3.1.0"),
+    ("windsurf", "1.2.4"),
+    ("continue", "0.9.250"),
+    ("zed", "0.156.0"),
+    ("opencode", "1.14.48"),
+    ("aider", "0.85.0"),
+    ("goose", "1.0.20"),
+]
+
+
+def _env_or_random_identity() -> tuple[str, str]:
+    """Return (name, version). Honors ATRYUM_SOURCE if set, else picks randomly."""
+    override = os.environ.get("ATRYUM_SOURCE", "").strip()
+    if override:
+        return override, "0.0.1"
+    return random.choice(AGENT_IDENTITIES)
+
+
+# ─── tiny HTTP helper (stdlib only, no requests dep) ────────────────────────
+
+
+def _request(
+    method: str,
+    url: str,
+    body: Any | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> tuple[int, dict[str, Any] | str]:
+    data = None
+    hdrs = dict(headers or {})
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        hdrs.setdefault("Content-Type", "application/json")
+    req = urlrequest.Request(url, data=data, method=method, headers=hdrs)
+    try:
+        with urlrequest.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            status = resp.status
+    except urlerror.HTTPError as e:
+        raw = e.read().decode("utf-8", errors="replace")
+        status = e.code
+    try:
+        return status, json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return status, raw
+
+
+def _print_json(label: str, payload: Any) -> None:
+    print(f"── {label} " + "─" * max(2, 60 - len(label)))
+    if isinstance(payload, (dict, list)):
+        print(json.dumps(payload, indent=2))
+    else:
+        print(payload)
+
+
+# ─── harness mode (external invocations) ────────────────────────────────────
+
+
+PENDING_STATES = {"received", "pending_approval", "executing"}
+APPROVED_STATES = {"approved"}
+REJECTED_STATES = {"denied", "expired", "cancelled"}
+
+
+def harness_submit(
+    base: str,
+    source: str,
+    tool: str,
+    input_obj: dict[str, Any],
+    description: str | None,
+    request_id: str,
+    thread_id: str,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "source": source,
+        "tool": tool,
+        "input": input_obj,
+        "request_id": request_id,
+    }
+    if description:
+        body["description"] = description
+    if thread_id:
+        body["thread_id"] = thread_id
+    status, payload = _request("POST", f"{base}/api/v1/external/invocations", body)
+    if status >= 300:
+        raise SystemExit(f"submit failed ({status}): {payload}")
+    assert isinstance(payload, dict)
+    return payload
+
+
+def harness_poll(base: str, invocation_id: str, poll_ms: int) -> dict[str, Any]:
+    url = f"{base}/api/v1/external/invocations/{invocation_id}"
+    while True:
+        status, payload = _request("GET", url)
+        if status >= 300:
+            raise SystemExit(f"poll failed ({status}): {payload}")
+        assert isinstance(payload, dict)
+        cur = payload.get("status")
+        if cur not in PENDING_STATES:
+            return payload
+        print(f"  …status={cur}, waiting {poll_ms}ms")
+        time.sleep(poll_ms / 1000)
+
+
+def harness_patch(
+    base: str,
+    invocation_id: str,
+    execution_status: str,
+    result: Any = None,
+    error: Any = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {"execution_status": execution_status}
+    if result is not None:
+        body["result"] = result
+    if error is not None:
+        body["error"] = error
+    if message:
+        body["message"] = message
+    status, payload = _request(
+        "PATCH", f"{base}/api/v1/external/invocations/{invocation_id}", body
+    )
+    if status >= 300:
+        raise SystemExit(f"patch failed ({status}): {payload}")
+    assert isinstance(payload, dict)
+    return payload
+
+
+def run_harness_once(
+    base: str,
+    source: str,
+    tool: str,
+    input_obj: dict[str, Any],
+    description: str | None,
+    thread_id: str,
+    poll_ms: int,
+    simulate: str,
+) -> None:
+    request_id = f"fake-{uuid.uuid4()}"
+    print(f"submitting tool={tool} source={source} request_id={request_id}")
+    submitted = harness_submit(
+        base, source, tool, input_obj, description, request_id, thread_id
+    )
+    _print_json("submit response", submitted)
+    inv_id = submitted["invocation_id"]
+    decided = submitted
+    if submitted.get("status") in PENDING_STATES:
+        print(f"awaiting approval at {base}/ui/  (invocation {inv_id})")
+        decided = harness_poll(base, inv_id, poll_ms)
+        _print_json("post-approval", decided)
+
+    final = decided.get("status")
+    if final not in APPROVED_STATES:
+        print(f"not approved (status={final}); nothing to execute.")
+        return
+
+    print("→ running PATCH execution_status=running")
+    harness_patch(base, inv_id, "running")
+
+    # Pretend to do work.
+    time.sleep(0.4)
+
+    if simulate == "ok":
+        out = {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"(fake-agent) ran '{tool}' with {input_obj!r} — pretend success",
+                }
+            ]
+        }
+        final_resp = harness_patch(base, inv_id, "completed", result=out)
+    elif simulate == "fail":
+        err = {"message": f"(fake-agent) pretend failure executing '{tool}'"}
+        final_resp = harness_patch(
+            base, inv_id, "failed", error=err, message="pretend failure"
+        )
+    elif simulate == "cancel":
+        final_resp = harness_patch(
+            base, inv_id, "cancelled", message="pretend cancellation"
+        )
+    else:
+        raise SystemExit(f"unknown --simulate-result value: {simulate}")
+    _print_json("final invocation", final_resp)
+
+
+# ─── demo: scripted multi-call scenario over harness path ───────────────────
+
+
+HARNESS_DEMO_CALLS: list[dict[str, Any]] = [
+    {
+        "tool": "Bash",
+        "input": {"cmd": "ls -la /tmp"},
+        "description": "list /tmp",
+        "simulate": "ok",
+    },
+    {
+        "tool": "edit_file",
+        "input": {"path": "/etc/hosts", "content": "127.0.0.1 evil.example"},
+        "description": "edit /etc/hosts (you should DENY this one)",
+        "simulate": "ok",
+    },
+    {
+        "tool": "Read",
+        "input": {"path": "/src/AGENTS.md"},
+        "description": "read AGENTS.md",
+        "simulate": "ok",
+    },
+    {
+        "tool": "Bash",
+        "input": {"cmd": "exit 1"},
+        "description": "command that 'fails'",
+        "simulate": "fail",
+    },
+]
+
+# Safe, side-effect-free calc-mcp tools so the MCP demo can spam invocations
+# against a real upstream and populate the UI with varied agent_client_name
+# values (clientInfo.name is only recorded for MCP-proxied calls, not for
+# external/harness submissions).
+MCP_DEMO_CALLS: list[dict[str, Any]] = [
+    {"tool": "math", "arguments": {"action": "eval", "expression": "2+2"}},
+    {"tool": "math", "arguments": {"action": "eval", "expression": "10*7"}},
+    {"tool": "random", "arguments": {"type": "uuid"}},
+    {"tool": "random", "arguments": {"type": "ulid"}},
+    {"tool": "hash", "arguments": {"algorithm": "sha256", "input": "hello"}},
+    {"tool": "base64", "arguments": {"action": "encode", "input": "atryum"}},
+    {"tool": "datetime", "arguments": {"action": "now"}},
+    {"tool": "semver", "arguments": {"action": "valid", "version": "1.2.3"}},
+]
+
+
+def run_demo(base: str, source: str | None, thread_id: str, poll_ms: int) -> None:
+    print(f"demo: {len(HARNESS_DEMO_CALLS)} harness calls + {len(MCP_DEMO_CALLS)} MCP calls -> {base}")
+    if source is None:
+        print("demo: randomizing agent identity per call (pass --source to pin one)")
+    print(f"open {base}/ui/ and approve/deny harness ones as they come in.\n")
+
+    # MCP calls first — they're auto-approved and record clientInfo, so the
+    # UI fills with varied agents immediately while you're still clicking
+    # through harness approvals.
+    print("── MCP phase (calc-mcp, varied clientInfo) ──")
+    for i, call in enumerate(MCP_DEMO_CALLS, 1):
+        name, version = (
+            (source, "0.0.1") if source is not None else random.choice(AGENT_IDENTITIES)
+        )
+        print(f"\n── mcp {i}/{len(MCP_DEMO_CALLS)}: {call['tool']} as {name}/{version} ──")
+        try:
+            run_mcp(
+                base=base,
+                server=DEFAULT_MCP_SERVER,
+                tool=call["tool"],
+                arguments=call["arguments"],
+                list_tools=False,
+                bearer=None,
+                client_name=name,
+                client_version=version,
+            )
+        except SystemExit as e:
+            print(f"  (mcp call failed: {e})")
+
+    # Harness calls.
+    print("\n── harness phase (external invocations, varied --source) ──")
+    for i, call in enumerate(HARNESS_DEMO_CALLS, 1):
+        agent = source if source is not None else random.choice(AGENT_IDENTITIES)[0]
+        print(f"\n══ harness {i}/{len(HARNESS_DEMO_CALLS)}: {call['tool']} as {agent} ══")
+        run_harness_once(
+            base=base,
+            source=agent,
+            tool=call["tool"],
+            input_obj=call["input"],
+            description=call["description"],
+            thread_id=thread_id,
+            poll_ms=poll_ms,
+            simulate=call["simulate"],
+        )
+    print("\ndemo complete.")
+
+
+# ─── mcp client mode (JSON-RPC over /mcp/{server}) ──────────────────────────
+
+
+def mcp_call(
+    base: str,
+    server: str | None,
+    method: str,
+    params: dict[str, Any] | None,
+    req_id: int,
+    protocol_version: str = "2025-06-18",
+    extra_headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    path = "/mcp/" + (server or "")
+    body: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    headers = {"MCP-Protocol-Version": protocol_version}
+    if extra_headers:
+        headers.update(extra_headers)
+    status, payload = _request("POST", base + path, body, headers=headers)
+    if status >= 300:
+        raise SystemExit(f"mcp {method} failed ({status}): {payload}")
+    if not isinstance(payload, dict):
+        raise SystemExit(f"mcp {method} returned non-json: {payload!r}")
+    return payload
+
+
+def run_mcp(
+    base: str,
+    server: str | None,
+    tool: str | None,
+    arguments: dict[str, Any] | None,
+    list_tools: bool,
+    bearer: str | None,
+    client_name: str,
+    client_version: str,
+) -> None:
+    headers: dict[str, str] = {}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+
+    print(f"mcp: server={server or '(aggregate)'} client={client_name}/{client_version}")
+
+    # 1. initialize
+    init = mcp_call(
+        base,
+        server,
+        "initialize",
+        {
+            "protocolVersion": "2025-06-18",
+            "clientInfo": {"name": client_name, "version": client_version},
+            "capabilities": {},
+        },
+        req_id=1,
+        extra_headers=headers,
+    )
+    _print_json("initialize", init)
+
+    # 2. notifications/initialized (no response expected, server returns 202)
+    mcp_call(
+        base,
+        server,
+        "notifications/initialized",
+        {},
+        req_id=2,
+        extra_headers=headers,
+    )
+
+    # 3. tools/list (optional)
+    if list_tools or tool is None:
+        tools = mcp_call(base, server, "tools/list", {}, req_id=3, extra_headers=headers)
+        _print_json("tools/list", tools)
+        if tool is None:
+            return
+
+    # 4. tools/call
+    call = mcp_call(
+        base,
+        server,
+        "tools/call",
+        {"name": tool, "arguments": arguments or {}},
+        req_id=4,
+        extra_headers=headers,
+    )
+    _print_json("tools/call", call)
+
+
+# ─── argparse ───────────────────────────────────────────────────────────────
+
+
+def _parse_json_arg(value: str, label: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"--{label} must be valid JSON: {e}")
+    if not isinstance(parsed, dict):
+        raise SystemExit(f"--{label} must be a JSON object")
+    return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="fake_agent.py",
+        description="Pretend to be an agent talking to Atryum.",
+    )
+    p.add_argument("--base", default=DEFAULT_URL, help=f"Atryum base URL (default {DEFAULT_URL})")
+    sub = p.add_subparsers(dest="mode", required=True)
+
+    default_name, default_version = _env_or_random_identity()
+
+    # harness
+    ph = sub.add_parser("harness", help="pretend to be a coding harness like amp")
+    ph.add_argument(
+        "--source",
+        default=default_name,
+        help=f"agent label shown as 'upstream' in atryum UI (default this run: {default_name})",
+    )
+    ph.add_argument("--tool", required=True)
+    ph.add_argument("--input", default="{}", help="JSON object of tool input")
+    ph.add_argument("--description", default=None)
+    ph.add_argument("--thread-id", default=DEFAULT_THREAD_ID)
+    ph.add_argument("--poll-ms", type=int, default=DEFAULT_POLL_MS)
+    ph.add_argument(
+        "--simulate-result",
+        choices=["ok", "fail", "cancel"],
+        default="ok",
+        help="how to PATCH the execution result after approval",
+    )
+
+    # demo
+    pd = sub.add_parser("demo", help="scripted multi-call demo over harness path")
+    pd.add_argument(
+        "--source",
+        default=None,
+        help="pin all demo calls to one agent label; default: pick a new random agent per call",
+    )
+    pd.add_argument("--thread-id", default=DEFAULT_THREAD_ID)
+    pd.add_argument("--poll-ms", type=int, default=DEFAULT_POLL_MS)
+
+    # mcp
+    pm = sub.add_parser("mcp", help="pretend to be an MCP client (JSON-RPC)")
+    pm.add_argument(
+        "server",
+        nargs="?",
+        default=DEFAULT_MCP_SERVER,
+        help=(
+            "MCP server name to talk to "
+            f"(default {DEFAULT_MCP_SERVER!r}; pass empty string '' for aggregate /mcp/)"
+        ),
+    )
+    pm.add_argument("--tool", default=None, help="tool name for tools/call")
+    pm.add_argument(
+        "--arguments", default="{}", help="JSON object of tool arguments"
+    )
+    pm.add_argument(
+        "--list-tools",
+        action="store_true",
+        help="call tools/list (default if --tool omitted)",
+    )
+    pm.add_argument(
+        "--bearer",
+        default=None,
+        help="bearer token for the Authorization header (optional)",
+    )
+    pm.add_argument(
+        "--client-name",
+        default=default_name,
+        help=f"clientInfo.name sent in initialize (default this run: {default_name})",
+    )
+    pm.add_argument(
+        "--client-version",
+        default=default_version,
+        help=f"clientInfo.version sent in initialize (default this run: {default_version})",
+    )
+
+    args = p.parse_args(argv)
+
+    if args.mode == "harness":
+        run_harness_once(
+            base=args.base,
+            source=args.source,
+            tool=args.tool,
+            input_obj=_parse_json_arg(args.input, "input"),
+            description=args.description,
+            thread_id=args.thread_id,
+            poll_ms=args.poll_ms,
+            simulate=args.simulate_result,
+        )
+    elif args.mode == "demo":
+        run_demo(
+            base=args.base,
+            source=args.source,  # may be None → demo will randomize per call
+            thread_id=args.thread_id,
+            poll_ms=args.poll_ms,
+        )
+    elif args.mode == "mcp":
+        # Empty string explicitly opts into the aggregate /mcp/ route.
+        server = args.server if args.server != "" else None
+        run_mcp(
+            base=args.base,
+            server=server,
+            tool=args.tool,
+            arguments=_parse_json_arg(args.arguments, "arguments"),
+            list_tools=args.list_tools,
+            bearer=args.bearer,
+            client_name=args.client_name,
+            client_version=args.client_version,
+        )
+    else:
+        p.error(f"unknown mode {args.mode!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add end-to-end agent / MCP-client metadata so the Atryum UI can show which coding harness or MCP client (amp, cursor, claude-code, opencode, …) made each tool call, alongside the human user identity.

Schema
- migration 008: agent_clients table (agent_id, client_name, client_version, subject, issuer, last_seen_at). Authoritative per-agent identity, upserted from MCP initialize handshakes.
- migration 009: invocations.client_name / client_version columns. Per-row fallback so anonymous (no agent_id) calls still carry the harness identity that issued them.

MCP capture
- handleMCPProxy("initialize") now records clientInfo. With auth on, it upserts into agent_clients keyed by agent_id. With auth off, it stores into an in-memory clientInfoCache on api.Handler keyed by Mcp-Session-Id (or remote IP + User-Agent fallback).
- handleMCPProxy("tools/call") reads that cache and threads ClientName/ClientVersion into CreateInvocationRequest so each row carries the harness identity even without auth.

Invocation pipeline
- invocation.Service.Invoke persists ClientName/ClientVersion per row.
- toResponse prefers per-row client info, then falls back to an agent_clients lookup keyed by agent_id when present.
- External Submit() no longer stores the harness name (req.Source) in inv.Upstream. The harness identity is recorded as inv.ClientName instead so it shows up in the Agent column. Upstream is left empty for non-MCP/external invocations; the UI renders that as "none". Approval rule matching still uses the original source value, so auto_approve/auto_deny on harness names continues to work.

Tests
- agent_id_test.go covers agent_id capture + propagation.
- agent_clients_test.go covers AgentClientRepo upsert/lookup.
- sqlite_test.go / db_test.go updated for the new columns.

Amp-Thread-ID: https://ampcode.com/threads/T-019e415e-0e25-71ce-a267-09f00e47d38b