### PR TITLE
feat: AI Evaluation LLM-as-judge rule type and agent sync from ValidMind backend

### DIFF
--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -25,6 +25,15 @@ machine_key = ""
 machine_secret = ""
 connection_timeout_seconds = 5
 
+# Optional agent sync configuration. When base_url is set in [backend] and
+# both org_cuid and record_type_cuid are provided, Atryum fetches all active
+# inventory models (agents) for that org + primary record type at startup and
+# prints their cuid, name, description, and agent_ids (from agent_ids_field_name).
+#
+# [agent_sync]
+# org_cuid = ""
+# agent_record_type_slug = ""
+
 [defaults]
 request_timeout_seconds = 30
 

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -37,6 +37,15 @@ connection_timeout_seconds = 5
 [defaults]
 request_timeout_seconds = 30
 
+# AI Evaluation rule type configuration.
+# When an approval rule uses the "ai_evaluation" action, Atryum calls the
+# ValidMind backend to have the LLM evaluate whether to approve or deny the
+# tool call. The constitution is fetched from the agent's VM inventory model
+# custom fields using the key below.
+#
+# [ai_evaluation]
+# constitution_field_key = "constitution"
+
 # Local-only auth debug mode. When true, the Authorization header is ignored
 # entirely on /mcp/: no bearer token is required and no identity is set on
 # the request context. Never enable outside local debugging.

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -194,7 +194,7 @@ func (a *agentsLookupAdapter) GetByAgentID(ctx context.Context, agentID string) 
 	if err != nil {
 		return invocation.AgentRecord{}, err
 	}
-	return invocation.AgentRecord{ID: rec.ID, VMCUID: rec.VMCUID}, nil
+	return invocation.AgentRecord{ID: rec.ID, VMCUID: rec.VMCUID, VMOrganizationCUID: rec.VMOrganizationCUID}, nil
 }
 
 // evaluatorAdapter bridges backendclient.Client → invocation.EvaluatorClient.
