### PR TITLE
Only return protected resource metadata when mcp auth is on

### DIFF
--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -246,3 +246,14 @@ func TestMCPNoValidatorPreservesAnonymousAccess(t *testing.T) {
 		t.Fatalf("expected 200 anonymous, got %d", w.Code)
 	}
 }
+
+func TestProtectedResourceMetadataNotServedWhenAuthDisabled(t *testing.T) {
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	req.Host = "atryum.example"
+	w := httptest.NewRecorder()
+	h.Routes().ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when auth disabled, got %d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -281,7 +281,9 @@ func (h *Handler) protectedResourceMetadata() http.Handler {
 func (h *Handler) Routes() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", h.healthz)
-	mux.Handle("/.well-known/oauth-protected-resource", h.protectedResourceMetadata())
+	if h.authValidator != nil {
+		mux.Handle("/.well-known/oauth-protected-resource", h.protectedResourceMetadata())
+	}
 	mcpHandler := auth.MiddlewareWithOptions(h.authValidator, "/.well-known/oauth-protected-resource", auth.MiddlewareOptions{SkipVerify: h.authDebugSkip, DebugLogIdentity: h.debug})(http.HandlerFunc(h.invokeUpstream))
 	mux.Handle("/mcp/", mcpHandler)
 	mux.HandleFunc("/api/v1/invocations", h.invocations)


### PR DESCRIPTION
When #18 added oauth for mcp clients, returning the oauth protected resource endpoint means that agent harnesses expect to enter the oauth flow, but no authentication servers are offered.

This disables that endpoint if the `[[auth]]` block is omitted from the config so we can still turn auth off if we want. We should probably NOT be able to do this in the future.