### PR TITLE
Expand client/server oauth handling; dockerize everything

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,12 +22,14 @@ stop:
 
 check: fmt test
 
-# PostgreSQL via docker-compose
-pg-up:
-	docker compose up -d --wait
+up:
+	docker compose --profile dev up -d --wait --build
 
-pg-down:
-	docker compose down
+down:
+	docker compose --profile dev down
+
+logs:
+  docker compose --profile dev logs --follow
 
 pg-reset:
 	docker compose down -v

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -1,5 +1,9 @@
 [server]
 listen_addr = ":8080"
+# Public browser-facing base URL used for OAuth redirect_uri generation.
+# In Docker Compose dev this can point at the Vite frontend proxy; in
+# production/Kubernetes it should be the ingress URL.
+public_base_url = "http://localhost:5175"
 # SQLite remains the default. database_path is used when database_url is empty.
 database_path = "./atryum.db"
 # Optional: select storage provider by URL scheme.
@@ -57,6 +61,30 @@ SHORTCUT_READONLY = "true"
 # timeout_seconds = 30
 # enabled = true
 # auth_token = ""
+
+# Optional HTTP + pre-shared OAuth bootstrap (Slack-style: AS doesn't support
+# Dynamic Client Registration, so the admin has registered an app with the
+# provider out-of-band and pasted client credentials below). Bootstrap-only:
+# these values seed mcp_servers when the DB is empty and are ignored on
+# subsequent runs. For ASes that support DCR (Datadog, Shortcut, ...),
+# leave these blank — discovery + DCR will populate them on first Connect.
+# [[upstreams]]
+# name              = "slack"
+# mode              = "http"
+# base_url          = "https://mcp.slack.com/mcp"
+# timeout_seconds   = 30
+# enabled           = true
+# oauth_client_id     = "1234567890.abcdef"
+# oauth_client_secret = "shhhhh"
+# # oauth_authorize_url / oauth_token_url are auto-discovered from
+# # .well-known/oauth-authorization-server when blank — only set them if
+# # the provider doesn't publish discovery metadata.
+# # oauth_authorize_url = ""
+# # oauth_token_url     = ""
+# # Leave oauth_scopes empty to let the OAuth app's registered scopes drive
+# # the grant (recommended for Slack). Set to a space-separated subset to
+# # scope the issued token down at authorize time.
+# # oauth_scopes        = "chat:write channels:history"
 
 # Inbound OAuth bearer-token authentication for /mcp/. Multiple [[auth]]
 # sections are supported; the validator picks the matching one based on

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -60,7 +60,7 @@ func main() {
 	serverRepo := store.NewServerRepoWithDialect(db, dialect)
 	oauthRepo := store.NewOAuthRepoWithDialect(db, dialect)
 	rulesRepo := store.NewRulesRepoWithDialect(db, dialect)
-	resolver := mcp.NewResolver(serverRepo, cfg)
+	resolver := mcp.NewResolver(serverRepo, cfg).WithCredentials(credentialAdapter{repo: oauthRepo})
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
 		log.Fatalf("bootstrap servers: %v", err)
 	}
@@ -82,7 +82,7 @@ func main() {
 	log.Printf("policy provider: %s", policyRegistry.Active().DisplayName())
 
 	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo)
-	serverAdmin := api.NewServerAdminService(serverRepo, oauthRepo, client, 5*time.Second)
+	serverAdmin := api.NewServerAdminService(serverRepo, oauthRepo, client, 5*time.Second, cfg.Server.PublicBaseURL)
 	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo)
 
 	authValidator, err := auth.NewValidator(cfg.Auth, nil)