@@ -205,6 +205,7 @@ type evaluatorAdapter struct {
 func (e *evaluatorAdapter) EvaluateToolCall(ctx context.Context, req invocation.EvaluateRequest) (invocation.EvaluateResponse, error) {
 	resp, err := e.client.EvaluateToolCall(ctx, backendclient.EvaluateRequest{
 		ModelConfigCUID:      req.ModelConfigCUID,
+		OrgCUID:              req.OrgCUID,
 		AgentVMCUID:          req.AgentVMCUID,
 		ConstitutionFieldKey: req.ConstitutionFieldKey,
 		ServerName:           req.ServerName,

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -125,7 +125,18 @@ func main() {
 	}
 	log.Printf("policy provider: %s", policyRegistry.Active().DisplayName())
 
-	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo)
+	// Wrap store and backend client in thin adapters that satisfy the
+	// invocation package interfaces without creating import cycles.
+	var invAgents invocation.AgentLookup
+	if agentsRepo != nil {
+		invAgents = &agentsLookupAdapter{repo: agentsRepo}
+	}
+	var invEvaluator invocation.EvaluatorClient
+	if backendClient != nil {
+		invEvaluator = &evaluatorAdapter{client: backendClient}
+	}
+
+	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo, invAgents, invEvaluator, cfg.AIEvaluation.ConstitutionFieldKey)
 	serverAdmin := api.NewServerAdminService(serverRepo, oauthRepo, client, 5*time.Second)
 	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo, agentsRepo, syncAgents, backendClient)
 
@@ -165,6 +176,40 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = srv.Shutdown(shutdownCtx)
+}
+
+// agentsLookupAdapter bridges store.AgentsRepo → invocation.AgentLookup.
+type agentsLookupAdapter struct {
+	repo *store.AgentsRepo
+}
+
+func (a *agentsLookupAdapter) GetByAgentID(ctx context.Context, agentID string) (invocation.AgentRecord, error) {
+	rec, err := a.repo.GetByAgentID(ctx, agentID)
+	if err != nil {
+		return invocation.AgentRecord{}, err
+	}
+	return invocation.AgentRecord{ID: rec.ID, VMCUID: rec.VMCUID}, nil
+}
+
+// evaluatorAdapter bridges backendclient.Client → invocation.EvaluatorClient.
+type evaluatorAdapter struct {
+	client *backendclient.Client
+}
+
+func (e *evaluatorAdapter) EvaluateToolCall(ctx context.Context, req invocation.EvaluateRequest) (invocation.EvaluateResponse, error) {
+	resp, err := e.client.EvaluateToolCall(ctx, backendclient.EvaluateRequest{
+		ModelConfigCUID:      req.ModelConfigCUID,
+		AgentVMCUID:          req.AgentVMCUID,
+		ConstitutionFieldKey: req.ConstitutionFieldKey,
+		ServerName:           req.ServerName,
+		ToolName:             req.ToolName,
+		ToolArgs:             req.ToolArgs,
+		Context:              req.Context,
+	})
+	if err != nil {
+		return invocation.EvaluateResponse{}, err
+	}
+	return invocation.EvaluateResponse{Approved: resp.Approved, Reason: resp.Reason}, nil
 }
 
 func truthyEnv(name string) bool {

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -3,12 +3,15 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/google/uuid"
 
 	"atryum/internal/api"
 	"atryum/internal/auth"
@@ -60,6 +63,47 @@ func main() {
 	serverRepo := store.NewServerRepoWithDialect(db, dialect)
 	oauthRepo := store.NewOAuthRepoWithDialect(db, dialect)
 	rulesRepo := store.NewRulesRepoWithDialect(db, dialect)
+	agentsRepo := store.NewAgentsRepoWithDialect(db, dialect)
+
+	// syncAgents is the shared sync function used both at startup and via the
+	// admin API POST /api/v1/admin/agents/sync endpoint.
+	syncAgents := func(ctx context.Context) error {
+		if backendClient == nil {
+			return fmt.Errorf("backend not configured")
+		}
+		if cfg.AgentSync.OrgCUID == "" || cfg.AgentSync.AgentRecordTypeSlug == "" {
+			return fmt.Errorf("agent_sync org_cuid and agent_record_type_slug must be set")
+		}
+		agentsResp, err := backendClient.FetchAgents(ctx, cfg.AgentSync.OrgCUID, cfg.AgentSync.AgentRecordTypeSlug)
+		if err != nil {
+			return fmt.Errorf("fetch agents: %w", err)
+		}
+		log.Printf("agent sync: fetched %d agent(s) for org=%s (%s) record_type=%s", agentsResp.Total, agentsResp.OrgCUID, agentsResp.OrgName, cfg.AgentSync.AgentRecordTypeSlug)
+		syncedAt := time.Now().UTC()
+		for _, a := range agentsResp.Results {
+			description, _ := a.CustomFields["description"].(string)
+			log.Printf("  agent cuid=%s name=%q description=%q", a.CUID, a.Name, description)
+			if upsertErr := agentsRepo.Upsert(ctx, store.AgentRecord{
+				ID:                 uuid.NewString(),
+				VMOrganizationCUID: agentsResp.OrgCUID,
+				VMOrganizationName: agentsResp.OrgName,
+				VMCUID:             a.CUID,
+				VMName:             a.Name,
+				VMDescription:      description,
+				Enabled:            true,
+				SyncedAt:           syncedAt,
+			}); upsertErr != nil {
+				log.Printf("  agent sync upsert failed for cuid=%s: %v", a.CUID, upsertErr)
+			}
+		}
+		return nil
+	}
+
+	if backendClient != nil && cfg.AgentSync.OrgCUID != "" && cfg.AgentSync.AgentRecordTypeSlug != "" {
+		if err := syncAgents(context.Background()); err != nil {
+			log.Printf("agent sync failed: %v", err)
+		}
+	}
 	resolver := mcp.NewResolver(serverRepo, cfg)
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
 		log.Fatalf("bootstrap servers: %v", err)
@@ -83,7 +127,7 @@ func main() {
 
 	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo)
 	serverAdmin := api.NewServerAdminService(serverRepo, oauthRepo, client, 5*time.Second)
-	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo)
+	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo, agentsRepo, syncAgents)
 
 	authValidator, err := auth.NewValidator(cfg.Auth, nil)
 	if err != nil {

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -127,7 +127,7 @@ func main() {
 
 	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo)
 	serverAdmin := api.NewServerAdminService(serverRepo, oauthRepo, client, 5*time.Second)
-	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo, agentsRepo, syncAgents)
+	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo, agentsRepo, syncAgents, backendClient)
 
 	authValidator, err := auth.NewValidator(cfg.Auth, nil)
 	if err != nil {

--- a/docs/testing/ai-evaluation.md
+++ b/docs/testing/ai-evaluation.md
@@ -1,0 +1,116 @@
+# Manual Testing: AI Evaluation (LLM-as-Judge)
+
+This guide walks through manually testing the AI Evaluation rule type end-to-end using the Atryum UI and a live ValidMind backend.
+
+---
+
+## Prerequisites
+
+- Atryum running locally (or accessible)
+- A ValidMind backend with at least one org, an `ai-agents` (or equivalent) record type, and one or more Inventory Model records representing agents
+- An identity provider (e.g. Auth0) configured as your `[[auth]]` issuer
+- Machine-user credentials for the ValidMind backend
+
+---
+
+## Step 1 — Configure `atryum.toml`
+
+You need three sections populated: `[[auth]]`, `[agent_sync]`, and `[ai_evaluation]`.
+
+```toml
+# Validates bearer tokens issued by your IDP.
+# Add one [[auth]] block per issuer you want to accept.
+[[auth]]
+enabled        = true
+issuer         = "https://your-tenant.us.auth0.com/"
+audience       = "https://api.your-validmind-instance.ai"
+# jwks_url is optional — omit to use OIDC discovery
+# jwks_url     = "https://your-tenant.us.auth0.com/.well-known/jwks.json"
+required_scope = ""
+agent_id_claim = "sub"   # claim that carries the agent's unique identity
+
+# Fetches active Inventory Model records from the backend at startup.
+[agent_sync]
+org_cuid               = "<your-org-cuid>"          # e.g. cl1gr2aiu000309ih76g9cvix
+agent_record_type_slug = "ai-agents"                # primary record type slug in VM
+
+# Tells Atryum which custom field on the Inventory Model holds the constitution.
+[ai_evaluation]
+constitution_field_key = "constitution"
+```
+
+> **Where to find `org_cuid`:** In ValidMind, go to **Settings → Organization** and copy the CUID shown in the URL or organization details.
+
+---
+
+## Step 2 — Restart Atryum
+
+Stop and restart the Atryum server. On startup it will:
+
+1. Verify the backend connection using your machine-user credentials.
+2. Fetch all active Inventory Model records for the configured org and record type slug.
+3. Log each fetched agent: `agent cuid=… name="…" description="…"`.
+
+Confirm the agents appear in the startup log before proceeding.
+
+---
+
+## Step 3 — Create a User Identity in the IDP
+
+In your identity provider (e.g. Auth0):
+
+1. Create a new **user** (e.g. via **User Management → Users → Create User**).
+2. Note the user's **ID** (the `sub` claim in the issued JWT) — this is the value Atryum will receive in the `agent_id_claim` field (`sub` by default).
+
+---
+
+## Step 4 — Link the User to an Agent in Atryum
+
+1. Open the Atryum UI and navigate to **Agents**.
+2. Find the agent record that corresponds to the Inventory Model you want to test.
+3. Click the agent to open it, then paste the **user ID** (`sub` value) from Step 3 into the **Agent IDs** field.
+4. Save.
+
+Atryum will now recognise bearer tokens issued for that user as belonging to this agent, enabling constitution lookup and org cross-validation when an AI Evaluation rule fires.
+
+---
+
+## Step 5 — Create an AI Evaluation Approval Rule
+
+1. In the Atryum UI, go to **Approval Rules** and click **New Rule**.
+2. Fill in the rule:
+
+   | Field | Value |
+   |---|---|
+   | **Action** | `AI Evaluation` |
+   | **Agent** | Select the agent you linked in Step 4 |
+   | **Model Configuration** | Select the LLM model config to use for evaluation |
+   | **Server** (optional) | Restrict to a specific MCP server, or leave blank for all |
+   | **Tool** (optional) | Restrict to a specific tool name, or leave blank for all |
+
+3. Save the rule.
+
+---
+
+## Step 6 — Trigger an Invocation and Observe the Evaluation
+
+Send a tool call through Atryum using a bearer token issued for the agent identity created in Step 3. The flow is:
+
+1. Atryum receives the invocation and matches it to the AI Evaluation rule.
+2. It resolves the agent's Inventory Model CUID and org CUID from the stored record.
+3. It calls `POST /internal/v1/atryum/evaluate` on the ValidMind backend with the agent details, constitution field key, and tool call context.
+4. The backend fetches the constitution from the Inventory Model's custom fields, builds a prompt, and asks the configured LLM to approve or deny.
+5. Atryum receives `{ approved, reason }` and either auto-approves (executes the tool) or auto-denies (returns an error to the caller).
+
+In the Atryum UI, open **Invocations** to see the outcome and the disposition reason logged against the invocation.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| No agents in startup log | `org_cuid` or `agent_record_type_slug` is wrong, or backend credentials are incorrect |
+| Rule never matches | Agent IDs field is empty, the user's `sub` doesn't match `agent_id_claim`, or the bearer token is not being sent by the agent |
+| Evaluation falls back to `human_approval` | `constitution_field_key` doesn't match the custom field name in VM, or the LLM call failed (check logs) |
+| 403 from `/evaluate` | `org_cuid` in the request doesn't match the agent's organization in ValidMind |

--- a/docs/testing/ai-evaluation.md
+++ b/docs/testing/ai-evaluation.md
@@ -38,9 +38,6 @@ agent_record_type_slug = "ai-agents"                # primary record type slug i
 [ai_evaluation]
 constitution_field_key = "constitution"
 ```
-
-> **Where to find `org_cuid`:** In ValidMind, go to **Settings → Organization** and copy the CUID shown in the URL or organization details.
-
 ---
 
 ## Step 2 — Restart Atryum
@@ -77,7 +74,7 @@ Atryum will now recognise bearer tokens issued for that user as belonging to thi
 
 ## Step 5 — Create an AI Evaluation Approval Rule
 
-1. In the Atryum UI, go to **Approval Rules** and click **New Rule**.
+1. In the Atryum UI, go to **Rules** and click **New Rule**.
 2. Fill in the rule:
 
    | Field | Value |

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -92,7 +92,7 @@ func defaultClaims() jwt.MapClaims {
 
 func newAuthedHandler(t *testing.T, svc service, rig *authTestRig) http.Handler {
 	t.Helper()
-	h := NewHandler(svc, stubServerService{}, nil, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil)
 	h.SetAuthValidator(rig.v)
 	return h.Routes()
 }
@@ -238,7 +238,7 @@ func TestProtectedResourceMetadataServed(t *testing.T) {
 
 // Sanity: when no validator is configured, /mcp/ behaves as before.
 func TestMCPNoValidatorPreservesAnonymousAccess(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -248,7 +248,7 @@ func TestMCPNoValidatorPreservesAnonymousAccess(t *testing.T) {
 }
 
 func TestProtectedResourceMetadataNotServedWhenAuthDisabled(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
 	req.Host = "atryum.example"
 	w := httptest.NewRecorder()

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"atryum/internal/auth"
+	backendclient "atryum/internal/backend"
 	"atryum/internal/invocation"
 	"atryum/internal/invocation/policy"
 	"atryum/internal/mcp"
@@ -75,17 +76,18 @@ type agentsRepo interface {
 }
 
 type Handler struct {
-	svc            service
-	serverSvc      serverService
-	policyRegistry *policy.Registry
-	rulesRepo      rulesRepo
-	agentsRepo     agentsRepo
-	syncAgentsFn   func(ctx context.Context) error
-	forwarder      mcpEnvelopeForwarder
-	staticHTTP     http.Handler
-	debug          bool
-	authDebugSkip  bool
-	authValidator  *auth.Validator
+	svc             service
+	serverSvc       serverService
+	policyRegistry  *policy.Registry
+	rulesRepo       rulesRepo
+	agentsRepo      agentsRepo
+	backendClient   *backendclient.Client
+	syncAgentsFn    func(ctx context.Context) error
+	forwarder       mcpEnvelopeForwarder
+	staticHTTP      http.Handler
+	debug           bool
+	authDebugSkip   bool
+	authValidator   *auth.Validator
 }
 
 type PolicyStatusResponse struct {
@@ -193,25 +195,40 @@ type OAuthConnectStatusResponse struct {
 // ─── Rules ───────────────────────────────────────────────────────────────────
 
 type AdminRule struct {
-	ID             string    `json:"id"`
-	Action         string    `json:"action"`
-	ServerPatterns []string  `json:"server_patterns"`
-	ToolPatterns   []string  `json:"tool_patterns"`
-	AgentIDPattern string    `json:"agent_id_pattern"`
-	Description    string    `json:"description,omitempty"`
-	Enabled        bool      `json:"enabled"`
-	Order          int       `json:"order"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	ID              string    `json:"id"`
+	Action          string    `json:"action"`
+	ServerPatterns  []string  `json:"server_patterns"`
+	ToolPatterns    []string  `json:"tool_patterns"`
+	AgentIDPattern  string    `json:"agent_id_pattern"`
+	ModelConfigCUID string    `json:"model_config_cuid,omitempty"`
+	AgentCUIDs      []string  `json:"agent_cuids"`
+	Description     string    `json:"description,omitempty"`
+	Enabled         bool      `json:"enabled"`
+	Order           int       `json:"order"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 type AdminRuleInput struct {
-	Action         string   `json:"action"`
-	ServerPatterns []string `json:"server_patterns"`
-	ToolPatterns   []string `json:"tool_patterns"`
-	AgentIDPattern string   `json:"agent_id_pattern"`
-	Description    string   `json:"description,omitempty"`
-	Enabled        *bool    `json:"enabled,omitempty"`
+	Action          string   `json:"action"`
+	ServerPatterns  []string `json:"server_patterns"`
+	ToolPatterns    []string `json:"tool_patterns"`
+	AgentIDPattern  string   `json:"agent_id_pattern"`
+	ModelConfigCUID string   `json:"model_config_cuid,omitempty"`
+	AgentCUIDs      []string `json:"agent_cuids"`
+	Description     string   `json:"description,omitempty"`
+	Enabled         *bool    `json:"enabled,omitempty"`
+}
+
+// AdminModelConfig is the API representation of a VM agent model configuration.
+type AdminModelConfig struct {
+	CUID string `json:"cuid"`
+	Name string `json:"name"`
+}
+
+type ModelConfigListResponse struct {
+	Items []AdminModelConfig `json:"items"`
+	Total int                `json:"total"`
 }
 
 type RuleListResponse struct {
@@ -286,7 +303,7 @@ type invocationStreamEnvelope struct {
 	Items []invocation.InvocationResponse `json:"items"`
 }
 
-func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Registry, rules rulesRepo, agents agentsRepo, syncAgents func(ctx context.Context) error) *Handler {
+func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Registry, rules rulesRepo, agents agentsRepo, syncAgents func(ctx context.Context) error, bc *backendclient.Client) *Handler {
 	staticSub, err := fs.Sub(webFS, "web")
 	if err != nil {
 		panic(err)
@@ -296,7 +313,7 @@ func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Reg
 	if f, ok := svc.(mcpEnvelopeForwarder); ok {
 		forwarder = f
 	}
-	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, agentsRepo: agents, syncAgentsFn: syncAgents, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
+	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, agentsRepo: agents, backendClient: bc, syncAgentsFn: syncAgents, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
 }
 
 // SetAuthValidator installs the inbound auth validator. When non-nil, the
@@ -337,6 +354,7 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/admin/rules/", h.adminRuleDetail)
 	mux.HandleFunc("/api/v1/admin/agents", h.adminAgents)
 	mux.HandleFunc("/api/v1/admin/agents/", h.adminAgentDetail)
+	mux.HandleFunc("/api/v1/admin/model-configs", h.adminModelConfigs)
 	mux.HandleFunc("/api/v1/admin/oauth/callback", h.oauthCallback)
 	mux.HandleFunc("/api/v1/admin/policy", h.adminPolicy)
 	mux.HandleFunc("/api/v1/external/invocations", h.externalInvocations)
@@ -705,13 +723,15 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 				enabled = *req.CreateRule.Enabled
 			}
 			newRule := store.Rule{
-				ID:             "rule_" + newUUID(),
-				Action:         req.CreateRule.Action,
-				ServerPatterns: normalizePatternSlice(req.CreateRule.ServerPatterns),
-				ToolPatterns:   normalizePatternSlice(req.CreateRule.ToolPatterns),
-				AgentIDPattern: defaultPattern(req.CreateRule.AgentIDPattern),
-				Description:    req.CreateRule.Description,
-				Enabled:        enabled,
+				ID:              "rule_" + newUUID(),
+				Action:          req.CreateRule.Action,
+				ServerPatterns:  normalizePatternSlice(req.CreateRule.ServerPatterns),
+				ToolPatterns:    normalizePatternSlice(req.CreateRule.ToolPatterns),
+				AgentIDPattern:  defaultPattern(req.CreateRule.AgentIDPattern),
+				ModelConfigCUID: req.CreateRule.ModelConfigCUID,
+				AgentCUIDs:      normalizePatternSlice(req.CreateRule.AgentCUIDs),
+				Description:     req.CreateRule.Description,
+				Enabled:         enabled,
 			}
 			if err := h.rulesRepo.InsertBefore(r.Context(), anchorID, newRule); err != nil {
 				writeError(w, http.StatusInternalServerError, err.Error())
@@ -753,13 +773,15 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 				enabled = *req.CreateRule.Enabled
 			}
 			newRule := store.Rule{
-				ID:             "rule_" + newUUID(),
-				Action:         req.CreateRule.Action,
-				ServerPatterns: normalizePatternSlice(req.CreateRule.ServerPatterns),
-				ToolPatterns:   normalizePatternSlice(req.CreateRule.ToolPatterns),
-				AgentIDPattern: defaultPattern(req.CreateRule.AgentIDPattern),
-				Description:    req.CreateRule.Description,
-				Enabled:        enabled,
+				ID:              "rule_" + newUUID(),
+				Action:          req.CreateRule.Action,
+				ServerPatterns:  normalizePatternSlice(req.CreateRule.ServerPatterns),
+				ToolPatterns:    normalizePatternSlice(req.CreateRule.ToolPatterns),
+				AgentIDPattern:  defaultPattern(req.CreateRule.AgentIDPattern),
+				ModelConfigCUID: req.CreateRule.ModelConfigCUID,
+				AgentCUIDs:      normalizePatternSlice(req.CreateRule.AgentCUIDs),
+				Description:     req.CreateRule.Description,
+				Enabled:         enabled,
 			}
 			if err := h.rulesRepo.InsertBefore(r.Context(), anchorID, newRule); err != nil {
 				writeError(w, http.StatusInternalServerError, err.Error())
@@ -1043,14 +1065,16 @@ func (h *Handler) adminRules(w http.ResponseWriter, r *http.Request) {
 			enabled = *req.Enabled
 		}
 		rule := store.Rule{
-			ID:             "rule_" + newUUID(),
-			Action:         req.Action,
-			ServerPatterns: normalizePatternSlice(req.ServerPatterns),
-			ToolPatterns:   normalizePatternSlice(req.ToolPatterns),
-			AgentIDPattern: defaultPattern(req.AgentIDPattern),
-			Description:    req.Description,
-			Enabled:        enabled,
-			Order:          order,
+			ID:              "rule_" + newUUID(),
+			Action:          req.Action,
+			ServerPatterns:  normalizePatternSlice(req.ServerPatterns),
+			ToolPatterns:    normalizePatternSlice(req.ToolPatterns),
+			AgentIDPattern:  defaultPattern(req.AgentIDPattern),
+			ModelConfigCUID: req.ModelConfigCUID,
+			AgentCUIDs:      normalizePatternSlice(req.AgentCUIDs),
+			Description:     req.Description,
+			Enabled:         enabled,
+			Order:           order,
 		}
 		if err := h.rulesRepo.Create(r.Context(), rule); err != nil {
 			writeError(w, http.StatusInternalServerError, err.Error())
@@ -1146,6 +1170,8 @@ func (h *Handler) adminRuleDetail(w http.ResponseWriter, r *http.Request) {
 		existing.ServerPatterns = normalizePatternSlice(req.ServerPatterns)
 		existing.ToolPatterns = normalizePatternSlice(req.ToolPatterns)
 		existing.AgentIDPattern = defaultPattern(req.AgentIDPattern)
+		existing.ModelConfigCUID = req.ModelConfigCUID
+		existing.AgentCUIDs = normalizePatternSlice(req.AgentCUIDs)
 		existing.Description = req.Description
 		existing.Enabled = enabled
 		if err := h.rulesRepo.Update(r.Context(), existing); err != nil {
@@ -1173,6 +1199,31 @@ func (h *Handler) adminRuleDetail(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ─── Model config handler ─────────────────────────────────────────────────────
+
+func (h *Handler) adminModelConfigs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if h.backendClient == nil {
+		writeError(w, http.StatusServiceUnavailable, "backend not configured")
+		return
+	}
+	resp, err := h.backendClient.FetchModelConfigs(r.Context())
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "failed to fetch model configs: "+err.Error())
+		return
+	}
+	items := make([]AdminModelConfig, 0, len(resp.Items))
+	for _, c := range resp.Items {
+		items = append(items, AdminModelConfig{CUID: c.CUID, Name: c.Name})
+	}
+	writeJSON(w, http.StatusOK, ModelConfigListResponse{Items: items, Total: len(items)})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 func toAdminRule(r store.Rule) AdminRule {
 	sp := r.ServerPatterns
 	if sp == nil {
@@ -1182,17 +1233,23 @@ func toAdminRule(r store.Rule) AdminRule {
 	if tp == nil {
 		tp = []string{}
 	}
+	ac := r.AgentCUIDs
+	if ac == nil {
+		ac = []string{}
+	}
 	return AdminRule{
-		ID:             r.ID,
-		Action:         r.Action,
-		ServerPatterns: sp,
-		ToolPatterns:   tp,
-		AgentIDPattern: r.AgentIDPattern,
-		Description:    r.Description,
-		Enabled:        r.Enabled,
-		Order:          r.Order,
-		CreatedAt:      r.CreatedAt,
-		UpdatedAt:      r.UpdatedAt,
+		ID:              r.ID,
+		Action:          r.Action,
+		ServerPatterns:  sp,
+		ToolPatterns:    tp,
+		AgentIDPattern:  r.AgentIDPattern,
+		ModelConfigCUID: r.ModelConfigCUID,
+		AgentCUIDs:      ac,
+		Description:     r.Description,
+		Enabled:         r.Enabled,
+		Order:           r.Order,
+		CreatedAt:       r.CreatedAt,
+		UpdatedAt:       r.UpdatedAt,
 	}
 }
 
@@ -1316,8 +1373,12 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 func validateRuleInput(req AdminRuleInput) error {
 	switch req.Action {
 	case "auto_approve", "auto_deny", "human_approval":
+	case "ai_evaluation":
+		if strings.TrimSpace(req.ModelConfigCUID) == "" {
+			return fmt.Errorf("model_config_cuid is required for ai_evaluation rules")
+		}
 	default:
-		return fmt.Errorf("action must be one of: auto_approve, auto_deny, human_approval")
+		return fmt.Errorf("action must be one of: auto_approve, auto_deny, human_approval, ai_evaluation")
 	}
 	return nil
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -67,11 +67,20 @@ type rulesRepo interface {
 	InsertBefore(ctx context.Context, anchorID string, rule store.Rule) error
 }
 
+type agentsRepo interface {
+	List(ctx context.Context) ([]store.AgentRecord, error)
+	Get(ctx context.Context, id string) (store.AgentRecord, error)
+	UpdateEnabled(ctx context.Context, id string, enabled bool) error
+	UpdateAgentIDs(ctx context.Context, id string, agentIDs string) error
+}
+
 type Handler struct {
 	svc            service
 	serverSvc      serverService
 	policyRegistry *policy.Registry
 	rulesRepo      rulesRepo
+	agentsRepo     agentsRepo
+	syncAgentsFn   func(ctx context.Context) error
 	forwarder      mcpEnvelopeForwarder
 	staticHTTP     http.Handler
 	debug          bool
@@ -209,6 +218,54 @@ type RuleListResponse struct {
 	Items []AdminRule `json:"items"`
 }
 
+// ─── Agent admin types ────────────────────────────────────────────────────────
+
+type AdminAgent struct {
+	CUID        string    `json:"cuid"`
+	OrgName     string    `json:"org_name"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	AgentIDs    []string  `json:"agent_ids"`
+	SyncedAt    time.Time `json:"synced_at"`
+	Enabled     bool      `json:"enabled"`
+}
+
+type AdminAgentInput struct {
+	Enabled  bool     `json:"enabled"`
+	AgentIDs []string `json:"agent_ids,omitempty"`
+}
+
+type AgentListResponse struct {
+	Items []AdminAgent `json:"items"`
+}
+
+func toAdminAgent(a store.AgentRecord) AdminAgent {
+	ids := parseAgentIDs(a.AgentIDs)
+	return AdminAgent{
+		CUID:        a.ID,
+		OrgName:     a.VMOrganizationName,
+		Name:        a.VMName,
+		Description: a.VMDescription,
+		AgentIDs:    ids,
+		SyncedAt:    a.SyncedAt,
+		Enabled:     a.Enabled,
+	}
+}
+
+func parseAgentIDs(raw string) []string {
+	if raw == "" {
+		return []string{}
+	}
+	var ids []string
+	if err := json.Unmarshal([]byte(raw), &ids); err != nil {
+		return []string{}
+	}
+	if ids == nil {
+		return []string{}
+	}
+	return ids
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 type jsonRPCRequest struct {
@@ -229,7 +286,7 @@ type invocationStreamEnvelope struct {
 	Items []invocation.InvocationResponse `json:"items"`
 }
 
-func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Registry, rules rulesRepo) *Handler {
+func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Registry, rules rulesRepo, agents agentsRepo, syncAgents func(ctx context.Context) error) *Handler {
 	staticSub, err := fs.Sub(webFS, "web")
 	if err != nil {
 		panic(err)
@@ -239,7 +296,7 @@ func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Reg
 	if f, ok := svc.(mcpEnvelopeForwarder); ok {
 		forwarder = f
 	}
-	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
+	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, agentsRepo: agents, syncAgentsFn: syncAgents, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
 }
 
 // SetAuthValidator installs the inbound auth validator. When non-nil, the
@@ -278,6 +335,8 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/admin/servers/", h.adminServerDetail)
 	mux.HandleFunc("/api/v1/admin/rules", h.adminRules)
 	mux.HandleFunc("/api/v1/admin/rules/", h.adminRuleDetail)
+	mux.HandleFunc("/api/v1/admin/agents", h.adminAgents)
+	mux.HandleFunc("/api/v1/admin/agents/", h.adminAgentDetail)
 	mux.HandleFunc("/api/v1/admin/oauth/callback", h.oauthCallback)
 	mux.HandleFunc("/api/v1/admin/policy", h.adminPolicy)
 	mux.HandleFunc("/api/v1/external/invocations", h.externalInvocations)
@@ -1143,6 +1202,116 @@ func normalizePatternSlice(s []string) []string {
 	}
 	return s
 }
+
+// ─── Agent handlers ───────────────────────────────────────────────────────────
+
+func (h *Handler) adminAgents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	records, err := h.agentsRepo.List(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	items := make([]AdminAgent, 0, len(records))
+	for _, a := range records {
+		items = append(items, toAdminAgent(a))
+	}
+	writeJSON(w, http.StatusOK, AgentListResponse{Items: items})
+}
+
+func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
+	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/agents/")
+	trimmed = strings.Trim(trimmed, "/")
+	if trimmed == "" {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	// POST /api/v1/admin/agents/sync — trigger a backend sync
+	if trimmed == "sync" {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		if h.syncAgentsFn == nil {
+			writeError(w, http.StatusServiceUnavailable, "agent sync not configured")
+			return
+		}
+		if err := h.syncAgentsFn(r.Context()); err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		records, err := h.agentsRepo.List(r.Context())
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		items := make([]AdminAgent, 0, len(records))
+		for _, a := range records {
+			items = append(items, toAdminAgent(a))
+		}
+		writeJSON(w, http.StatusOK, AgentListResponse{Items: items})
+		return
+	}
+
+	// PATCH /api/v1/admin/agents/:id — update enabled
+	id := trimmed
+	switch r.Method {
+	case http.MethodGet:
+		record, err := h.agentsRepo.Get(r.Context(), id)
+		if err != nil {
+			status := http.StatusInternalServerError
+			if err == sql.ErrNoRows {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, toAdminAgent(record))
+	case http.MethodPatch:
+		var req AdminAgentInput
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json")
+			return
+		}
+		if err := h.agentsRepo.UpdateEnabled(r.Context(), id, req.Enabled); err != nil {
+			status := http.StatusInternalServerError
+			if err == sql.ErrNoRows {
+				status = http.StatusNotFound
+			}
+			writeError(w, status, err.Error())
+			return
+		}
+		if req.AgentIDs != nil {
+			idsJSON, err := json.Marshal(req.AgentIDs)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to encode agent_ids")
+				return
+			}
+			if err := h.agentsRepo.UpdateAgentIDs(r.Context(), id, string(idsJSON)); err != nil {
+				status := http.StatusInternalServerError
+				if err == sql.ErrNoRows {
+					status = http.StatusNotFound
+				}
+				writeError(w, status, err.Error())
+				return
+			}
+		}
+		record, err := h.agentsRepo.Get(r.Context(), id)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, toAdminAgent(record))
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 func validateRuleInput(req AdminRuleInput) error {
 	switch req.Action {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -88,7 +88,7 @@ func (stubServerService) CompleteConnect(context.Context, string, string, string
 }
 
 func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("MCP-Protocol-Version", "2025-11-25")
@@ -113,7 +113,7 @@ func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 }
 
 func TestMCPInitializedNotificationReturnsAccepted(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}`))
 	w := httptest.NewRecorder()
 
@@ -126,7 +126,7 @@ func TestMCPInitializedNotificationReturnsAccepted(t *testing.T) {
 
 func TestMCPPingPassThrough(t *testing.T) {
 	svc := &stubService{upstream: mcp.Upstream{Name: "demo", Mode: mcp.UpstreamModeHTTP}, forward: mcp.ForwardResult{StatusCode: http.StatusOK, Body: []byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`), ContentType: "application/json", ProtocolVersion: "2025-11-25"}}