@@ -126,4 +126,19 @@ func main() {
 func truthyEnv(name string) bool {
 	value := os.Getenv(name)
 	return value == "1" || value == "true" || value == "TRUE" || value == "yes" || value == "YES"
+}
+
+// credentialAdapter bridges store.OAuthRepo into the narrow
+// mcp.CredentialStore interface the resolver consumes. Keeps the mcp
+// package independent of the concrete OAuthRepo/OAuthCredential types.
+type credentialAdapter struct {
+	repo *store.OAuthRepo
+}
+
+func (a credentialAdapter) GetCredential(ctx context.Context, serverName string) (mcp.AccessTokenView, error) {
+	cred, err := a.repo.GetCredential(ctx, serverName)
+	if err != nil {
+		return mcp.AccessTokenView{}, err
+	}
+	return mcp.AccessTokenView{AccessToken: cred.AccessToken}, nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,72 @@ services:
       timeout: 5s
       retries: 10
 
+  # First-run setup is handled by keycloak-init below. It checks whether the
+  # "atryum" realm exists; when it does not, it runs ./keycloak/setup-realm.sh.
+  #
+  # The script provisions the realm via the Admin REST API:
+  # creates the realm, the "atryum:mcp" client scope (with audience mapper +
+  # include-in-token-scope), the confidential "atryum" client for
+  # client_credentials grants, and tunes the anonymous DCR policies so MCP
+  # clients (Claude Code etc.) can self-register. Each step in the script
+  # carries a code comment with the equivalent admin-UI navigation, so it
+  # also serves as executable documentation of the manual setup.
+  #
+  # The script is idempotent — re-run it manually any time to reconcile drift:
+  #   ./keycloak/setup-realm.sh
+  # Login is admin/admin at http://localhost:8088.
+  keycloak:
+    profiles: ["dev"]
+    image: quay.io/keycloak/keycloak:26.0
+    command: ["start-dev", "--http-port=8088"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "8088:8088"
+    volumes:
+      - keycloak_data:/opt/keycloak/data
+      # Drop *.json realm exports here to auto-import on first run:
+      - ./keycloak/import:/opt/keycloak/data/import:ro
+    healthcheck:
+      # Keycloak 26 serves /health/* on a separate management interface
+      # (default port 9000), not on the main HTTP port. The image is
+      # minimal — no curl, no wget — but it has bash, so we probe with
+      # bash's /dev/tcp builtin and grep for the 200 OK. Health stays
+      # in-container; port 9000 is intentionally NOT published.
+      test:
+        - "CMD-SHELL"
+        - 'exec 3<>/dev/tcp/127.0.0.1/9000; printf "GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n" >&3; grep -q "^HTTP/1.1 200" <&3'
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
+  keycloak-init:
+    profiles: ["dev"]
+    image: alpine:3.20
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    environment:
+      KC_URL: http://keycloak:8088
+      KC_ADMIN: admin
+      KC_PASSWORD: admin
+      REALM: atryum
+      KC_SETUP_SKIP_IF_REALM_EXISTS: "true"
+    volumes:
+      - ./keycloak/setup-realm.sh:/setup-realm.sh:ro
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        apk add --no-cache bash curl jq
+        bash /setup-realm.sh
+
   atryum:
     profiles: ["dev"]
     build:
@@ -22,6 +88,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
+    environment:
+      - ATRYUM_MCP_DEBUG=true
     volumes:
       - ./atryum.toml:/app/atryum.toml:ro
     healthcheck:
@@ -33,6 +101,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      keycloak-init:
+        condition: service_completed_successfully
 
   # Production: single binary with embedded Vite frontend (off by default)
   # Usage: docker compose --profile prod up atryum-prod
@@ -54,6 +124,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      keycloak:
+        condition: service_healthy
 
   frontend-init:
     profiles: ["dev"]
@@ -68,7 +140,18 @@ services:
     image: node:22-alpine
     user: "1000:1000"
     working_dir: /app
-    command: sh -c "npm install && npm run dev:atryum"
+    command:
+      - sh
+      - -c
+      - |
+        set -eu
+        lock_hash="$$(sha256sum package-lock.json | awk '{print $$1}')"
+        marker="node_modules/.package-lock.sha256"
+        if [ ! -d node_modules/.bin ] || [ ! -f "$$marker" ] || [ "$$(cat "$$marker")" != "$$lock_hash" ]; then
+          npm install
+          printf '%s' "$$lock_hash" > "$$marker"
+        fi
+        npm run dev:atryum
     ports:
       - "5175:5175"
     volumes:
@@ -84,6 +167,7 @@ services:
 
 volumes:
   pgdata:
+  keycloak_data:
   frontend_node_modules:
 
 networks:

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -104,32 +104,38 @@ type DenyRequest struct {
 }
 
 type AdminServer struct {
-	Name               string            `json:"name"`
-	Mode               string            `json:"mode"`
-	BaseURL            string            `json:"base_url,omitempty"`
-	AuthToken          string            `json:"auth_token,omitempty"`
-	AuthHeaders        []mcp.AuthHeader  `json:"auth_headers,omitempty"`
-	TimeoutSeconds     int               `json:"timeout_seconds"`
-	Command            string            `json:"command,omitempty"`
-	Args               []string          `json:"args,omitempty"`
-	Env                map[string]string `json:"env,omitempty"`
-	Enabled            bool              `json:"enabled"`
-	AuthType           string            `json:"auth_type"`
-	ConnectionStatus   string            `json:"connection_status"`
-	AuthStatus         string            `json:"auth_status"`
-	ReauthNeeded       bool              `json:"reauth_needed"`
-	LastCheckedAt      *time.Time        `json:"last_checked_at,omitempty"`
-	LastCheckOK        bool              `json:"last_check_ok"`
-	LastErrorSummary   *string           `json:"last_error_summary,omitempty"`
-	ActionRequired     *string           `json:"action_required,omitempty"`
-	OAuthProviderID         string `json:"oauth_provider_id,omitempty"`
-	OAuthProviderLabel      string `json:"oauth_provider_label,omitempty"`
-	OAuthClientRegistration string `json:"oauth_client_registration,omitempty"`
-	OAuthClientID           string `json:"oauth_client_id,omitempty"`
-	OAuthAuthorizeURL       string `json:"oauth_authorize_url,omitempty"`
-	OAuthTokenURL           string `json:"oauth_token_url,omitempty"`
-	OAuthScopes             string `json:"oauth_scopes,omitempty"`
-	HasOAuthClientSecret    bool   `json:"has_oauth_client_secret,omitempty"`
+	Name                    string            `json:"name"`
+	Mode                    string            `json:"mode"`
+	BaseURL                 string            `json:"base_url,omitempty"`
+	AuthToken               string            `json:"auth_token,omitempty"`
+	AuthHeaders             []mcp.AuthHeader  `json:"auth_headers,omitempty"`
+	TimeoutSeconds          int               `json:"timeout_seconds"`
+	Command                 string            `json:"command,omitempty"`
+	Args                    []string          `json:"args,omitempty"`
+	Env                     map[string]string `json:"env,omitempty"`
+	Enabled                 bool              `json:"enabled"`
+	AuthType                string            `json:"auth_type"`
+	ConnectionStatus        string            `json:"connection_status"`
+	AuthStatus              string            `json:"auth_status"`
+	ReauthNeeded            bool              `json:"reauth_needed"`
+	LastCheckedAt           *time.Time        `json:"last_checked_at,omitempty"`
+	LastCheckOK             bool              `json:"last_check_ok"`
+	LastErrorSummary        *string           `json:"last_error_summary,omitempty"`
+	ActionRequired          *string           `json:"action_required,omitempty"`
+	OAuthProviderID         string            `json:"oauth_provider_id,omitempty"`
+	OAuthProviderLabel      string            `json:"oauth_provider_label,omitempty"`
+	OAuthClientRegistration string            `json:"oauth_client_registration,omitempty"`
+	OAuthClientID           string            `json:"oauth_client_id,omitempty"`
+	OAuthAuthorizeURL       string            `json:"oauth_authorize_url,omitempty"`
+	OAuthTokenURL           string            `json:"oauth_token_url,omitempty"`
+	OAuthScopes             string            `json:"oauth_scopes,omitempty"`
+	HasOAuthClientSecret    bool              `json:"has_oauth_client_secret,omitempty"`
+	// OAuthGrantedScopes is what the authorization server actually issued
+	// on the most recent token exchange (read from oauth_credentials.scope).
+	// Distinct from OAuthScopes, which is what we *request* in the next
+	// authorize URL. They can diverge: Slack-style ASes honor whatever
+	// scopes the registered app declares regardless of what we send.
+	OAuthGrantedScopes string `json:"oauth_granted_scopes,omitempty"`
 }
 
 type AdminServerUpsertRequest struct {
@@ -1183,10 +1189,11 @@ func readUintQuery(r *http.Request, key string, fallback uint64) uint64 {
 }
 
 type ServerAdminService struct {
-	repo      serverRepo
-	oauthRepo *store.OAuthRepo
-	client    *mcp.Client
-	timeout   time.Duration
+	repo          serverRepo
+	oauthRepo     *store.OAuthRepo
+	client        *mcp.Client
+	timeout       time.Duration
+	publicBaseURL string
 }
 
 type serverRepo interface {
@@ -1198,8 +1205,8 @@ type serverRepo interface {
 	DisableServer(ctx context.Context, name string) error
 }
 
-func NewServerAdminService(repo serverRepo, oauthRepo *store.OAuthRepo, client *mcp.Client, timeout time.Duration) *ServerAdminService {
-	return &ServerAdminService{repo: repo, oauthRepo: oauthRepo, client: client, timeout: timeout}
+func NewServerAdminService(repo serverRepo, oauthRepo *store.OAuthRepo, client *mcp.Client, timeout time.Duration, publicBaseURL string) *ServerAdminService {
+	return &ServerAdminService{repo: repo, oauthRepo: oauthRepo, client: client, timeout: timeout, publicBaseURL: strings.TrimRight(strings.TrimSpace(publicBaseURL), "/")}
 }
 
 func (s *ServerAdminService) List(ctx context.Context, filter mcp.ServerFilter) (ServerListResponse, error) {
@@ -1209,7 +1216,7 @@ func (s *ServerAdminService) List(ctx context.Context, filter mcp.ServerFilter) 
 	}
 	servers := make([]AdminServer, 0, len(items))
 	for _, item := range items {
-		servers = append(servers, toAdminServer(item))
+		servers = append(servers, s.adminViewWithGrantedScopes(ctx, item))
 	}
 	return ServerListResponse{Items: servers, Total: total, Offset: filter.Offset, Limit: normalizeLimit(filter.Limit, 50)}, nil
 }
@@ -1219,7 +1226,19 @@ func (s *ServerAdminService) Get(ctx context.Context, name string) (AdminServer,
 	if err != nil {
 		return AdminServer{}, err
 	}
-	return toAdminServer(upstream), nil
+	return s.adminViewWithGrantedScopes(ctx, upstream), nil
+}
+
+// adminViewWithGrantedScopes is toAdminServer + an overlay of the actual
+// scope string the AS granted on the latest successful token exchange.
+// Pulled separately from oauth_credentials.scope so the UI can show both
+// what we requested and what's actually live.
+func (s *ServerAdminService) adminViewWithGrantedScopes(ctx context.Context, upstream mcp.Upstream) AdminServer {
+	view := toAdminServer(upstream)
+	if cred, err := s.oauthRepo.GetCredential(ctx, upstream.Name); err == nil {
+		view.OAuthGrantedScopes = cred.Scope
+	}
+	return view
 }
 
 func (s *ServerAdminService) Upsert(ctx context.Context, name string, req AdminServerUpsertRequest) (AdminServer, error) {
@@ -1295,7 +1314,7 @@ func (s *ServerAdminService) Upsert(ctx context.Context, name string, req AdminS
 	if err := s.repo.UpsertServer(ctx, upstream); err != nil {
 		return AdminServer{}, err
 	}
-	return toAdminServer(upstream), nil
+	return s.adminViewWithGrantedScopes(ctx, upstream), nil
 }
 
 func (s *ServerAdminService) Delete(ctx context.Context, name string, disable bool) error {
@@ -1348,7 +1367,11 @@ func (s *ServerAdminService) StartConnect(ctx context.Context, name string, appB
 	if err != nil {
 		return OAuthConnectStartResponse{}, err
 	}
-	redirectURI := strings.TrimRight(appBaseURL, "/") + "/api/v1/admin/oauth/callback"
+	redirectBaseURL := strings.TrimRight(appBaseURL, "/")
+	if s.publicBaseURL != "" {
+		redirectBaseURL = s.publicBaseURL
+	}
+	redirectURI := redirectBaseURL + "/api/v1/admin/oauth/callback"
 	connectReq, err := provider.BuildConnectRequest(ctx, upstream, redirectURI, stateToken)
 	if err != nil {
 		return OAuthConnectStartResponse{}, err

--- a/internal/api/web/app.js
+++ b/internal/api/web/app.js
@@ -35,6 +35,13 @@ $('#show-disabled-servers').addEventListener('change', () => {
   loadServers();
 });
 $('#server-mode').addEventListener('change', updateServerModeFields);
+$('#server-oauth-use-default-scopes').addEventListener('change', (event) => {
+  const checked = event.target.checked;
+  $('#server-oauth-scopes-row').style.display = checked ? 'none' : '';
+  if (checked) {
+    $('#server-oauth-scopes').value = '';
+  }
+});
 $('#server-form').addEventListener('submit', async (event) => {
   event.preventDefault();
   await saveServer();
@@ -421,7 +428,15 @@ function fillServerForm(detail) {
     : '';
   $('#server-oauth-authorize-url').value = detail.oauth_authorize_url || '';
   $('#server-oauth-token-url').value = detail.oauth_token_url || '';
-  $('#server-oauth-scopes').value = detail.oauth_scopes || '';
+  const scopes = (detail.oauth_scopes || '').trim();
+  $('#server-oauth-scopes').value = scopes;
+  $('#server-oauth-use-default-scopes').checked = scopes === '';
+  $('#server-oauth-scopes-row').style.display = scopes === '' ? 'none' : '';
+  const granted = $('#server-oauth-granted-scopes');
+  if (granted) {
+    granted.value = detail.oauth_granted_scopes || '';
+    $('#server-oauth-granted-scopes-row').style.display = detail.oauth_granted_scopes ? '' : 'none';
+  }
   updateServerModeFields();
 }
 
@@ -461,6 +476,11 @@ function startNewServer() {
   $('#server-enabled').checked = true;
   $('#server-mode').value = 'http';
   $('#toggle-server-enabled').textContent = 'Disable';
+  $('#server-oauth-use-default-scopes').checked = true;
+  $('#server-oauth-scopes-row').style.display = 'none';
+  $('#server-oauth-scopes').value = '';
+  const grantedRow = $('#server-oauth-granted-scopes-row');
+  if (grantedRow) grantedRow.style.display = 'none';
   applyConnectButtonState({ mode: 'http', base_url: '', oauth_provider_id: '' });
   $('#server-badges').innerHTML = [renderBadge('unknown'), renderBadge('unknown'), renderBadge('not_tested', 'neutral')].join('');
   $('#server-detail-summary').innerHTML = '<div><strong>Status:</strong> Create and test a server to see readiness and auth state.</div>';

--- a/internal/api/web/index.html
+++ b/internal/api/web/index.html
@@ -196,7 +196,9 @@
                 <label><span>Client Secret</span><input id="server-oauth-client-secret" type="password" placeholder="(leave blank to keep stored value)" /></label>
                 <label><span>Authorize URL</span><input id="server-oauth-authorize-url" placeholder="auto-discovered when blank" /></label>
                 <label><span>Token URL</span><input id="server-oauth-token-url" placeholder="auto-discovered when blank" /></label>
-                <label><span>Scopes (space-separated)</span><input id="server-oauth-scopes" placeholder="chat:write channels:history" /></label>
+                <label class="checkbox-inline"><input id="server-oauth-use-default-scopes" type="checkbox" checked /><span>Use default scopes (whatever the OAuth app declared with the provider)</span></label>
+                <label id="server-oauth-scopes-row" style="display:none"><span>Scopes (space-separated, requested — scope down to a subset)</span><input id="server-oauth-scopes" placeholder="chat:write channels:history" /></label>
+                <label id="server-oauth-granted-scopes-row" style="display:none"><span>Granted scopes (from latest token exchange)</span><textarea id="server-oauth-granted-scopes" rows="3" disabled></textarea></label>
               </details>
               <label class="field-stdio">
                 <span>Command</span>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,10 +43,11 @@ type PolicyConfig struct {
 }
 
 type ServerConfig struct {
-	ListenAddr   string `toml:"listen_addr"`
-	DatabasePath string `toml:"database_path"`
-	DatabaseURL  string `toml:"database_url"`
-	LogLevel     string `toml:"log_level"`
+	ListenAddr    string `toml:"listen_addr"`
+	PublicBaseURL string `toml:"public_base_url"`
+	DatabasePath  string `toml:"database_path"`
+	DatabaseURL   string `toml:"database_url"`
+	LogLevel      string `toml:"log_level"`
 }
 
 type DefaultsConfig struct {
@@ -63,6 +64,16 @@ type UpstreamConfig struct {
 	Command        string            `toml:"command"`
 	Args           []string          `toml:"args"`
 	Env            map[string]string `toml:"env"`
+	// Optional pre-shared OAuth credentials. Only consulted on the
+	// bootstrap path (empty DB) — once a row exists in mcp_servers these
+	// are ignored and the admin form / DCR take over. Use for ASes that
+	// don't support Dynamic Client Registration (Slack, GitHub OAuth
+	// Apps, etc.) where the admin has registered a client out-of-band.
+	OAuthClientID     string `toml:"oauth_client_id"`
+	OAuthClientSecret string `toml:"oauth_client_secret"`
+	OAuthAuthorizeURL string `toml:"oauth_authorize_url"`
+	OAuthTokenURL     string `toml:"oauth_token_url"`
+	OAuthScopes       string `toml:"oauth_scopes"`
 }
 
 func Load(path string) (Config, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -11,6 +11,7 @@ func TestLoadServerDatabaseURL(t *testing.T) {
 	path := filepath.Join(dir, "atryum.toml")
 	if err := os.WriteFile(path, []byte(`[server]
 listen_addr = ":9090"
+public_base_url = "https://atryum.example.com"
 database_path = "./atryum.db"
 database_url = "postgresql://postgres:password@127.0.0.1:5432/postgres"
 log_level = "debug"
@@ -30,6 +31,9 @@ connection_timeout_seconds = 7
 	}
 	if cfg.Server.DatabaseURL != "postgresql://postgres:password@127.0.0.1:5432/postgres" {
 		t.Fatalf("DatabaseURL = %q", cfg.Server.DatabaseURL)
+	}
+	if cfg.Server.PublicBaseURL != "https://atryum.example.com" {
+		t.Fatalf("PublicBaseURL = %q", cfg.Server.PublicBaseURL)
 	}
 	if cfg.Backend.BaseURL != "https://backend.example" {
 		t.Fatalf("Backend.BaseURL = %q", cfg.Backend.BaseURL)

--- a/internal/mcp/auth_provider/oauth_metadata.go
+++ b/internal/mcp/auth_provider/oauth_metadata.go
@@ -348,26 +348,25 @@ func strategyProvider(upstream mcp.Upstream) (Provider, error) {
 	}
 }
 
+// defaultScopes picks a sensible scope default for OIDC-style ASes only.
+// For pure-OAuth ASes (Slack, GitHub, etc.) the right behavior is to send
+// no scope parameter at all and let the AS grant whatever scopes the
+// registered client app declared — picking an arbitrary subset of
+// scopes_supported (as we used to) silently truncates consent to the
+// first few scopes alphabetically and confuses everyone. Admins who want
+// to scope down explicitly can fill in the manual OAuth form.
 func defaultScopes(scopes []string) []string {
-	preferred := []string{"openid", "profile", "email"}
-	out := make([]string, 0, len(preferred))
 	available := make(map[string]struct{}, len(scopes))
 	for _, scope := range scopes {
 		available[scope] = struct{}{}
 	}
-	for _, scope := range preferred {
+	if _, ok := available["openid"]; !ok {
+		return nil
+	}
+	out := []string{"openid"}
+	for _, scope := range []string{"profile", "email"} {
 		if _, ok := available[scope]; ok {
 			out = append(out, scope)
-		}
-	}
-	if len(out) == 0 {
-		for _, scope := range scopes {
-			if strings.TrimSpace(scope) != "" {
-				out = append(out, scope)
-			}
-			if len(out) == 3 {
-				break
-			}
 		}
 	}
 	return out

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -193,15 +194,39 @@ type ServerFilter struct {
 	Enabled *bool
 }
 
+// CredentialStore returns the OAuth access token currently stored for a
+// server. It is consulted on every ResolveContext so that proxied MCP
+// requests (tools/list, tools/call, forward) get the live access token
+// attached. The interface is intentionally narrow — the resolver does not
+// need to know about refresh tokens or expiry; that's the credential
+// store's problem.
+type CredentialStore interface {
+	GetCredential(ctx context.Context, serverName string) (AccessTokenView, error)
+}
+
+type AccessTokenView struct {
+	AccessToken string
+}
+
 type Resolver struct {
-	store     ServerStore
-	bootstrap map[string]Upstream
+	store       ServerStore
+	credentials CredentialStore
+	bootstrap   map[string]Upstream
 }
 
 type Client struct {
 	httpClient *http.Client
 	nextID     atomic.Int64
 	debug      bool
+
+	// MCP Streamable HTTP session IDs per upstream. The transport
+	// (since spec rev 2025-03-26) lets a server require an `Mcp-Session-Id`
+	// header on every non-initialize request. We initialize lazily, cache
+	// the id, and clear it on 404 (server-side expiry) so the next call
+	// re-inits. Stateless upstreams (those that never return the header)
+	// stay as empty strings.
+	sessionMu sync.Mutex
+	sessions  map[string]string
 }
 
 type InvokeResult struct {
@@ -247,9 +272,18 @@ func NewResolver(store ServerStore, cfg config.Config) *Resolver {
 	return &Resolver{store: store, bootstrap: bootstrap}
 }
 
+// WithCredentials returns the resolver wired up with an OAuth credential
+// store. When set, ResolveContext overlays the stored access token onto
+// upstream.AuthToken so that downstream HTTP requests carry it as a
+// Bearer header.
+func (r *Resolver) WithCredentials(credentials CredentialStore) *Resolver {
+	r.credentials = credentials
+	return r
+}
+
 func NewHTTPClient() *Client {
 	debug := strings.EqualFold(os.Getenv("ATRYUM_MCP_DEBUG"), "1") || strings.EqualFold(os.Getenv("ATRYUM_MCP_DEBUG"), "true")
-	return &Client{httpClient: &http.Client{}, debug: debug}
+	return &Client{httpClient: &http.Client{}, debug: debug, sessions: make(map[string]string)}
 }
 
 func (r *Resolver) Resolve(name string) (Upstream, error) {
@@ -260,7 +294,7 @@ func (r *Resolver) ResolveContext(ctx context.Context, name string) (Upstream, e
 	if r.store != nil {
 		upstream, err := r.store.GetServer(ctx, name)
 		if err == nil {
-			return upstream, nil
+			return r.overlayCredential(ctx, upstream), nil
 		}
 		if err != nil && err != sql.ErrNoRows {
 			return Upstream{}, err
@@ -270,7 +304,24 @@ func (r *Resolver) ResolveContext(ctx context.Context, name string) (Upstream, e
 	if !ok || !upstream.Enabled {
 		return Upstream{}, fmt.Errorf("upstream %q not configured or disabled", name)
 	}
-	return upstream, nil
+	return r.overlayCredential(ctx, upstream), nil
+}
+
+// overlayCredential injects the live OAuth access token (when one is
+// stored) onto upstream.AuthToken so that applyAuthHeaders adds the
+// Bearer header to forwarded MCP requests. The DB never persists the
+// access token onto mcp_servers.auth_token — it lives in
+// oauth_credentials and is replayed on each resolve.
+func (r *Resolver) overlayCredential(ctx context.Context, upstream Upstream) Upstream {
+	if r.credentials == nil {
+		return upstream
+	}
+	cred, err := r.credentials.GetCredential(ctx, upstream.Name)
+	if err != nil || strings.TrimSpace(cred.AccessToken) == "" {
+		return upstream
+	}
+	upstream.AuthToken = cred.AccessToken
+	return upstream
 }
 
 func (r *Resolver) ListAll(ctx context.Context) ([]Upstream, error) {
@@ -281,13 +332,16 @@ func (r *Resolver) ListAll(ctx context.Context) ([]Upstream, error) {
 			return nil, err
 		}
 		if len(upstreams) > 0 {
+			for i := range upstreams {
+				upstreams[i] = r.overlayCredential(ctx, upstreams[i])
+			}
 			return upstreams, nil
 		}
 	}
 	var result []Upstream
 	for _, u := range r.bootstrap {
 		if u.Enabled {
-			result = append(result, u)
+			result = append(result, r.overlayCredential(ctx, u))
 		}
 	}
 	return result, nil
@@ -447,6 +501,9 @@ func (c *Client) TestConnection(ctx context.Context, upstream Upstream) Connecti
 }
 
 func (c *Client) invokeHTTP(ctx context.Context, upstream Upstream, tool string, input map[string]any, requestID *string) (InvokeResult, error) {
+	if err := c.ensureHTTPSession(ctx, upstream); err != nil {
+		return InvokeResult{}, err
+	}
 	params := map[string]any{"name": tool, "arguments": input}
 	if requestID != nil && *requestID != "" {
 		params["_meta"] = map[string]any{"atryumRequestId": *requestID}
@@ -476,6 +533,9 @@ func (c *Client) invokeHTTP(ctx context.Context, upstream Upstream, tool string,
 }
 
 func (c *Client) listToolsHTTP(ctx context.Context, upstream Upstream) ([]Tool, error) {
+	if err := c.ensureHTTPSession(ctx, upstream); err != nil {
+		return nil, err
+	}
 	body, err := json.Marshal(Envelope{JSONRPC: "2.0", ID: json.RawMessage([]byte("1")), Method: "tools/list", Params: mustRawJSON(map[string]any{})})
 	if err != nil {
 		return nil, err
@@ -495,6 +555,13 @@ func (c *Client) listToolsHTTP(ctx context.Context, upstream Upstream) ([]Tool, 
 }
 
 func (c *Client) forwardEnvelopeHTTP(ctx context.Context, upstream Upstream, envelope Envelope, protocolVersion string) (ForwardResult, error) {
+	// "initialize" requests carry no prior session; for everything else,
+	// make sure we have one so spec-compliant upstreams don't reject us.
+	if envelope.Method != "initialize" {
+		if err := c.ensureHTTPSession(ctx, upstream); err != nil {
+			return ForwardResult{}, err
+		}
+	}
 	body, err := json.Marshal(envelope)
 	if err != nil {
 		return ForwardResult{}, err
@@ -502,7 +569,7 @@ func (c *Client) forwardEnvelopeHTTP(ctx context.Context, upstream Upstream, env
 	return c.doHTTPEnvelope(ctx, upstream, body, protocolVersion)
 }
 
-func (c *Client) doHTTPEnvelopeRaw(ctx context.Context, upstream Upstream, body []byte, protocolVersion string) (*http.Response, error) {
+func (c *Client) doHTTPEnvelopeRaw(ctx context.Context, upstream Upstream, body []byte, protocolVersion, sessionID string) (*http.Response, error) {
 	endpoint := strings.TrimRight(upstream.BaseURL, "/")
 	client := c.httpClient
 	if upstream.Timeout > 0 {
@@ -517,16 +584,27 @@ func (c *Client) doHTTPEnvelopeRaw(ctx context.Context, upstream Upstream, body 
 	if strings.TrimSpace(protocolVersion) != "" {
 		req.Header.Set("MCP-Protocol-Version", protocolVersion)
 	}
+	if strings.TrimSpace(sessionID) != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
 	applyAuthHeaders(req, upstream)
 	return client.Do(req)
 }
 
 func (c *Client) doHTTPEnvelope(ctx context.Context, upstream Upstream, body []byte, protocolVersion string) (ForwardResult, error) {
-	resp, err := c.doHTTPEnvelopeRaw(ctx, upstream, body, protocolVersion)
+	sessionID := c.getSession(upstream.Name)
+	resp, err := c.doHTTPEnvelopeRaw(ctx, upstream, body, protocolVersion, sessionID)
 	if err != nil {
 		return ForwardResult{}, err
 	}
 	defer resp.Body.Close()
+	// Capture/clear session id based on response. 404 with an existing
+	// session means the server forgot us; drop it so the next call inits.
+	if newSession := strings.TrimSpace(resp.Header.Get("Mcp-Session-Id")); newSession != "" {
+		c.setSession(upstream.Name, newSession)
+	} else if resp.StatusCode == http.StatusNotFound && sessionID != "" {
+		c.clearSession(upstream.Name)
+	}
 	contentType := resp.Header.Get("Content-Type")
 	if strings.Contains(contentType, "text/event-stream") {
 		data, sseErr := extractFirstSSEData(resp.Body)
@@ -541,6 +619,61 @@ func (c *Client) doHTTPEnvelope(ctx context.Context, upstream Upstream, body []b
 		return ForwardResult{}, err
 	}
 	return ForwardResult{StatusCode: resp.StatusCode, Body: respBody.Bytes(), ContentType: contentType, ProtocolVersion: resp.Header.Get("MCP-Protocol-Version")}, nil
+}
+
+func (c *Client) getSession(name string) string {
+	c.sessionMu.Lock()
+	defer c.sessionMu.Unlock()
+	return c.sessions[name]
+}
+
+func (c *Client) setSession(name, id string) {
+	c.sessionMu.Lock()
+	defer c.sessionMu.Unlock()
+	c.sessions[name] = id
+}
+
+func (c *Client) clearSession(name string) {
+	c.sessionMu.Lock()
+	defer c.sessionMu.Unlock()
+	delete(c.sessions, name)
+}
+
+// ensureHTTPSession initializes the upstream session if not yet established,
+// returning silently if the upstream is stateless (doesn't emit
+// Mcp-Session-Id). Required by spec-compliant servers (e.g. Shortcut) which
+// reject non-initialize requests that arrive without a session id.
+func (c *Client) ensureHTTPSession(ctx context.Context, upstream Upstream) error {
+	if c.getSession(upstream.Name) != "" {
+		return nil
+	}
+	initBody, err := json.Marshal(Envelope{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage([]byte("1")),
+		Method:  "initialize",
+		Params: mustRawJSON(map[string]any{
+			"protocolVersion": DefaultMCPProtocolVersion,
+			"clientInfo":      map[string]any{"name": "atryum", "version": "0.1.0"},
+			"capabilities":    map[string]any{},
+		}),
+	})
+	if err != nil {
+		return err
+	}
+	// doHTTPEnvelope reads the Mcp-Session-Id response header and stores it.
+	if _, err := c.doHTTPEnvelope(ctx, upstream, initBody, DefaultMCPProtocolVersion); err != nil {
+		return err
+	}
+	// Spec requires the client to send notifications/initialized after a
+	// successful initialize. Stateless servers ignore it; stateful ones need
+	// it to mark the session usable.
+	if c.getSession(upstream.Name) != "" {
+		notifyBody, err := json.Marshal(Envelope{JSONRPC: "2.0", Method: "notifications/initialized", Params: mustRawJSON(map[string]any{})})
+		if err == nil {
+			_, _ = c.doHTTPEnvelope(ctx, upstream, notifyBody, DefaultMCPProtocolVersion)
+		}
+	}
+	return nil
 }
 
 func (c *Client) invokeStdio(ctx context.Context, upstream Upstream, tool string, input map[string]any) (InvokeResult, error) {
@@ -669,15 +802,25 @@ func fromConfig(u config.UpstreamConfig) Upstream {
 		mode = UpstreamMode(u.Mode)
 	}
 	upstream := Upstream{
-		Name:      u.Name,
-		Mode:      mode,
-		BaseURL:   strings.TrimRight(u.BaseURL, "/"),
-		AuthToken: u.AuthToken,
-		Timeout:   time.Duration(u.TimeoutSeconds) * time.Second,
-		Command:   u.Command,
-		Args:      append([]string(nil), u.Args...),
-		Env:       cloneMap(u.Env),
-		Enabled:   u.Enabled,
+		Name:              u.Name,
+		Mode:              mode,
+		BaseURL:           strings.TrimRight(u.BaseURL, "/"),
+		AuthToken:         u.AuthToken,
+		Timeout:           time.Duration(u.TimeoutSeconds) * time.Second,
+		Command:           u.Command,
+		Args:              append([]string(nil), u.Args...),
+		Env:               cloneMap(u.Env),
+		Enabled:           u.Enabled,
+		OAuthClientID:     strings.TrimSpace(u.OAuthClientID),
+		OAuthClientSecret: u.OAuthClientSecret,
+		OAuthAuthorizeURL: strings.TrimSpace(u.OAuthAuthorizeURL),
+		OAuthTokenURL:     strings.TrimSpace(u.OAuthTokenURL),
+		OAuthScopes:       strings.TrimSpace(u.OAuthScopes),
+	}
+	if strings.TrimSpace(u.OAuthClientID) != "" {
+		// Bootstrapped pre-shared client — record provenance so the UI
+		// can label it and so subsequent saves don't re-flip provenance.
+		upstream.OAuthClientRegistration = ClientRegistrationPreshared
 	}
 	upstream.Status = inferInitialStatus(upstream)
 	return upstream

--- a/keycloak/setup-realm.sh
+++ b/keycloak/setup-realm.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+#
+# setup-realm.sh — provision the "atryum" Keycloak realm from scratch via the
+# Admin REST API. Idempotent: re-running on an existing realm only patches the
+# pieces that drift.
+#
+# Each step has a comment showing the equivalent admin-UI path, so this script
+# doubles as executable documentation for the manual setup.
+#
+# Usage:
+#   docker compose up -d keycloak
+#   ./keycloak/setup-realm.sh
+#
+# Env overrides:
+#   KC_URL       (default http://localhost:8088)
+#   KC_ADMIN     (default admin)
+#   KC_PASSWORD  (default admin)
+#   REALM        (default atryum)
+#   KC_SETUP_SKIP_IF_REALM_EXISTS
+#                (default false)         — exit without reconciling settings
+#                                            when REALM already exists
+#   CLIENT_ID    (default atryum)         — the confidential client used by
+#                                            agents doing client_credentials
+#   SCOPE_NAME   (default atryum:mcp)     — resource scope, also the audience
+#   AUDIENCE     (default atryum)         — literal value placed in `aud` claim
+
+set -euo pipefail
+
+KC_URL="${KC_URL:-http://localhost:8088}"
+KC_ADMIN="${KC_ADMIN:-admin}"
+KC_PASSWORD="${KC_PASSWORD:-admin}"
+REALM="${REALM:-atryum}"
+KC_SETUP_SKIP_IF_REALM_EXISTS="${KC_SETUP_SKIP_IF_REALM_EXISTS:-false}"
+CLIENT_ID="${CLIENT_ID:-atryum}"
+SCOPE_NAME="${SCOPE_NAME:-atryum:mcp}"
+AUDIENCE="${AUDIENCE:-atryum}"
+REDIRECT_URI="${REDIRECT_URI:-http://localhost:8080/*}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing: $1" >&2; exit 1; }; }
+need curl
+need jq
+
+log() { printf "\033[1;36m==>\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m!!\033[0m %s\n" "$*" >&2; }
+
+# Step 1 — UI: http://localhost:8088 → log in as admin/admin
+log "Acquiring admin token..."
+TOKEN=$(curl -fsS -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+  -d "client_id=admin-cli&grant_type=password&username=${KC_ADMIN}&password=${KC_PASSWORD}" \
+  | jq -r .access_token)
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || { echo "admin login failed" >&2; exit 1; }
+
+api() {
+  local method="$1" path="$2"; shift 2
+  curl -sS -X "$method" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    "${KC_URL}/admin/realms${path}" "$@"
+}
+
+# Step 2 — UI: top-left realm switcher → "Create realm" → name "atryum"
+if api GET "/${REALM}" -o /dev/null -w "%{http_code}" | grep -q 200; then
+  log "Realm '${REALM}' already exists."
+  if [ "$KC_SETUP_SKIP_IF_REALM_EXISTS" = "true" ]; then
+    log "Skipping setup because KC_SETUP_SKIP_IF_REALM_EXISTS=true."
+    exit 0
+  fi
+else
+  log "Creating realm '${REALM}'..."
+  api POST "" -d "{\"realm\":\"${REALM}\",\"enabled\":true}" >/dev/null
+fi
+
+REALM_ID=$(api GET "/${REALM}" | jq -r .id)
+
+# Step 3 — UI: Client Scopes → Create client scope
+#   Name: atryum:mcp
+#   Type: Default
+#   Settings → "Include in token scope": ON
+#     (without this, the JWT's `scope` claim won't contain "atryum:mcp" and
+#      Atryum's required_scope check fails with "missing required scope")
+log "Ensuring client scope '${SCOPE_NAME}'..."
+SCOPE_ID=$(api GET "/${REALM}/client-scopes" \
+  | jq -r --arg n "$SCOPE_NAME" '.[] | select(.name==$n) | .id' | head -1)
+
+SCOPE_BODY=$(cat <<EOF
+{
+  "name": "${SCOPE_NAME}",
+  "protocol": "openid-connect",
+  "attributes": {
+    "include.in.token.scope": "true",
+    "display.on.consent.screen": "true"
+  }
+}
+EOF
+)
+
+if [ -z "$SCOPE_ID" ]; then
+  api POST "/${REALM}/client-scopes" -d "$SCOPE_BODY" >/dev/null
+  SCOPE_ID=$(api GET "/${REALM}/client-scopes" \
+    | jq -r --arg n "$SCOPE_NAME" '.[] | select(.name==$n) | .id' | head -1)
+else
+  # PUT requires id in the body
+  api PUT "/${REALM}/client-scopes/${SCOPE_ID}" \
+    -d "$(echo "$SCOPE_BODY" | jq --arg id "$SCOPE_ID" '. + {id:$id}')" >/dev/null
+fi
+
+# Step 3b — UI: Client Scopes → atryum:mcp → Mappers → Add → By configuration
+#                → Audience
+#   Name: aud-atryum
+#   Included Custom Audience: atryum   (leave Included Client Audience empty)
+#   Add to access token: ON
+#     (without `included.custom.audience` set, tokens won't have
+#      `aud:"atryum"` and Atryum rejects with "issuer/audience not allowed")
+log "Ensuring audience mapper on '${SCOPE_NAME}'..."
+MAPPER_ID=$(api GET "/${REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models" \
+  | jq -r '.[] | select(.protocolMapper=="oidc-audience-mapper") | .id' | head -1)
+
+MAPPER_BODY=$(cat <<EOF
+{
+  "name": "aud-${AUDIENCE}",
+  "protocol": "openid-connect",
+  "protocolMapper": "oidc-audience-mapper",
+  "consentRequired": false,
+  "config": {
+    "included.custom.audience": "${AUDIENCE}",
+    "access.token.claim": "true",
+    "introspection.token.claim": "true",
+    "id.token.claim": "false",
+    "userinfo.token.claim": "false",
+    "lightweight.claim": "false"
+  }
+}
+EOF
+)
+
+if [ -z "$MAPPER_ID" ]; then
+  api POST "/${REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models" \
+    -d "$MAPPER_BODY" >/dev/null
+else
+  api PUT "/${REALM}/client-scopes/${SCOPE_ID}/protocol-mappers/models/${MAPPER_ID}" \
+    -d "$(echo "$MAPPER_BODY" | jq --arg id "$MAPPER_ID" '. + {id:$id}')" >/dev/null
+fi
+
+# Step 3c — UI: Realm Settings → Client Scopes → Default → add "atryum:mcp"
+#   (makes every client automatically get this scope as a default scope, so
+#    its mappers and `scope` claim entry are emitted on every token)
+log "Adding '${SCOPE_NAME}' to realm default scopes..."
+api PUT "/${REALM}/default-default-client-scopes/${SCOPE_ID}" >/dev/null
+
+# Step 4 — UI: Clients → Create client
+#   Client ID: atryum
+#   Client authentication: ON  (confidential)
+#   Authentication flow: Service accounts roles → ON
+#   Valid redirect URIs: http://localhost:8080/*
+log "Ensuring confidential client '${CLIENT_ID}'..."
+ATRYUM_UUID=$(api GET "/${REALM}/clients?clientId=${CLIENT_ID}" | jq -r '.[0].id // empty')
+
+CLIENT_BODY=$(cat <<EOF
+{
+  "clientId": "${CLIENT_ID}",
+  "enabled": true,
+  "protocol": "openid-connect",
+  "publicClient": false,
+  "serviceAccountsEnabled": true,
+  "standardFlowEnabled": true,
+  "directAccessGrantsEnabled": false,
+  "redirectUris": ["${REDIRECT_URI}"],
+  "attributes": {
+    "oauth2.device.authorization.grant.enabled": "false"
+  }
+}
+EOF
+)
+
+if [ -z "$ATRYUM_UUID" ]; then
+  api POST "/${REALM}/clients" -d "$CLIENT_BODY" >/dev/null
+  ATRYUM_UUID=$(api GET "/${REALM}/clients?clientId=${CLIENT_ID}" | jq -r '.[0].id')
+else
+  api PUT "/${REALM}/clients/${ATRYUM_UUID}" \
+    -d "$(echo "$CLIENT_BODY" | jq --arg id "$ATRYUM_UUID" '. + {id:$id}')" >/dev/null
+fi
+
+# Fetch and display the client secret (needed for client_credentials grant)
+SECRET=$(api GET "/${REALM}/clients/${ATRYUM_UUID}/client-secret" | jq -r .value)
+
+# Step 5 — UI: Clients → Client Registration → Client Registration Policies
+#   Under "Anonymous" policies:
+#     - DELETE "Trusted Hosts"  (blocks DCR from non-listed hosts; too
+#       restrictive for agents that can come from any IP — safe to remove
+#       in dev, but in production prefer to whitelist agent IP ranges)
+log "Removing 'Trusted Hosts' anonymous DCR policy..."
+TRUSTED_ID=$(api GET "/${REALM}/components?type=org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" \
+  | jq -r '.[] | select(.name=="Trusted Hosts" and .subType=="anonymous") | .id')
+if [ -n "$TRUSTED_ID" ]; then
+  api DELETE "/${REALM}/components/${TRUSTED_ID}" >/dev/null
+else
+  log "  (already removed)"
+fi
+
+# Step 5b — UI: same screen → click "Allowed Client Scopes" (anonymous)
+#   Enable "Allow Default Scopes": ON
+#   Allowed Client Scopes: openid, atryum:mcp, offline_access, profile, email
+#     (openid and offline_access aren't realm-default scopes, so they're
+#      blocked unless listed here — MCP SDKs request all five during DCR)
+log "Updating 'Allowed Client Scopes' anonymous DCR policy..."
+ALLOWED_ID=$(api GET "/${REALM}/components?type=org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" \
+  | jq -r '.[] | select(.name=="Allowed Client Scopes" and .subType=="anonymous") | .id')
+
+if [ -z "$ALLOWED_ID" ]; then
+  warn "Allowed Client Scopes (anonymous) not found — skipping. DCR may fail."
+else
+  PARENT_ID=$(api GET "/${REALM}/components/${ALLOWED_ID}" | jq -r .parentId)
+  api PUT "/${REALM}/components/${ALLOWED_ID}" -d "$(cat <<EOF
+{
+  "id": "${ALLOWED_ID}",
+  "name": "Allowed Client Scopes",
+  "providerId": "allowed-client-templates",
+  "providerType": "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy",
+  "parentId": "${PARENT_ID}",
+  "subType": "anonymous",
+  "config": {
+    "allow-default-scopes": ["true"],
+    "allowed-client-scopes": ["openid", "${SCOPE_NAME}", "profile", "email"]
+  }
+}
+EOF
+)" >/dev/null
+fi
+
+# Step 5c — Delete the realm's `offline_access` client scope.
+# WHY: Claude Code's MCP SDK auto-appends `offline_access` to its
+# authorization request whenever the AS advertises it in `scopes_supported`
+# (see https://code.claude.com/docs/en/mcp#restrict-oauth-scopes). Keycloak's
+# DCR doesn't auto-merge realm defaults when the SDK supplies a `scope`
+# field, so the DCR-registered client never has `offline_access` assigned,
+# and the auth endpoint rejects with `Invalid scopes: atryum:mcp
+# offline_access`. Deleting the scope from the realm removes it from
+# `scopes_supported`, so Claude Code no longer appends it and the auth
+# request becomes `scope=atryum:mcp` — which works. Refresh tokens still
+# work in their default (non-offline) form. Codex doesn't request
+# offline_access at all, so this isn't needed for Codex but doesn't hurt.
+# UI equivalent: Client Scopes → offline_access → "Delete".
+log "Removing 'offline_access' client scope from realm..."
+OFFLINE_ID=$(api GET "/${REALM}/client-scopes" \
+  | jq -r '.[] | select(.name=="offline_access") | .id' | head -1)
+if [ -n "$OFFLINE_ID" ]; then
+  api DELETE "/${REALM}/client-scopes/${OFFLINE_ID}" >/dev/null
+else
+  log "  (already removed)"
+fi
+
+# Step 6 — UI: Users → Add user
+#   Username: user
+#   Email: user@example.com (Email verified: ON to skip verify-email flow)
+#   First name: Test, Last name: User
+#   After save → Credentials tab → Set password: "password", Temporary: OFF
+log "Ensuring default user 'user'..."
+USER_BODY='{
+  "username": "user",
+  "enabled": true,
+  "emailVerified": true,
+  "email": "user@example.com",
+  "firstName": "Test",
+  "lastName": "User"
+}'
+USER_ID=$(api GET "/${REALM}/users?username=user&exact=true" | jq -r '.[0].id // empty')
+if [ -z "$USER_ID" ]; then
+  api POST "/${REALM}/users" \
+    -d "$(echo "$USER_BODY" | jq '. + {credentials:[{type:"password",value:"password",temporary:false}]}')" >/dev/null
+  USER_ID=$(api GET "/${REALM}/users?username=user&exact=true" | jq -r '.[0].id')
+else
+  # Patch profile fields and reset the password (idempotent on re-run).
+  api PUT "/${REALM}/users/${USER_ID}" \
+    -d "$(echo "$USER_BODY" | jq --arg id "$USER_ID" '. + {id:$id}')" >/dev/null
+  api PUT "/${REALM}/users/${USER_ID}/reset-password" \
+    -d '{"type":"password","value":"password","temporary":false}' >/dev/null
+fi
+
+printf "\n\033[1;32m✔ Realm '%s' is set up.\033[0m\n" "${REALM}"
+cat <<EOF
+
+  Issuer:        ${KC_URL}/realms/${REALM}
+  Confidential client:
+    client_id:     ${CLIENT_ID}
+    client_secret: ${SECRET}
+    grant:         client_credentials  (scope=${SCOPE_NAME})
+
+  MCP clients can also self-register via Dynamic Client Registration at:
+    ${KC_URL}/realms/${REALM}/clients-registrations/openid-connect
+
+  Default user (for browser-based authorization-code flows):
+    username: user
+    password: password
+
+  Atryum config (atryum.toml):
+    [[auth]]
+    issuer         = "http://keycloak:8088/realms/${REALM}"   # use docker hostname
+    audience       = "${AUDIENCE}"
+    required_scope = "${SCOPE_NAME}"
+    agent_id_claim = "client_id"
+
+EOF


### PR DESCRIPTION
## Summary

This PR expands Atryum’s OAuth support and dev environment setup across multiple areas:

- Adds support for pre-shared OAuth client credentials in upstream config, useful for providers that do not support Dynamic Client Registration (slack!)
- Improves Streamable HTTP MCP session initialization, tracking `Mcp-Session-Id`, and sending initialized notifications (shortcut!)
- Fixes use of stored OAuth access tokens for MCP upstreams (github!)
- Distinguish requested OAuth scopes from granted scopes, with a default-scopes option for provider-managed scope grants
- Adds `public_base_url` support for stable OAuth redirect URI generation behind the Vite dev proxy or ingress; needed for docker containers to know where to redirect after auth
- Expands the Docker Compose dev profile with Keycloak provisioning, frontend dependency caching, and updated `just` commands so we can run all this stuff in docker now

## Notes

Includes an idempotent Keycloak setup script that provisions the local `atryum` realm, client scope, audience mapper, confidential client, DCR policy adjustments, and a default test user. This allows us to authenticate with DCR to localhost:8088 as `user`/`password`