-	h := NewHandler(svc, stubServerService{}, nil, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping","params":{}}`))
 	w := httptest.NewRecorder()
 
@@ -142,7 +142,7 @@ func TestMCPPingPassThrough(t *testing.T) {
 
 func TestMCPUnknownNotificationPassThroughFallbackAccepted(t *testing.T) {
 	svc := &stubService{fwdErr: context.Canceled}
-	h := NewHandler(svc, stubServerService{}, nil, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/custom","params":{"x":1}}`))
 	w := httptest.NewRecorder()
 
@@ -154,7 +154,7 @@ func TestMCPUnknownNotificationPassThroughFallbackAccepted(t *testing.T) {
 }
 
 func TestMCPMalformedJSONReturnsParseError(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":`))
 	w := httptest.NewRecorder()
 
@@ -166,7 +166,7 @@ func TestMCPMalformedJSONReturnsParseError(t *testing.T) {
 }
 
 func TestMCPGetOpenSSEStream(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, "/mcp/demo", nil).WithContext(ctx)
 	w := httptest.NewRecorder()
@@ -187,7 +187,7 @@ func TestMCPGetOpenSSEStream(t *testing.T) {
 }
 
 func TestMCPDeleteReturn405(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodDelete, "/mcp/demo", nil)
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
@@ -197,7 +197,7 @@ func TestMCPDeleteReturn405(t *testing.T) {
 }
 
 func TestMCPToolsList(t *testing.T) {
-	h := NewHandler(&stubService{tools: []mcp.Tool{{Name: "demo_tool"}}}, stubServerService{}, nil, nil)
+	h := NewHandler(&stubService{tools: []mcp.Tool{{Name: "demo_tool"}}}, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
 	w := httptest.NewRecorder()
 
@@ -211,7 +211,7 @@ func TestMCPToolsList(t *testing.T) {
 func TestMCPToolsCallInterceptsInvocation(t *testing.T) {
 	now := time.Now().UTC()
 	svc := &stubService{invoke: invocation.InvocationResponse{InvocationID: "inv_123", ServerName: "demo", ToolName: "demo_tool", Status: invocation.StatusSucceeded, Input: json.RawMessage(`{"a":1}`), SubmittedAt: now, CompletedAt: &now, Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)}}
-	h := NewHandler(svc, stubServerService{}, nil, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"demo_tool","arguments":{"a":1}}}`))
 	w := httptest.NewRecorder()
 
@@ -234,7 +234,7 @@ func TestMCPToolsCallInterceptsInvocation(t *testing.T) {
 func TestAdminInvocationsResponsesIncludeServerToolAndInput(t *testing.T) {
 	now := time.Now().UTC()
 	svc := &stubService{invoke: invocation.InvocationResponse{InvocationID: "inv_123", ServerName: "demo-server", ToolName: "demo_tool", Status: invocation.StatusSucceeded, Input: json.RawMessage(`{"issue":123,"verbose":true}`), SubmittedAt: now, CompletedAt: &now}}
-	h := NewHandler(svc, stubServerService{}, nil, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil)
 
 	t.Run("list", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -13,11 +13,26 @@ import (
 )
 
 const connectionPath = "/internal/v1/atryum/connection"
+const agentsPath = "/internal/v1/atryum/agents"
 
 type ConnectionResponse struct {
 	OK              bool   `json:"ok"`
 	MachineUserCUID string `json:"machine_user_cuid"`
 	ServiceName     string `json:"service_name"`
+}
+
+// Agent represents an inventory model record returned by the backend.
+type Agent struct {
+	CUID         string         `json:"cuid"`
+	Name         string         `json:"name"`
+	CustomFields map[string]any `json:"custom_fields"`
+}
+
+type AgentsResponse struct {
+	OrgCUID string  `json:"org_cuid"`
+	OrgName string  `json:"org_name"`
+	Results []Agent `json:"results"`
+	Total   int     `json:"total"`
 }
 
 type Client struct {
@@ -45,6 +60,44 @@ func NewClient(cfg config.BackendConfig) (*Client, error) {
 		machineSecret: strings.TrimSpace(cfg.MachineSecret),
 		httpClient:    &http.Client{Timeout: time.Duration(cfg.ConnectionTimeoutSecs) * time.Second},
 	}, nil
+}
+
+// FetchAgents retrieves active inventory model agents from the backend for the
+// given org and primary record type slug. It returns an empty slice when the
+// backend returns zero results.
+func (c *Client) FetchAgents(ctx context.Context, orgCUID, agentRecordTypeSlug string) (AgentsResponse, error) {
+	u, err := url.Parse(c.baseURL + agentsPath)
+	if err != nil {
+		return AgentsResponse{}, fmt.Errorf("build agents URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("org_cuid", orgCUID)
+	q.Set("primary_record_type_slug", agentRecordTypeSlug)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return AgentsResponse{}, fmt.Errorf("build agents request: %w", err)
+	}
+	req.Header.Set("X-MACHINE-KEY", c.machineKey)
+	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return AgentsResponse{}, fmt.Errorf("call agents endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return AgentsResponse{}, fmt.Errorf("agents endpoint returned %s", resp.Status)
+	}
+
+	var payload AgentsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return AgentsResponse{}, fmt.Errorf("decode agents response: %w", err)
+	}
+	return payload, nil
 }
 
 func (c *Client) CheckConnection(ctx context.Context) (ConnectionResponse, error) {

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -15,6 +15,7 @@ import (
 const connectionPath = "/internal/v1/atryum/connection"
 const agentsPath = "/internal/v1/atryum/agents"
 const modelConfigsPath = "/internal/v1/atryum/model-configs"
+const evaluatePath = "/internal/v1/atryum/evaluate"
 
 type ConnectionResponse struct {
 	OK              bool   `json:"ok"`
@@ -136,6 +137,61 @@ func (c *Client) FetchModelConfigs(ctx context.Context) (ModelConfigsResponse, e
 	var payload ModelConfigsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return ModelConfigsResponse{}, fmt.Errorf("decode model-configs response: %w", err)
+	}
+	return payload, nil
+}
+
+// EvaluateRequest is sent to the VM backend to ask the LLM whether a tool
+// call should be approved or denied.
+type EvaluateRequest struct {
+	ModelConfigCUID      string         `json:"model_config_cuid"`
+	AgentVMCUID          string         `json:"agent_vm_cuid,omitempty"`
+	ConstitutionFieldKey string         `json:"constitution_field_key,omitempty"`
+	ServerName           string         `json:"server_name"`
+	ToolName             string         `json:"tool_name"`
+	ToolArgs             map[string]any `json:"tool_args,omitempty"`
+	Context              string         `json:"context,omitempty"`
+}
+
+// EvaluateResponse is the result returned by the VM backend after LLM evaluation.
+type EvaluateResponse struct {
+	Approved bool   `json:"approved"`
+	Reason   string `json:"reason"`
+}
+
+// EvaluateToolCall calls the VM backend's evaluate endpoint and returns whether
+// the tool call should be approved.
+func (c *Client) EvaluateToolCall(ctx context.Context, req EvaluateRequest) (EvaluateResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return EvaluateResponse{}, fmt.Errorf("marshal evaluate request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, c.baseURL+evaluatePath,
+		strings.NewReader(string(body)),
+	)
+	if err != nil {
+		return EvaluateResponse{}, fmt.Errorf("build evaluate request: %w", err)
+	}
+	httpReq.Header.Set("X-MACHINE-KEY", c.machineKey)
+	httpReq.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return EvaluateResponse{}, fmt.Errorf("call evaluate endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return EvaluateResponse{}, fmt.Errorf("evaluate endpoint returned %s", resp.Status)
+	}
+
+	var payload EvaluateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return EvaluateResponse{}, fmt.Errorf("decode evaluate response: %w", err)
 	}
 	return payload, nil
 }

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -95,6 +95,7 @@ func (c *Client) FetchAgents(ctx context.Context, orgCUID, agentRecordTypeSlug s
 	}
 	req.Header.Set("X-MACHINE-KEY", c.machineKey)
 	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	req.Header.Set("X-Org-CUID", orgCUID)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)
@@ -145,6 +146,7 @@ func (c *Client) FetchModelConfigs(ctx context.Context) (ModelConfigsResponse, e
 // call should be approved or denied.
 type EvaluateRequest struct {
 	ModelConfigCUID      string         `json:"model_config_cuid"`
+	OrgCUID              string         `json:"org_cuid,omitempty"`
 	AgentVMCUID          string         `json:"agent_vm_cuid,omitempty"`
 	ConstitutionFieldKey string         `json:"constitution_field_key,omitempty"`
 	ServerName           string         `json:"server_name"`
@@ -176,6 +178,9 @@ func (c *Client) EvaluateToolCall(ctx context.Context, req EvaluateRequest) (Eva
 	}
 	httpReq.Header.Set("X-MACHINE-KEY", c.machineKey)
 	httpReq.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	if req.OrgCUID != "" {
+		httpReq.Header.Set("X-Org-CUID", req.OrgCUID)
+	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json")
 

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -14,6 +14,7 @@ import (
 
 const connectionPath = "/internal/v1/atryum/connection"
 const agentsPath = "/internal/v1/atryum/agents"
+const modelConfigsPath = "/internal/v1/atryum/model-configs"
 
 type ConnectionResponse struct {
 	OK              bool   `json:"ok"`
@@ -33,6 +34,18 @@ type AgentsResponse struct {
 	OrgName string  `json:"org_name"`
 	Results []Agent `json:"results"`
 	Total   int     `json:"total"`
+}
+
+// ModelConfig represents a single agent model configuration returned by the backend.
+type ModelConfig struct {
+	CUID string `json:"cuid"`
+	Name string `json:"name"`
+}
+
+// ModelConfigsResponse is the response envelope for the model-configs endpoint.
+type ModelConfigsResponse struct {
+	Items []ModelConfig `json:"items"`
+	Total int           `json:"total"`
 }
 
 type Client struct {
@@ -96,6 +109,33 @@ func (c *Client) FetchAgents(ctx context.Context, orgCUID, agentRecordTypeSlug s
 	var payload AgentsResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return AgentsResponse{}, fmt.Errorf("decode agents response: %w", err)
+	}
+	return payload, nil
+}
+
+// FetchModelConfigs retrieves all agent model configurations from the backend.
+func (c *Client) FetchModelConfigs(ctx context.Context) (ModelConfigsResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+modelConfigsPath, nil)
+	if err != nil {
+		return ModelConfigsResponse{}, fmt.Errorf("build model-configs request: %w", err)
+	}
+	req.Header.Set("X-MACHINE-KEY", c.machineKey)
+	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return ModelConfigsResponse{}, fmt.Errorf("call model-configs endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ModelConfigsResponse{}, fmt.Errorf("model-configs endpoint returned %s", resp.Status)
+	}
+
+	var payload ModelConfigsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return ModelConfigsResponse{}, fmt.Errorf("decode model-configs response: %w", err)
 	}
 	return payload, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,17 +10,25 @@ import (
 )
 
 type Config struct {
-	Server    ServerConfig     `toml:"server"`
-	Backend   BackendConfig    `toml:"backend"`
-	AgentSync AgentSyncConfig  `toml:"agent_sync"`
-	Defaults  DefaultsConfig   `toml:"defaults"`
-	Policy    PolicyConfig     `toml:"policy"`
-	Upstreams []UpstreamConfig `toml:"upstreams"`
+	Server       ServerConfig       `toml:"server"`
+	Backend      BackendConfig      `toml:"backend"`
+	AgentSync    AgentSyncConfig    `toml:"agent_sync"`
+	AIEvaluation AIEvaluationConfig `toml:"ai_evaluation"`
+	Defaults     DefaultsConfig     `toml:"defaults"`
+	Policy       PolicyConfig       `toml:"policy"`
+	Upstreams    []UpstreamConfig   `toml:"upstreams"`
 	// Auth holds zero or more inbound OAuth bearer-token validators
 	// (e.g. one entry for Keycloak, one for Auth0). When empty, the agent-
 	// facing /mcp/ routes remain anonymous.
 	Auth      []auth.Config   `toml:"auth"`
 	AuthDebug AuthDebugConfig `toml:"auth_debug"`
+}
+
+// AIEvaluationConfig configures the AI Evaluation rule type.
+// ConstitutionFieldKey is the key in the VM inventory model's custom_fields
+// map that holds the agent's constitution (governing rules for LLM evaluation).
+type AIEvaluationConfig struct {
+	ConstitutionFieldKey string `toml:"constitution_field_key"`
 }
 
 // AgentSyncConfig configures startup agent (inventory model) fetching from the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 type Config struct {
 	Server    ServerConfig     `toml:"server"`
 	Backend   BackendConfig    `toml:"backend"`
+	AgentSync AgentSyncConfig  `toml:"agent_sync"`
 	Defaults  DefaultsConfig   `toml:"defaults"`
 	Policy    PolicyConfig     `toml:"policy"`
 	Upstreams []UpstreamConfig `toml:"upstreams"`
@@ -20,6 +21,14 @@ type Config struct {
 	// facing /mcp/ routes remain anonymous.
 	Auth      []auth.Config   `toml:"auth"`
 	AuthDebug AuthDebugConfig `toml:"auth_debug"`
+}
+
+// AgentSyncConfig configures startup agent (inventory model) fetching from the
+// ValidMind backend. All fields are optional; the fetch is skipped when either
+// OrgCUID or RecordTypeCUID is empty.
+type AgentSyncConfig struct {
+	OrgCUID             string `toml:"org_cuid"`
+	AgentRecordTypeSlug string `toml:"agent_record_type_slug"`
 }
 
 // BackendConfig configures Atryum's startup connection check to the ValidMind

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -65,7 +65,7 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	svc := invocation.NewService(
 		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
 		mcp.NewHTTPClient(), policy.AlwaysDenyProvider{}, // would deny if the rule didn't match
-		5*time.Second, rules,
+		5*time.Second, rules, nil, nil, "",
 	)
 
 	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-007", Issuer: "https://idp.test"})
@@ -148,7 +148,7 @@ func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 	svc := invocation.NewService(
 		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
 		mcp.NewHTTPClient(), policy.AlwaysDenyProvider{},
-		5*time.Second, rules,
+		5*time.Second, rules, nil, nil, "",
 	)
 
 	rid := "legacy-request-id"

--- a/internal/invocation/rules.go
+++ b/internal/invocation/rules.go
@@ -7,17 +7,24 @@ const (
 	RuleActionAutoApprove   = "auto_approve"
 	RuleActionAutoDeny      = "auto_deny"
 	RuleActionHumanApproval = "human_approval"
+	// RuleActionAIEvaluation routes the invocation to an LLM for automated
+	// accept/reject evaluation using the referenced model configuration.
+	// Until LLM wiring is implemented, matched invocations fall back to
+	// human_approval so no invocation is silently dropped.
+	RuleActionAIEvaluation = "ai_evaluation"
 )
 
 // ApprovalRule is the invocation-layer view of a configured rule.
 // It is intentionally decoupled from the store layer to avoid import cycles.
 type ApprovalRule struct {
-	ID             string   // unique rule identifier
-	Action         string   // one of the RuleAction* constants
-	ServerPatterns []string // empty slice = match any server
-	ToolPatterns   []string // empty slice = match any tool
-	AgentIDPattern string   // "*" or "" = match any agent
-	Enabled        bool
+	ID              string   // unique rule identifier
+	Action          string   // one of the RuleAction* constants
+	ServerPatterns  []string // empty slice = match any server
+	ToolPatterns    []string // empty slice = match any tool
+	AgentIDPattern  string   // "*" or "" = match any agent
+	ModelConfigCUID string   // VM agent model config to use for ai_evaluation rules
+	AgentCUIDs      []string // Atryum agent CUIDs this rule targets; empty = all
+	Enabled         bool
 }
 
 // rulesStore is the minimal interface the invocation service needs.
@@ -30,7 +37,8 @@ type rulesStore interface {
 // parameters, or nil if no rule matches (fall back to human approval).
 // The agentID is the authenticated agent identity (empty when auth is
 // disabled — callers fall back to request_id for parity with pre-auth behavior).
-func matchRule(rules []ApprovalRule, server, tool, agentID string) *ApprovalRule {
+// The agentCUID is the Atryum-local agent record CUID used by ai_evaluation rules.
+func matchRule(rules []ApprovalRule, server, tool, agentID, agentCUID string) *ApprovalRule {
 	for i := range rules {
 		r := &rules[i]
 		if !r.Enabled {
@@ -45,9 +53,25 @@ func matchRule(rules []ApprovalRule, server, tool, agentID string) *ApprovalRule
 		if !matchAgentIDPattern(r.AgentIDPattern, agentID) {
 			continue
 		}
+		if !matchAgentCUIDs(r.AgentCUIDs, agentCUID) {
+			continue
+		}
 		return r
 	}
 	return nil
+}
+
+// matchAgentCUIDs returns true when cuids is empty (match all) or contains agentCUID.
+func matchAgentCUIDs(cuids []string, agentCUID string) bool {
+	if len(cuids) == 0 {
+		return true
+	}
+	for _, c := range cuids {
+		if c == agentCUID {
+			return true
+		}
+	}
+	return false
 }
 
 // matchPatterns returns true when value matches any entry in patterns,

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -25,8 +25,9 @@ type AgentLookup interface {
 // AgentRecord is a lightweight copy of store.AgentRecord used within the
 // invocation package to avoid a circular import.
 type AgentRecord struct {
-	ID     string // local Atryum agent UUID (used for rule matching)
-	VMCUID string // VM inventory model CUID (used for constitution lookup)
+	ID                 string // local Atryum agent UUID (used for rule matching)
+	VMCUID             string // VM inventory model CUID (used for constitution lookup)
+	VMOrganizationCUID string // VM organization CUID (used for cross-tenant validation)
 }
 
 // EvaluatorClient is the minimal interface required by the invocation service
@@ -39,6 +40,7 @@ type EvaluatorClient interface {
 // not import the backend package directly.
 type EvaluateRequest struct {
 	ModelConfigCUID      string         `json:"model_config_cuid"`
+	OrgCUID              string         `json:"org_cuid,omitempty"`
 	AgentVMCUID          string         `json:"agent_vm_cuid,omitempty"`
 	ConstitutionFieldKey string         `json:"constitution_field_key,omitempty"`
 	ServerName           string         `json:"server_name"`
@@ -271,11 +273,14 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 		return policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: evaluator not configured (falling back to human_approval)"}
 	}
 
-	// Resolve the agent's VM CUID so the constitution can be fetched server-side.
+	// Resolve the agent's VM CUID and org CUID so the constitution can be
+	// fetched server-side and the request can be cross-validated against the org.
 	agentVMCUID := ""
+	orgCUID := ""
 	if s.agents != nil && agentID != "" {
 		if rec, err := s.agents.GetByAgentID(ctx, agentID); err == nil {
 			agentVMCUID = rec.VMCUID
+			orgCUID = rec.VMOrganizationCUID
 		} else {
 			slog.Warn("ai_evaluation: could not resolve agent VM CUID; proceeding without constitution",
 				"agent_id", agentID, "error", err)
@@ -288,6 +293,7 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 		"tool", toolName,
 		"agent_id", agentID,
 		"agent_vm_cuid", agentVMCUID,
+		"org_cuid", orgCUID,
 		"model_config_cuid", rule.ModelConfigCUID,
 		"constitution_field_key", s.constitutionFieldKey,
 	)
@@ -297,6 +303,7 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 
 	resp, err := s.evaluator.EvaluateToolCall(evalCtx, EvaluateRequest{
 		ModelConfigCUID:      rule.ModelConfigCUID,
+		OrgCUID:              orgCUID,
 		AgentVMCUID:          agentVMCUID,
 		ConstitutionFieldKey: s.constitutionFieldKey,
 		ServerName:           serverName,

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -14,6 +15,43 @@ import (
 	"atryum/internal/invocation/policy"
 	"atryum/internal/mcp"
 )
+
+// AgentLookup is the minimal interface required by the invocation service to
+// resolve an agent's VM CUID from its runtime agent ID.
+type AgentLookup interface {
+	GetByAgentID(ctx context.Context, agentID string) (AgentRecord, error)
+}
+
+// AgentRecord is a lightweight copy of store.AgentRecord used within the
+// invocation package to avoid a circular import.
+type AgentRecord struct {
+	ID     string // local Atryum agent UUID (used for rule matching)
+	VMCUID string // VM inventory model CUID (used for constitution lookup)
+}
+
+// EvaluatorClient is the minimal interface required by the invocation service
+// to call the VM backend for LLM evaluation.
+type EvaluatorClient interface {
+	EvaluateToolCall(ctx context.Context, req EvaluateRequest) (EvaluateResponse, error)
+}
+
+// EvaluateRequest mirrors backend.EvaluateRequest so the service package does
+// not import the backend package directly.
+type EvaluateRequest struct {
+	ModelConfigCUID      string         `json:"model_config_cuid"`
+	AgentVMCUID          string         `json:"agent_vm_cuid,omitempty"`
+	ConstitutionFieldKey string         `json:"constitution_field_key,omitempty"`
+	ServerName           string         `json:"server_name"`
+	ToolName             string         `json:"tool_name"`
+	ToolArgs             map[string]any `json:"tool_args,omitempty"`
+	Context              string         `json:"context,omitempty"`
+}
+
+// EvaluateResponse mirrors backend.EvaluateResponse.
+type EvaluateResponse struct {
+	Approved bool   `json:"approved"`
+	Reason   string `json:"reason"`
+}
 
 type approvalDecision struct {
 	approved bool
@@ -45,27 +83,44 @@ type upstreamClient interface {
 }
 
 type Service struct {
-	invocations      invocationRepo
-	events           eventRepo
-	resolver         resolver
-	client           upstreamClient
-	policy           policy.Provider
-	rules            rulesStore // nil = no rule evaluation
-	defaultTimeout   time.Duration
-	mu               sync.Mutex
-	pendingApprovals map[string]chan approvalDecision
+	invocations          invocationRepo
+	events               eventRepo
+	resolver             resolver
+	client               upstreamClient
+	policy               policy.Provider
+	rules                rulesStore // nil = no rule evaluation
+	agents               AgentLookup
+	evaluator            EvaluatorClient
+	constitutionFieldKey string
+	defaultTimeout       time.Duration
+	mu                   sync.Mutex
+	pendingApprovals     map[string]chan approvalDecision
 }
 
-func NewService(inv invocationRepo, evt eventRepo, resolver resolver, client upstreamClient, policyProvider policy.Provider, defaultTimeout time.Duration, rules rulesStore) *Service {
+func NewService(
+	inv invocationRepo,
+	evt eventRepo,
+	resolver resolver,
+	client upstreamClient,
+	policyProvider policy.Provider,
+	defaultTimeout time.Duration,
+	rules rulesStore,
+	agents AgentLookup,
+	evaluator EvaluatorClient,
+	constitutionFieldKey string,
+) *Service {
 	return &Service{
-		invocations:      inv,
-		events:           evt,
-		resolver:         resolver,
-		client:           client,
-		policy:           policyProvider,
-		rules:            rules,
-		defaultTimeout:   defaultTimeout,
-		pendingApprovals: make(map[string]chan approvalDecision),
+		invocations:          inv,
+		events:               evt,
+		resolver:             resolver,
+		client:               client,
+		policy:               policyProvider,
+		rules:                rules,
+		agents:               agents,
+		evaluator:            evaluator,
+		constitutionFieldKey: constitutionFieldKey,
+		defaultTimeout:       defaultTimeout,
+		pendingApprovals:     make(map[string]chan approvalDecision),
 	}
 }
 
@@ -98,6 +153,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 	// is disabled the field is empty and we fall back to request_id for rule
 	// matching to preserve pre-auth behavior.
 	agentID := auth.AgentIDFromContext(ctx)
+	agentRec := s.resolveAgentRecord(ctx, agentID)
 
 	now := time.Now().UTC()
 	inv := Invocation{
@@ -128,7 +184,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 			if user == "" && req.RequestID != nil {
 				user = *req.RequestID
 			}
-			if matched := matchRule(approvalRules, upstream.Name, req.Tool, user, ""); matched != nil {
+			if matched := matchRule(approvalRules, upstream.Name, req.Tool, user, agentRec.ID); matched != nil {
 				ruleMatched = true
 				if matched.ID != "" {
 					matchedRuleID = &matched.ID
@@ -139,8 +195,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 				case RuleActionAutoApprove:
 					decision = policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (auto_approve)"}
 				case RuleActionAIEvaluation:
-					// Stub: fall back to human approval until LLM wiring is implemented.
-					decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (ai_evaluation — pending human review)"}
+					decision = s.runAIEvaluation(ctx, matched, upstream.Name, req.Tool, req.Input, agentID)
 				default:
 					decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (human_approval)"}
 				}
@@ -186,6 +241,90 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		// DispositionHuman and DispositionWorkflow both gate on a human decision.
 		return s.waitForHumanApproval(ctx, inv, upstream, req)
 	}
+}
+
+// resolveAgentRecord looks up the Atryum agent record for the given runtime
+// agentID. Returns a zero-value AgentRecord (with empty ID) when the agent
+// cannot be found or when agents lookup is not configured — callers treat an
+// empty ID as "match all agents" in rule filtering.
+func (s *Service) resolveAgentRecord(ctx context.Context, agentID string) AgentRecord {
+	if s.agents == nil || agentID == "" {
+		return AgentRecord{}
+	}
+	rec, err := s.agents.GetByAgentID(ctx, agentID)
+	if err != nil {
+		slog.Warn("could not resolve agent record for rule matching; agent-scoped rules will not match",
+			"agent_id", agentID, "error", err)
+		return AgentRecord{}
+	}
+	return rec
+}
+
+// runAIEvaluation calls the VM backend's evaluate endpoint and translates the
+// LLM verdict into a policy.Decision. On any error or if the evaluator is not
+// configured, it falls back to DispositionHuman so no invocation is silently lost.
+func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serverName, toolName string, toolArgs map[string]any, agentID string) policy.Decision {
+	if s.evaluator == nil {
+		slog.Warn("ai_evaluation rule matched but no evaluator configured; falling back to human_approval",
+			"rule_id", rule.ID, "tool", toolName, "server", serverName)
+		return policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: evaluator not configured (falling back to human_approval)"}
+	}
+
+	// Resolve the agent's VM CUID so the constitution can be fetched server-side.
+	agentVMCUID := ""
+	if s.agents != nil && agentID != "" {
+		if rec, err := s.agents.GetByAgentID(ctx, agentID); err == nil {
+			agentVMCUID = rec.VMCUID
+		} else {
+			slog.Warn("ai_evaluation: could not resolve agent VM CUID; proceeding without constitution",
+				"agent_id", agentID, "error", err)
+		}
+	}
+
+	slog.Info("ai_evaluation: calling LLM",
+		"rule_id", rule.ID,
+		"server", serverName,
+		"tool", toolName,
+		"agent_id", agentID,
+		"agent_vm_cuid", agentVMCUID,
+		"model_config_cuid", rule.ModelConfigCUID,
+		"constitution_field_key", s.constitutionFieldKey,
+	)
+
+	evalCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	resp, err := s.evaluator.EvaluateToolCall(evalCtx, EvaluateRequest{
+		ModelConfigCUID:      rule.ModelConfigCUID,
+		AgentVMCUID:          agentVMCUID,
+		ConstitutionFieldKey: s.constitutionFieldKey,
+		ServerName:           serverName,
+		ToolName:             toolName,
+		ToolArgs:             toolArgs,
+	})
+	if err != nil {
+		slog.Error("ai_evaluation: LLM evaluation failed; falling back to human_approval",
+			"rule_id", rule.ID, "tool", toolName, "error", err)
+		return policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: LLM call failed (falling back to human_approval)"}
+	}
+
+	verdict := "APPROVED"
+	if !resp.Approved {
+		verdict = "DENIED"
+	}
+	slog.Info("ai_evaluation: result",
+		"verdict", verdict,
+		"rule_id", rule.ID,
+		"server", serverName,
+		"tool", toolName,
+		"agent_id", agentID,
+		"reason", resp.Reason,
+	)
+
+	if resp.Approved {
+		return policy.Decision{Disposition: policy.DispositionAuto, Reason: "ai_evaluation approved: " + resp.Reason}
+	}
+	return policy.Decision{Disposition: policy.DispositionNever, Reason: "ai_evaluation denied: " + resp.Reason}
 }
 
 // denyByPolicy hard-denies the call without execution.
@@ -438,6 +577,7 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	}
 	// Evaluate rules against (source, tool, user) — same logic as Invoke.
 	agentID := auth.AgentIDFromContext(ctx)
+	agentRec := s.resolveAgentRecord(ctx, agentID)
 
 	now := time.Now().UTC()
 	inv := Invocation{
@@ -456,6 +596,7 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	if err := s.invocations.Create(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
+	var matchedRule *ApprovalRule
 	ruleAction := ""
 	if s.rules != nil {
 		if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
@@ -463,8 +604,9 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 			if user == "" && req.RequestID != nil {
 				user = *req.RequestID
 			}
-			if matched := matchRule(approvalRules, source, req.Tool, user, ""); matched != nil {
-				ruleAction = matched.Action
+			matchedRule = matchRule(approvalRules, source, req.Tool, user, agentRec.ID)
+			if matchedRule != nil {
+				ruleAction = matchedRule.Action
 			}
 		}
 	}
@@ -503,6 +645,29 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 		}
 		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.approved", Payload: mustJSON(map[string]any{"auto_approved": true, "auto_reason": "matched approval rule (auto_approve)"}), CreatedAt: time.Now().UTC()})
 		return s.toResponse(inv), nil
+
+	case RuleActionAIEvaluation:
+		aiDecision := s.runAIEvaluation(ctx, matchedRule, source, req.Tool, req.Input, agentID)
+		if aiDecision.Disposition == policy.DispositionAuto {
+			inv.Status = StatusApproved
+			inv.Approval = &Approval{Status: "auto_approved", Reason: stringPtr(aiDecision.Reason)}
+			if err := s.invocations.UpdateResult(ctx, inv); err != nil {
+				return InvocationResponse{}, err
+			}
+			_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.approved", Payload: mustJSON(map[string]any{"auto_approved": true, "auto_reason": aiDecision.Reason}), CreatedAt: time.Now().UTC()})
+			return s.toResponse(inv), nil
+		}
+		if aiDecision.Disposition == policy.DispositionNever {
+			completed := time.Now().UTC()
+			inv.Status = StatusDenied
+			inv.CompletedAt = &completed
+			inv.Approval = &Approval{Status: "auto_denied", Reason: stringPtr(aiDecision.Reason)}
+			inv.Error = mustJSON(map[string]any{"content": []map[string]any{{"type": "text", "text": "Tool call denied by AI evaluation. Reason: " + aiDecision.Reason}}, "isError": true})
+			_ = s.invocations.UpdateResult(context.Background(), inv)
+			_ = s.events.Create(context.Background(), Event{InvocationID: inv.InvocationID, EventType: "invocation.denied", Payload: mustJSON(map[string]any{"reason": aiDecision.Reason, "disposition": "never"}), CreatedAt: completed})
+			return s.toResponse(inv), nil
+		}
+		// Fall through to human approval on fallback.
 	}
 
 	// Default: human approval required.

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -128,7 +128,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 			if user == "" && req.RequestID != nil {
 				user = *req.RequestID
 			}
-			if matched := matchRule(approvalRules, upstream.Name, req.Tool, user); matched != nil {
+			if matched := matchRule(approvalRules, upstream.Name, req.Tool, user, ""); matched != nil {
 				ruleMatched = true
 				if matched.ID != "" {
 					matchedRuleID = &matched.ID
@@ -138,6 +138,9 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 					decision = policy.Decision{Disposition: policy.DispositionNever, Reason: "matched approval rule (auto_deny)"}
 				case RuleActionAutoApprove:
 					decision = policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (auto_approve)"}
+				case RuleActionAIEvaluation:
+					// Stub: fall back to human approval until LLM wiring is implemented.
+					decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (ai_evaluation — pending human review)"}
 				default:
 					decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (human_approval)"}
 				}
@@ -460,7 +463,7 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 			if user == "" && req.RequestID != nil {
 				user = *req.RequestID
 			}
-			if matched := matchRule(approvalRules, source, req.Tool, user); matched != nil {
+			if matched := matchRule(approvalRules, source, req.Tool, user, ""); matched != nil {
 				ruleAction = matched.Action
 			}
 		}

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -29,12 +29,25 @@ func TestInvokeAndInspectHTTP(t *testing.T) {
 		}
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Fatalf("decode: %v", err)
+			t.Errorf("decode: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
-		if body["method"] != "tools/call" {
-			t.Fatalf("expected tools/call, got %#v", body["method"])
+		switch body["method"] {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      body["id"],
+				"result":  map[string]any{"serverInfo": map[string]any{"name": "fake-github", "version": "0.1.0"}, "capabilities": map[string]any{}},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/call":
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+		default:
+			t.Errorf("unexpected method: %v", body["method"])
+			w.WriteHeader(http.StatusBadRequest)
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
 	}))
 	defer upstream.Close()
 
@@ -200,13 +213,17 @@ func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 func approveNextInvocation(t *testing.T, service *invocation.Service, delay time.Duration) {
 	time.Sleep(delay)
 	list, err := service.List(context.Background(), invocation.InvocationListFilter{Limit: 10})
+	// Return silently when there are no pending invocations — this is expected
+	// when AlwaysApproveProvider completes the invocation before this goroutine
+	// runs. Calling t.Errorf after the test has completed causes a panic.
 	if err != nil || len(list.Items) == 0 {
-		// Log instead of Fatalf — this runs in a goroutine and the parent test
-		// may have already finished, which would cause a panic.
-		t.Errorf("list invocations: %v", err)
 		return
 	}
-	if err := service.Approve(context.Background(), list.Items[0].InvocationID); err != nil {
+	pending := list.Items[0]
+	if pending.Status != invocation.StatusPendingApproval {
+		return
+	}
+	if err := service.Approve(context.Background(), pending.InvocationID); err != nil {
 		t.Errorf("approve invocation: %v", err)
 	}
 }

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -194,7 +194,7 @@ func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	return invocation.NewService(store.NewInvocationRepo(db), store.NewEventRepo(db), resolver, mcp.NewHTTPClient(), policy.AlwaysApproveProvider{}, 5*time.Second, nil)
+	return invocation.NewService(store.NewInvocationRepo(db), store.NewEventRepo(db), resolver, mcp.NewHTTPClient(), policy.AlwaysApproveProvider{}, 5*time.Second, nil, nil, nil, "")
 }
 
 func approveNextInvocation(t *testing.T, service *invocation.Service, delay time.Duration) {

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -144,6 +145,21 @@ func (r *AgentsRepo) UpdateEnabled(ctx context.Context, id string, enabled bool)
 		return sql.ErrNoRows
 	}
 	return err
+}
+
+// GetByAgentID returns the agent record whose agent_ids JSON array contains the
+// given agentID string. Returns sql.ErrNoRows when no match is found.
+func (r *AgentsRepo) GetByAgentID(ctx context.Context, agentID string) (AgentRecord, error) {
+	cols := strings.Join(agentColumns, ", ")
+	var query string
+	if r.dialect == DialectPostgres {
+		// PostgreSQL: use the @> containment operator on JSONB.
+		query = `SELECT ` + cols + ` FROM agents WHERE agent_ids @> to_jsonb($1::text)::jsonb LIMIT 1`
+	} else {
+		// SQLite: use json_each to expand the array and match the value.
+		query = `SELECT ` + cols + ` FROM agents WHERE EXISTS (SELECT 1 FROM json_each(agent_ids) WHERE value = ?) LIMIT 1`
+	}
+	return scanAgent(r.db.QueryRowContext(ctx, query, agentID))
 }
 
 // List returns all agent records ordered by vm_name.

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -1,0 +1,188 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+// AgentRecord is the store-level representation of a synced VM inventory model.
+// agent_ids and enabled are managed by Atryum after the initial sync and are
+// never overwritten when re-syncing from the backend.
+type AgentRecord struct {
+	ID                 string
+	VMOrganizationCUID string
+	VMOrganizationName string
+	VMCUID             string
+	VMName             string
+	VMDescription      string
+	AgentIDs           string // JSON array, e.g. "[]" or "[\"id1\",\"id2\"]"
+	Enabled            bool
+	SyncedAt           time.Time
+}
+
+// AgentsRepo provides upsert and query operations for the agents table.
+type AgentsRepo struct {
+	db      *sql.DB
+	sb      sq.StatementBuilderType
+	dialect Dialect
+}
+
+func NewAgentsRepo(db *sql.DB) *AgentsRepo {
+	return NewAgentsRepoWithDialect(db, DialectSQLite)
+}
+
+func NewAgentsRepoWithDialect(db *sql.DB, dialect Dialect) *AgentsRepo {
+	return &AgentsRepo{db: db, sb: statementBuilderForDialect(dialect), dialect: dialect}
+}
+
+var agentColumns = []string{
+	"id", "vm_organization_cuid", "vm_organization_name",
+	"vm_cuid", "vm_name", "vm_description",
+	"agent_ids", "enabled", "synced_at",
+}
+
+// Upsert inserts a new agent record or, on conflict with an existing vm_cuid,
+// updates only the VM-sourced fields (vm_organization_cuid, vm_organization_name,
+// vm_name, vm_description, synced_at). The agent_ids and enabled columns are
+// never touched on update so that Atryum-managed state is preserved.
+func (r *AgentsRepo) Upsert(ctx context.Context, agent AgentRecord) error {
+	agentIDs := agent.AgentIDs
+	if agentIDs == "" {
+		agentIDs = "[]"
+	}
+	enabled := 1
+	if !agent.Enabled {
+		enabled = 0
+	}
+	syncedAt := agent.SyncedAt
+	if syncedAt.IsZero() {
+		syncedAt = time.Now().UTC()
+	}
+
+	insert, args, err := r.sb.Insert("agents").
+		Columns(agentColumns...).
+		Values(
+			agent.ID,
+			agent.VMOrganizationCUID,
+			agent.VMOrganizationName,
+			agent.VMCUID,
+			agent.VMName,
+			emptyToNil(agent.VMDescription),
+			agentIDs,
+			enabled,
+			syncedAt,
+		).
+		Suffix(`ON CONFLICT (vm_cuid) DO UPDATE SET
+			vm_organization_cuid = excluded.vm_organization_cuid,
+			vm_organization_name = excluded.vm_organization_name,
+			vm_name              = excluded.vm_name,
+			vm_description       = excluded.vm_description,
+			synced_at            = excluded.synced_at`).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("build agent upsert: %w", err)
+	}
+	_, err = r.db.ExecContext(ctx, insert, args...)
+	return err
+}
+
+// Get returns a single agent record by its local id.
+func (r *AgentsRepo) Get(ctx context.Context, id string) (AgentRecord, error) {
+	query, args, err := r.sb.Select(agentColumns...).
+		From("agents").
+		Where(sq.Eq{"id": id}).
+		ToSql()
+	if err != nil {
+		return AgentRecord{}, err
+	}
+	return scanAgent(r.db.QueryRowContext(ctx, query, args...))
+}
+
+// UpdateAgentIDs replaces the agent_ids JSON array for the agent with the given id.
+func (r *AgentsRepo) UpdateAgentIDs(ctx context.Context, id string, agentIDs string) error {
+	query, args, err := r.sb.Update("agents").
+		Set("agent_ids", agentIDs).
+		Where(sq.Eq{"id": id}).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("build agent_ids update: %w", err)
+	}
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err == nil && n == 0 {
+		return sql.ErrNoRows
+	}
+	return err
+}
+
+// UpdateEnabled sets the enabled flag for the agent with the given id.
+func (r *AgentsRepo) UpdateEnabled(ctx context.Context, id string, enabled bool) error {
+	enabledVal := 1
+	if !enabled {
+		enabledVal = 0
+	}
+	query, args, err := r.sb.Update("agents").
+		Set("enabled", enabledVal).
+		Where(sq.Eq{"id": id}).
+		ToSql()
+	if err != nil {
+		return fmt.Errorf("build agent update: %w", err)
+	}
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	n, err := result.RowsAffected()
+	if err == nil && n == 0 {
+		return sql.ErrNoRows
+	}
+	return err
+}
+
+// List returns all agent records ordered by vm_name.
+func (r *AgentsRepo) List(ctx context.Context) ([]AgentRecord, error) {
+	query, args, err := r.sb.Select(agentColumns...).
+		From("agents").
+		OrderBy("vm_name ASC").
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []AgentRecord
+	for rows.Next() {
+		a, err := scanAgent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func scanAgent(scanner interface{ Scan(dest ...any) error }) (AgentRecord, error) {
+	var a AgentRecord
+	var vmDescription sql.NullString
+	var enabled int
+	if err := scanner.Scan(
+		&a.ID, &a.VMOrganizationCUID, &a.VMOrganizationName,
+		&a.VMCUID, &a.VMName, &vmDescription,
+		&a.AgentIDs, &enabled, &a.SyncedAt,
+	); err != nil {
+		return AgentRecord{}, err
+	}
+	a.VMDescription = vmDescription.String
+	a.Enabled = enabled == 1
+	return a, nil
+}

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 8 {
+	if len(migrations) != 10 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -61,6 +61,8 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{6, "006_invocation_agent_id.sql"},
 		{7, "007_rename_user_pattern.sql"},
 		{8, "008_oauth_client_registration.sql"},
+		{9, "009_agents_table"},
+		{10, "010_ai_evaluation_rule"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -71,10 +73,10 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 7 {
+	if len(pending) != 9 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	wantVersions := []int{2, 3, 4, 5, 6, 7, 8}
+	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10}
 	for i, want := range wantVersions {
 		if pending[i].Version != want {
 			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)

--- a/internal/store/migrations/009_agents_table.go
+++ b/internal/store/migrations/009_agents_table.go
@@ -1,0 +1,41 @@
+package migrations
+
+func migration009() Definition {
+	return Definition{
+		Version: 9,
+		Name:    "009_agents_table",
+		Steps: []Step{
+			RawDialect("create agents table", `
+				CREATE TABLE IF NOT EXISTS agents (
+					id                   TEXT      PRIMARY KEY,
+					vm_organization_cuid TEXT      NOT NULL,
+					vm_organization_name TEXT      NOT NULL,
+					vm_cuid              TEXT      NOT NULL UNIQUE,
+					vm_name              TEXT      NOT NULL,
+					vm_description       TEXT,
+					agent_ids            TEXT      NOT NULL DEFAULT '[]',
+					enabled              INTEGER   NOT NULL DEFAULT 1,
+					synced_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)
+			`, `
+				CREATE TABLE IF NOT EXISTS agents (
+					id                   TEXT      PRIMARY KEY,
+					vm_organization_cuid TEXT      NOT NULL,
+					vm_organization_name TEXT      NOT NULL,
+					vm_cuid              TEXT      NOT NULL UNIQUE,
+					vm_name              TEXT      NOT NULL,
+					vm_description       TEXT,
+					agent_ids            JSONB     NOT NULL DEFAULT '[]',
+					enabled              BOOLEAN   NOT NULL DEFAULT TRUE,
+					synced_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)
+			`),
+			Raw("create agents vm_cuid index", `
+				CREATE INDEX IF NOT EXISTS idx_agents_vm_cuid ON agents (vm_cuid)
+			`),
+			Raw("create agents vm_organization_cuid index", `
+				CREATE INDEX IF NOT EXISTS idx_agents_vm_organization_cuid ON agents (vm_organization_cuid)
+			`),
+		},
+	}
+}

--- a/internal/store/migrations/010_ai_evaluation_rule.go
+++ b/internal/store/migrations/010_ai_evaluation_rule.go
@@ -1,0 +1,18 @@
+package migrations
+
+func migration010() Definition {
+	return Definition{
+		Version: 10,
+		Name:    "010_ai_evaluation_rule",
+		Steps: []Step{
+			Raw("add model_config_cuid column to approval_rules", `
+				ALTER TABLE approval_rules ADD COLUMN model_config_cuid TEXT
+			`),
+			RawDialect("add agent_cuids column to approval_rules", `
+				ALTER TABLE approval_rules ADD COLUMN agent_cuids TEXT NOT NULL DEFAULT '[]'
+			`, `
+				ALTER TABLE approval_rules ADD COLUMN agent_cuids JSONB NOT NULL DEFAULT '[]'
+			`),
+		},
+	}
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -43,5 +43,6 @@ func All() []Definition {
 		migration007(),
 		migration008(),
 		migration009(),
+		migration010(),
 	}
 }

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -42,5 +42,6 @@ func All() []Definition {
 		migration006(),
 		migration007(),
 		migration008(),
+		migration009(),
 	}
 }

--- a/internal/store/rules.go
+++ b/internal/store/rules.go
@@ -16,17 +16,22 @@ import (
 // ServerPatterns and ToolPatterns are serialized as JSON arrays in the
 // server_pattern / tool_pattern TEXT columns; an empty slice means "match all".
 // AgentIDPattern is the literal authenticated agent_id (or "*"/"" for any).
+// ModelConfigCUID references the VM agent model configuration for ai_evaluation rules.
+// AgentCUIDs is a JSON-encoded list of Atryum agent CUIDs the rule applies to;
+// an empty slice means "match all agents".
 type Rule struct {
-	ID             string
-	Action         string
-	ServerPatterns []string
-	ToolPatterns   []string
-	AgentIDPattern string
-	Description    string
-	Enabled        bool
-	Order          int
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID              string
+	Action          string
+	ServerPatterns  []string
+	ToolPatterns    []string
+	AgentIDPattern  string
+	ModelConfigCUID string
+	AgentCUIDs      []string
+	Description     string
+	Enabled         bool
+	Order           int
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 }
 
 // RulesRepo provides CRUD and ordering operations for approval_rules.
@@ -45,12 +50,13 @@ func NewRulesRepoWithDialect(db *sql.DB, dialect Dialect) *RulesRepo {
 
 var ruleColumns = []string{
 	"id", "action", "server_pattern", "tool_pattern", "agent_id_pattern",
+	"model_config_cuid", "agent_cuids",
 	"description", "enabled", "rule_order", "created_at", "updated_at",
 }
 
 func (r *RulesRepo) Create(ctx context.Context, rule Rule) error {
 	now := time.Now().UTC()
-	serverJSON, toolJSON, err := encodeRulePatterns(rule)
+	serverJSON, toolJSON, agentCUIDsJSON, err := encodeRulePatterns(rule)
 	if err != nil {
 		return err
 	}
@@ -58,6 +64,7 @@ func (r *RulesRepo) Create(ctx context.Context, rule Rule) error {
 		Columns(ruleColumns...).
 		Values(
 			rule.ID, rule.Action, serverJSON, toolJSON, rule.AgentIDPattern,
+			emptyToNil(rule.ModelConfigCUID), agentCUIDsJSON,
 			emptyToNil(rule.Description), boolToInt(rule.Enabled), rule.Order, now, now,
 		).ToSql()
 	if err != nil {
@@ -119,7 +126,7 @@ func (r *RulesRepo) NextOrder(ctx context.Context) (int, error) {
 
 func (r *RulesRepo) Update(ctx context.Context, rule Rule) error {
 	now := time.Now().UTC()
-	serverJSON, toolJSON, err := encodeRulePatterns(rule)
+	serverJSON, toolJSON, agentCUIDsJSON, err := encodeRulePatterns(rule)
 	if err != nil {
 		return err
 	}
@@ -128,6 +135,8 @@ func (r *RulesRepo) Update(ctx context.Context, rule Rule) error {
 		Set("server_pattern", serverJSON).
 		Set("tool_pattern", toolJSON).
 		Set("agent_id_pattern", rule.AgentIDPattern).
+		Set("model_config_cuid", emptyToNil(rule.ModelConfigCUID)).
+		Set("agent_cuids", agentCUIDsJSON).
 		Set("description", emptyToNil(rule.Description)).
 		Set("enabled", boolToInt(rule.Enabled)).
 		Set("updated_at", now).
@@ -264,17 +273,19 @@ func (r *RulesRepo) Move(ctx context.Context, id string, direction string) ([]Ru
 
 func scanRule(scanner interface{ Scan(dest ...any) error }) (Rule, error) {
 	var rule Rule
-	var serverJSON, toolJSON string
-	var description sql.NullString
+	var serverJSON, toolJSON, agentCUIDsJSON string
+	var modelConfigCUID, description sql.NullString
 	var enabled int
 	if err := scanner.Scan(
 		&rule.ID, &rule.Action, &serverJSON, &toolJSON, &rule.AgentIDPattern,
+		&modelConfigCUID, &agentCUIDsJSON,
 		&description, &enabled, &rule.Order, &rule.CreatedAt, &rule.UpdatedAt,
 	); err != nil {
 		return Rule{}, err
 	}
 	rule.Enabled = enabled == 1
 	rule.Description = description.String
+	rule.ModelConfigCUID = modelConfigCUID.String
 	if err := json.Unmarshal([]byte(serverJSON), &rule.ServerPatterns); err != nil {
 		rule.ServerPatterns = []string{}
 	}
@@ -286,6 +297,14 @@ func scanRule(scanner interface{ Scan(dest ...any) error }) (Rule, error) {
 	}
 	if rule.ToolPatterns == nil {
 		rule.ToolPatterns = []string{}
+	}
+	if agentCUIDsJSON != "" {
+		if err := json.Unmarshal([]byte(agentCUIDsJSON), &rule.AgentCUIDs); err != nil {
+			rule.AgentCUIDs = []string{}
+		}
+	}
+	if rule.AgentCUIDs == nil {
+		rule.AgentCUIDs = []string{}
 	}
 	return rule, nil
 }
@@ -301,12 +320,14 @@ func (r *RulesRepo) ListApprovalRules(ctx context.Context) ([]invocation.Approva
 	out := make([]invocation.ApprovalRule, 0, len(rules))
 	for _, rule := range rules {
 		out = append(out, invocation.ApprovalRule{
-			ID:             rule.ID,
-			Action:         rule.Action,
-			ServerPatterns: rule.ServerPatterns,
-			ToolPatterns:   rule.ToolPatterns,
-			AgentIDPattern: rule.AgentIDPattern,
-			Enabled:        rule.Enabled,
+			ID:              rule.ID,
+			Action:          rule.Action,
+			ServerPatterns:  rule.ServerPatterns,
+			ToolPatterns:    rule.ToolPatterns,
+			AgentIDPattern:  rule.AgentIDPattern,
+			ModelConfigCUID: rule.ModelConfigCUID,
+			AgentCUIDs:      rule.AgentCUIDs,
+			Enabled:         rule.Enabled,
 		})
 	}
 	return out, nil
@@ -351,7 +372,7 @@ func (r *RulesRepo) InsertBefore(ctx context.Context, anchorID string, rule Rule
 	// Insert the new rule at insertOrder.
 	rule.Order = insertOrder
 	now := time.Now().UTC()
-	serverJSON, toolJSON, err := encodeRulePatterns(rule)
+	serverJSON, toolJSON, agentCUIDsJSON, err := encodeRulePatterns(rule)
 	if err != nil {
 		return err
 	}
@@ -359,6 +380,7 @@ func (r *RulesRepo) InsertBefore(ctx context.Context, anchorID string, rule Rule
 		Columns(ruleColumns...).
 		Values(
 			rule.ID, rule.Action, serverJSON, toolJSON, rule.AgentIDPattern,
+			emptyToNil(rule.ModelConfigCUID), agentCUIDsJSON,
 			emptyToNil(rule.Description), boolToInt(rule.Enabled), rule.Order, now, now,
 		).ToSql()
 	if err != nil {
@@ -371,7 +393,7 @@ func (r *RulesRepo) InsertBefore(ctx context.Context, anchorID string, rule Rule
 	return tx.Commit()
 }
 
-func encodeRulePatterns(rule Rule) (serverJSON string, toolJSON string, err error) {
+func encodeRulePatterns(rule Rule) (serverJSON string, toolJSON string, agentCUIDsJSON string, err error) {
 	sp := rule.ServerPatterns
 	if sp == nil {
 		sp = []string{}
@@ -380,13 +402,21 @@ func encodeRulePatterns(rule Rule) (serverJSON string, toolJSON string, err erro
 	if tp == nil {
 		tp = []string{}
 	}
+	ac := rule.AgentCUIDs
+	if ac == nil {
+		ac = []string{}
+	}
 	spBytes, e := json.Marshal(sp)
 	if e != nil {
-		return "", "", e
+		return "", "", "", e
 	}
 	tpBytes, e := json.Marshal(tp)
 	if e != nil {
-		return "", "", e
+		return "", "", "", e
 	}
-	return string(spBytes), string(tpBytes), nil
+	acBytes, e := json.Marshal(ac)
+	if e != nil {
+		return "", "", "", e
+	}
+	return string(spBytes), string(tpBytes), string(acBytes), nil
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -41,8 +41,8 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 8 {
-		t.Fatalf("expected 8 migrations, got %d", count)
+	if count != 10 {
+		t.Fatalf("expected 10 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 8 {
-		t.Fatalf("expected 8 migrations after double init, got %d", count)
+	if count != 10 {
+		t.Fatalf("expected 10 migrations after double init, got %d", count)
 	}
 }
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

Introduces three major capabilities to Atryum as part of the LLM-as-judge governance stack:

1. **Agent sync from ValidMind backend** — Atryum now polls the VM backend to pull agent (inventory model) records into its local SQLite store via a new `agents` table (migration 009). Agents are scoped per organization and kept in sync at startup and on a configurable interval.

2. **AI Evaluation rule type** — A new `ai_evaluation` rule action (migration 010) that, instead of auto-approving/denying or routing to a human, calls the VM backend's `/internal/v1/atryum/evaluate` endpoint with the invocation payload. The backend uses LiteLLM and the agent's model configuration to return an `APPROVE`/`DENY` decision with reasoning.

3. **API + invocation service wiring** — `handlers.go` exposes the agent list; `invocation/service.go` integrates the `ai_evaluation` decision path into the rule evaluation loop; `invocation/rules.go` is extended to support the new rule action; `internal/backend/client.go` adds the HTTP client for calling the VM backend evaluate endpoint.

**Key files:**
- `internal/store/migrations/009_agents_table.go` — agents table
- `internal/store/migrations/010_ai_evaluation_rule.go` — ai_evaluation rule type
- `internal/store/agents.go` — agent CRUD
- `internal/store/rules.go` — rule store updates
- `internal/backend/client.go` — VM backend HTTP client
- `internal/invocation/service.go` — LLM-as-judge integration
- `internal/invocation/rules.go` — rule action extension
- `internal/api/handlers.go` — API handler updates
- `cmd/atryum/main.go` — startup wiring
- `internal/config/config.go` — new config fields
- `atryum.example.toml` — updated example config

## How to test

1. Configure `atryum.toml` with valid `[backend]` credentials (org CUID, machine user token, base URL).
2. Start Atryum — it should sync agents from the VM backend on startup (check logs for sync confirmation).
3. Create a rule with `action = "ai_evaluation"` and a valid `model_config_cuid`.
4. Trigger a tool invocation that matches the rule — Atryum should call the VM `/evaluate` endpoint and apply the returned `APPROVE`/`DENY` decision.
5. Run the test suite: `go test ./...`

## What needs special review?

- **`invocation/service.go`** — the LLM-as-judge decision path, error handling, and fallback behavior if the evaluate endpoint is unreachable.
- **`internal/backend/client.go`** — HTTP client timeout, retry logic, and auth header handling.
- **Migration 009/010** — schema correctness and forward-compatibility with existing data.
- **`cmd/atryum/main.go`** — agent sync goroutine lifecycle and graceful shutdown.

## Dependencies, breaking changes, and deployment notes

- **Paired with** the FE PR (AI Evaluation rule UI) and the BE PR (internal `/agents`, `/model-configs`, `/evaluate` endpoints).
- **Config change**: `atryum.toml` requires a new `[backend]` section — see updated `atryum.example.toml`.
- **DB migrations** run automatically on startup; existing SQLite databases will be migrated in place.
- No breaking changes to the existing MCP server or OAuth flow.

## Release notes

Internal — part of the Atryum LLM-as-judge governance stack (wip-0.1).

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [ ] PR linked to Shortcut
- [x] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required)
- [x] Environment variable additions/changes documented (if required)

Made with [Cursor](https://cursor.com)