### PR TITLE
Nudge agents towards preapproved rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,13 @@ ATRYUM_POSTGRES_TESTS=1 ATRYUM_POSTGRES_TEST_DSN="postgresql://postgres:password
 Public:
 - `POST /mcp/:server`
 - `POST /api/v1/invocations`
+- `GET /api/v1/agent/rules?server=&source=&tool=&agent_id=&request_id=` - returns enabled approval rules applicable to the caller; protected by the same bearer auth as `/mcp/` when auth is configured
 - `GET /healthz`
+
+MCP clients connected through `/mcp/` also see a synthetic `atryum.rules.get`
+tool in `tools/list`. It returns the same rules payload without creating an
+approval-gated invocation, so agents can inspect their rule environment before
+choosing which tool to call.
 
 Admin APIs:
 - `GET /api/v1/admin/invocations?offset=0&limit=50&server=&tool=&status=`

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -185,7 +185,7 @@ func TestAgentRulesRequiresAuthAndUsesTokenAgentID(t *testing.T) {
 		{ID: "own-rule", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "agent-007", Enabled: true, Order: 0},
 		{ID: "other-rule", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "other", Enabled: true, Order: 1},
 	}}
-	h := NewHandler(&stubService{}, stubServerService{}, nil, rules)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, nil, nil, nil)
 	h.SetAuthValidator(rig.v)
 	handler := h.Routes()
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -16,6 +16,7 @@ import (
 
 	"atryum/internal/auth"
 	"atryum/internal/invocation"
+	"atryum/internal/store"
 )
 
 // jwksHandler serves a minimal JWKS document for the given RSA public key so
@@ -175,6 +176,46 @@ func TestMCPAcceptsValidTokenAndPlumbsAgentID(t *testing.T) {
 	id := auth.AgentIDFromContext(svc.invokedCtx)
 	if id != "agent-007" {
 		t.Fatalf("expected agent_id agent-007 on invoke ctx, got %q", id)
+	}
+}
+
+func TestAgentRulesRequiresAuthAndUsesTokenAgentID(t *testing.T) {
+	rig := newAuthTestRig(t)
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "own-rule", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "agent-007", Enabled: true, Order: 0},
+		{ID: "other-rule", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "other", Enabled: true, Order: 1},
+	}}
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules)
+	h.SetAuthValidator(rig.v)
+	handler := h.Routes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/rules?source=amp&tool=Read", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without bearer, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	tok := rig.sign(t, defaultClaims())
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/agent/rules?agent_id=other&source=amp&tool=Read", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with bearer, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AgentRulesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.AgentID != "agent-007" {
+		t.Fatalf("expected token agent_id to win, got %q", resp.AgentID)
+	}
+	if resp.Action != invocation.RuleActionAutoApprove {
+		t.Fatalf("expected own rule action, got %q", resp.Action)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].ID != "own-rule" {
+		t.Fatalf("expected only own rule, got %#v", resp.Items)
 	}
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -291,6 +291,41 @@ func parseAgentIDs(raw string) []string {
 	return ids
 }
 
+const agentRulesToolName = "atryum.rules.get"
+
+// atryumInitializeInstructions is returned in the MCP `initialize` result so
+// MCP clients can surface it to the model as system-level guidance. The goal
+// is to make the agent aware that approval rules govern tool access and that
+// it should consult `atryum.rules.get` before choosing tools.
+const atryumInitializeInstructions = "This MCP server (atryum) gates tool calls through approval rules. " +
+	"Before calling any tool, call the `atryum.rules.get` tool to retrieve the rules that apply to you " +
+	"and the effective action (`auto_approve`, `human_approval`, or `auto_deny`) for a given server/tool. " +
+	"Prefer tools that resolve to `auto_approve`. Tools that resolve to `human_approval` will block until a " +
+	"human responds; tools that resolve to `auto_deny` will be rejected. " +
+	"Pass the target `server` (or `source`) and `tool` arguments to `atryum.rules.get` to get a disposition."
+
+type AgentRule struct {
+	ID             string   `json:"id"`
+	Action         string   `json:"action"`
+	ServerPatterns []string `json:"server_patterns"`
+	ToolPatterns   []string `json:"tool_patterns"`
+	AgentIDPattern string   `json:"agent_id_pattern"`
+	Description    string   `json:"description,omitempty"`
+	Order          int      `json:"order"`
+}
+
+type AgentRulesResponse struct {
+	AgentID       string      `json:"agent_id,omitempty"`
+	Server        string      `json:"server,omitempty"`
+	Tool          string      `json:"tool,omitempty"`
+	DefaultAction string      `json:"default_action"`
+	Action        string      `json:"action,omitempty"`
+	MatchedRuleID *string     `json:"matched_rule_id,omitempty"`
+	Items         []AgentRule `json:"items"`
+}
+
+var agentRulesToolInputSchema = json.RawMessage(`{"type":"object","properties":{"server":{"type":"string","description":"MCP server/upstream name to evaluate"},"source":{"type":"string","description":"External executor source to evaluate, such as amp"},"tool":{"type":"string","description":"Tool name to evaluate"}},"additionalProperties":false}`)
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 type jsonRPCRequest struct {
@@ -373,6 +408,8 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/admin/model-configs", h.adminModelConfigs)
 	mux.HandleFunc("/api/v1/admin/oauth/callback", h.oauthCallback)
 	mux.HandleFunc("/api/v1/admin/policy", h.adminPolicy)
+	agentRulesHandler := auth.MiddlewareWithOptions(h.authValidator, "/.well-known/oauth-protected-resource", auth.MiddlewareOptions{SkipVerify: h.authDebugSkip, DebugLogIdentity: h.debug})(http.HandlerFunc(h.agentRules))
+	mux.Handle("/api/v1/agent/rules", agentRulesHandler)
 	mux.HandleFunc("/api/v1/external/invocations", h.externalInvocations)
 	mux.HandleFunc("/api/v1/external/invocations/", h.externalInvocationDetail)
 	apiKeyMW := auth.APIKeyMiddleware(h.apiKeyAuth)
@@ -496,6 +533,80 @@ func (h *Handler) invocations(w http.ResponseWriter, r *http.Request) {
 	h.handleInvocation(w, r, "")
 }
 
+func (h *Handler) agentRules(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if h.rulesRepo == nil {
+		writeJSON(w, http.StatusOK, AgentRulesResponse{DefaultAction: invocation.RuleActionHumanApproval, Items: []AgentRule{}})
+		return
+	}
+
+	agentID := auth.AgentIDFromContext(r.Context())
+	if agentID == "" {
+		agentID = strings.TrimSpace(r.URL.Query().Get("agent_id"))
+	}
+	if agentID == "" {
+		agentID = strings.TrimSpace(r.URL.Query().Get("request_id"))
+	}
+	server := strings.TrimSpace(r.URL.Query().Get("server"))
+	if server == "" {
+		server = strings.TrimSpace(r.URL.Query().Get("source"))
+	}
+	tool := strings.TrimSpace(r.URL.Query().Get("tool"))
+
+	resp, err := h.buildAgentRulesResponse(r.Context(), agentID, server, tool)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, tool string) (AgentRulesResponse, error) {
+	resp := AgentRulesResponse{
+		AgentID:       agentID,
+		Server:        server,
+		Tool:          tool,
+		DefaultAction: invocation.RuleActionHumanApproval,
+		Items:         []AgentRule{},
+	}
+	if h.rulesRepo == nil {
+		return resp, nil
+	}
+
+	rules, err := h.rulesRepo.List(ctx)
+	if err != nil {
+		return AgentRulesResponse{}, err
+	}
+
+	for _, rule := range rules {
+		if !rule.Enabled || !apiMatchAgentIDPattern(rule.AgentIDPattern, agentID) {
+			continue
+		}
+		resp.Items = append(resp.Items, AgentRule{
+			ID:             rule.ID,
+			Action:         rule.Action,
+			ServerPatterns: rule.ServerPatterns,
+			ToolPatterns:   rule.ToolPatterns,
+			AgentIDPattern: rule.AgentIDPattern,
+			Description:    rule.Description,
+			Order:          rule.Order,
+		})
+		if resp.Action == "" && server != "" && tool != "" &&
+			apiMatchPatterns(rule.ServerPatterns, server) &&
+			apiMatchPatterns(rule.ToolPatterns, tool) {
+			resp.Action = rule.Action
+			if rule.ID != "" {
+				id := rule.ID
+				resp.MatchedRuleID = &id
+			}
+		}
+	}
+	return resp, nil
+}
+
 func (h *Handler) handleInvocation(w http.ResponseWriter, r *http.Request, server string) {
 	var req invocation.CreateInvocationRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -552,6 +663,7 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 			"capabilities": map[string]any{
 				"tools": map[string]any{},
 			},
+			"instructions": atryumInitializeInstructions,
 		}
 		h.writeRPCResult(w, req.ID, result)
 	case "notifications/initialized":
@@ -568,8 +680,10 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 			h.writeRPCError(w, req.ID, -32000, err.Error())
 			return
 		}
+		tools = appendAtryumTools(tools)
 		_ = h.emitTraceEvent(r.Context(), server, "mcp.tools.list", map[string]any{"tool_count": len(tools), "request_id": requestID})
-		h.writeRPCResult(w, req.ID, map[string]any{"tools": tools})
+		annotated := h.annotateToolsWithPolicy(r.Context(), server, tools)
+		h.writeRPCResult(w, req.ID, map[string]any{"tools": annotated})
 	case "tools/call":
 		var params struct {
 			Name      string         `json:"name"`
@@ -577,6 +691,16 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 		}
 		if err := json.Unmarshal(req.Params, &params); err != nil {
 			h.writeRPCError(w, req.ID, -32602, "invalid params")
+			return
+		}
+		if params.Name == agentRulesToolName {
+			result, err := h.callAgentRulesTool(r.Context(), server, params.Arguments)
+			if err != nil {
+				h.writeRPCError(w, req.ID, -32000, err.Error())
+				return
+			}
+			_ = h.emitTraceEvent(r.Context(), server, "mcp.tools.call", map[string]any{"request_id": requestID, "status": "succeeded", "tool": params.Name})
+			h.writeRPCResult(w, req.ID, result)
 			return
 		}
 		callServer := server
@@ -600,7 +724,11 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 		tracePayload := map[string]any{"request_id": requestID, "status": resp.Status, "invocation_id": resp.InvocationID, "tool": params.Name}
 		_ = h.emitTraceEvent(r.Context(), server, "mcp.tools.call", tracePayload)
 		if len(resp.Error) > 0 {
-			h.writeRPCResult(w, req.ID, normalizeToolCallResult(resp.Error, true))
+			result := normalizeToolCallResult(resp.Error, true)
+			if resp.Status == invocation.StatusDenied {
+				result = h.appendRulesContextToToolResult(r.Context(), result, callServer, params.Name)
+			}
+			h.writeRPCResult(w, req.ID, result)
 			return
 		}
 		h.writeRPCResult(w, req.ID, normalizeToolCallResult(resp.Result, false))
@@ -701,6 +829,201 @@ func parseDateParam(value string) (time.Time, error) {
 		return t.UTC(), nil
 	}
 	return time.Time{}, fmt.Errorf("expected RFC3339 timestamp or YYYY-MM-DD date")
+}
+
+func apiMatchPatterns(patterns []string, value string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	for _, pattern := range patterns {
+		if pattern == "*" || pattern == value {
+			return true
+		}
+	}
+	return false
+}
+
+func apiMatchAgentIDPattern(pattern, agentID string) bool {
+	return pattern == "" || pattern == "*" || pattern == agentID
+}
+
+// annotatedTool is the on-the-wire shape used for tools/list when atryum is
+// able to compute a per-tool policy disposition. It mirrors mcp.Tool but adds
+// an `annotations` block plus a description prefix so models that ignore
+// unknown fields still see the policy hint inline.
+type annotatedTool struct {
+	Name        string             `json:"name"`
+	Description string             `json:"description,omitempty"`
+	InputSchema json.RawMessage    `json:"inputSchema,omitempty"`
+	Annotations *atryumAnnotations `json:"annotations,omitempty"`
+}
+
+type atryumAnnotations struct {
+	Atryum atryumToolPolicy `json:"atryum"`
+}
+
+type atryumToolPolicy struct {
+	EffectiveAction string `json:"effective_action"`
+	MatchedRuleID   string `json:"matched_rule_id,omitempty"`
+}
+
+// annotateToolsWithPolicy decorates each tool with its effective approval
+// disposition for the current agent so the model sees the policy at the moment
+// it picks a tool. Annotation requires both rulesRepo and a concrete server;
+// in aggregate mode (server == "") we cannot reliably attribute tools to a
+// server, so we return the tools unchanged.
+func (h *Handler) annotateToolsWithPolicy(ctx context.Context, server string, tools []mcp.Tool) []any {
+	out := make([]any, len(tools))
+	if h.rulesRepo == nil || strings.TrimSpace(server) == "" {
+		for i, t := range tools {
+			out[i] = t
+		}
+		return out
+	}
+	rules, err := h.rulesRepo.List(ctx)
+	if err != nil {
+		for i, t := range tools {
+			out[i] = t
+		}
+		return out
+	}
+	agentID := auth.AgentIDFromContext(ctx)
+	for i, t := range tools {
+		if t.Name == agentRulesToolName {
+			out[i] = t
+			continue
+		}
+		action, matched := effectiveActionForTool(rules, server, t.Name, agentID)
+		desc := t.Description
+		if action != "" {
+			prefix := "[atryum policy: " + action + "] "
+			if desc == "" {
+				desc = strings.TrimSpace(prefix)
+			} else {
+				desc = prefix + desc
+			}
+		}
+		out[i] = annotatedTool{
+			Name:        t.Name,
+			Description: desc,
+			InputSchema: t.InputSchema,
+			Annotations: &atryumAnnotations{Atryum: atryumToolPolicy{
+				EffectiveAction: action,
+				MatchedRuleID:   matched,
+			}},
+		}
+	}
+	return out
+}
+
+// effectiveActionForTool returns the action of the first enabled rule that
+// matches (server, tool, agentID), mirroring invocation.matchRule semantics.
+// When no rule matches, it returns RuleActionHumanApproval (the default).
+func effectiveActionForTool(rules []store.Rule, server, tool, agentID string) (string, string) {
+	for _, r := range rules {
+		if !r.Enabled {
+			continue
+		}
+		if !apiMatchPatterns(r.ServerPatterns, server) {
+			continue
+		}
+		if !apiMatchPatterns(r.ToolPatterns, tool) {
+			continue
+		}
+		if !apiMatchAgentIDPattern(r.AgentIDPattern, agentID) {
+			continue
+		}
+		return r.Action, r.ID
+	}
+	return invocation.RuleActionHumanApproval, ""
+}
+
+// appendRulesContextToToolResult adds an extra text content block to a denied
+// tool call result describing the applicable rules and effective action, so
+// the model can learn the policy through feedback instead of having to call
+// atryum.rules.get explicitly.
+func (h *Handler) appendRulesContextToToolResult(ctx context.Context, result any, server, tool string) any {
+	if h.rulesRepo == nil {
+		return result
+	}
+	rulesResp, err := h.buildAgentRulesResponse(ctx, auth.AgentIDFromContext(ctx), server, tool)
+	if err != nil {
+		return result
+	}
+	body, err := json.MarshalIndent(rulesResp, "", "  ")
+	if err != nil {
+		return result
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		return result
+	}
+	rulesText := "Atryum approval rules applicable to this call:\n" + string(body)
+	if existing, ok := m["content"].([]map[string]any); ok {
+		m["content"] = append(existing, map[string]any{"type": "text", "text": rulesText})
+		return m
+	}
+	if existing, ok := m["content"].([]any); ok {
+		m["content"] = append(existing, map[string]any{"type": "text", "text": rulesText})
+		return m
+	}
+	m["content"] = []map[string]any{{"type": "text", "text": rulesText}}
+	return m
+}
+
+func appendAtryumTools(tools []mcp.Tool) []mcp.Tool {
+	for _, tool := range tools {
+		if tool.Name == agentRulesToolName {
+			return tools
+		}
+	}
+	return append(tools, mcp.Tool{
+		Name:        agentRulesToolName,
+		Description: "Return the approval rules and effective action for this agent. Call this before choosing tools so you can prefer auto_approve tools and avoid tools that require human_approval or auto_deny.",
+		InputSchema: agentRulesToolInputSchema,
+	})
+}
+
+func (h *Handler) callAgentRulesTool(ctx context.Context, currentServer string, args map[string]any) (map[string]any, error) {
+	server := strings.TrimSpace(currentServer)
+	if server == "" {
+		server = stringArg(args, "server")
+	}
+	if server == "" {
+		server = stringArg(args, "source")
+	}
+	tool := stringArg(args, "tool")
+	resp, err := h.buildAgentRulesResponse(ctx, auth.AgentIDFromContext(ctx), server, tool)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"content": []map[string]any{{
+			"type": "text",
+			"text": string(body),
+		}},
+		"isError": false,
+	}, nil
+}
+
+func stringArg(args map[string]any, name string) string {
+	if args == nil {
+		return ""
+	}
+	value, ok := args[name]
+	if !ok {
+		return ""
+	}
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	default:
+		return strings.TrimSpace(fmt.Sprint(v))
+	}
 }
 
 func (h *Handler) adminInvocations(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -272,7 +272,7 @@ func TestMCPRulesToolReturnsApplicableRulesWithoutInvocation(t *testing.T) {
 		{ID: "read-auto", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "*", Enabled: true, Order: 0},
 	}}
 	svc := &stubService{}
-	h := NewHandler(svc, stubServerService{}, nil, rules)
+	h := NewHandler(svc, stubServerService{}, nil, rules, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"atryum.rules.get","arguments":{"tool":"Read"}}}`))
 	w := httptest.NewRecorder()
 
@@ -309,7 +309,7 @@ func TestAgentRulesListsApplicableRulesAndDisposition(t *testing.T) {
 		{ID: "fallback-human", Action: invocation.RuleActionHumanApproval, ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"}, AgentIDPattern: "*", Enabled: true, Order: 2},
 		{ID: "disabled", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Bash"}, AgentIDPattern: "agent-007", Enabled: false, Order: 3},
 	}}
-	h := NewHandler(&stubService{}, stubServerService{}, nil, rules)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/rules?agent_id=agent-007&source=amp&tool=Read", nil)
 	w := httptest.NewRecorder()
 
@@ -345,7 +345,7 @@ func TestMCPToolsListAnnotatesEffectiveAction(t *testing.T) {
 		{ID: "bash-deny", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Bash"}, AgentIDPattern: "*", Enabled: true, Order: 1},
 	}}
 	svc := &stubService{tools: []mcp.Tool{{Name: "Read", Description: "read a file"}, {Name: "Bash", Description: "run a shell command"}, {Name: "Other"}}}
-	h := NewHandler(svc, stubServerService{}, nil, rules)
+	h := NewHandler(svc, stubServerService{}, nil, rules, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
 	w := httptest.NewRecorder()
 
@@ -407,7 +407,7 @@ func TestMCPToolsCallDenialIncludesRulesContext(t *testing.T) {
 		SubmittedAt: now, CompletedAt: &now,
 		Error: json.RawMessage(`{"content":[{"type":"text","text":"Tool call denied by approval rule (auto_deny)."}],"isError":true}`),
 	}}
-	h := NewHandler(svc, stubServerService{}, nil, rules)
+	h := NewHandler(svc, stubServerService{}, nil, rules, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"Bash","arguments":{"cmd":"ls"}}}`))
 	w := httptest.NewRecorder()
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -11,6 +11,7 @@ import (
 
 	"atryum/internal/invocation"
 	"atryum/internal/mcp"
+	"atryum/internal/store"
 )
 
 type stubService struct {
@@ -90,6 +91,31 @@ func (stubServerService) CompleteConnect(context.Context, string, string, string
 	return OAuthConnectStatusResponse{}, nil
 }
 
+type stubRulesRepo struct {
+	rules []store.Rule
+	err   error
+}
+
+func (s *stubRulesRepo) Create(context.Context, store.Rule) error { return nil }
+func (s *stubRulesRepo) Get(_ context.Context, id string) (store.Rule, error) {
+	for _, rule := range s.rules {
+		if rule.ID == id {
+			return rule, nil
+		}
+	}
+	return store.Rule{}, nil
+}
+func (s *stubRulesRepo) List(context.Context) ([]store.Rule, error) {
+	return s.rules, s.err
+}
+func (s *stubRulesRepo) NextOrder(context.Context) (int, error)   { return len(s.rules), nil }
+func (s *stubRulesRepo) Update(context.Context, store.Rule) error { return nil }
+func (s *stubRulesRepo) Delete(context.Context, string) error     { return nil }
+func (s *stubRulesRepo) Move(context.Context, string, string) ([]store.Rule, error) {
+	return s.rules, nil
+}
+func (s *stubRulesRepo) InsertBefore(context.Context, string, store.Rule) error { return nil }
+
 func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`))
@@ -112,6 +138,10 @@ func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 	result := resp["result"].(map[string]any)
 	if result["protocolVersion"] != "2025-11-25" {
 		t.Fatalf("expected protocol version 2025-11-25, got %#v", result["protocolVersion"])
+	}
+	instructions, ok := result["instructions"].(string)
+	if !ok || !strings.Contains(instructions, "atryum.rules.get") {
+		t.Fatalf("expected initialize instructions to mention atryum.rules.get, got %#v", result["instructions"])
 	}
 }
 
@@ -209,6 +239,9 @@ func TestMCPToolsList(t *testing.T) {
 	if !strings.Contains(w.Body.String(), `"demo_tool"`) {
 		t.Fatalf("expected tools list, got %s", w.Body.String())
 	}
+	if !strings.Contains(w.Body.String(), `"atryum.rules.get"`) {
+		t.Fatalf("expected synthetic rules tool, got %s", w.Body.String())
+	}
 }
 
 func TestMCPToolsCallInterceptsInvocation(t *testing.T) {
@@ -231,6 +264,176 @@ func TestMCPToolsCallInterceptsInvocation(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), `"text":"ok"`) {
 		t.Fatalf("expected tool result, got %s", w.Body.String())
+	}
+}
+
+func TestMCPRulesToolReturnsApplicableRulesWithoutInvocation(t *testing.T) {
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "read-auto", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "*", Enabled: true, Order: 0},
+	}}
+	svc := &stubService{}
+	h := NewHandler(svc, stubServerService{}, nil, rules)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"atryum.rules.get","arguments":{"tool":"Read"}}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if svc.invokedReq != nil {
+		t.Fatalf("rules tool should not create invocation, got %#v", svc.invokedReq)
+	}
+	var rpcResp struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &rpcResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rpcResp.Result.Content) != 1 {
+		t.Fatalf("expected one content item, got %#v", rpcResp.Result.Content)
+	}
+	if !strings.Contains(rpcResp.Result.Content[0].Text, `"read-auto"`) || !strings.Contains(rpcResp.Result.Content[0].Text, `"action": "auto_approve"`) {
+		t.Fatalf("expected rules payload in tool result, got %s", rpcResp.Result.Content[0].Text)
+	}
+}
+
+func TestAgentRulesListsApplicableRulesAndDisposition(t *testing.T) {
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "other-agent", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "agent-other", Enabled: true, Order: 0},
+		{ID: "read-auto", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "agent-007", Description: "Read is safe", Enabled: true, Order: 1},
+		{ID: "fallback-human", Action: invocation.RuleActionHumanApproval, ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"}, AgentIDPattern: "*", Enabled: true, Order: 2},
+		{ID: "disabled", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Bash"}, AgentIDPattern: "agent-007", Enabled: false, Order: 3},
+	}}
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/rules?agent_id=agent-007&source=amp&tool=Read", nil)
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AgentRulesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.AgentID != "agent-007" {
+		t.Fatalf("expected agent_id agent-007, got %q", resp.AgentID)
+	}
+	if resp.Action != invocation.RuleActionAutoApprove {
+		t.Fatalf("expected auto approve disposition, got %q", resp.Action)
+	}
+	if resp.MatchedRuleID == nil || *resp.MatchedRuleID != "read-auto" {
+		t.Fatalf("expected matched rule read-auto, got %#v", resp.MatchedRuleID)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected two applicable rules, got %#v", resp.Items)
+	}
+	if resp.Items[0].ID != "read-auto" || resp.Items[1].ID != "fallback-human" {
+		t.Fatalf("unexpected applicable rules order: %#v", resp.Items)
+	}
+}
+
+func TestMCPToolsListAnnotatesEffectiveAction(t *testing.T) {
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "read-auto", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "*", Enabled: true, Order: 0},
+		{ID: "bash-deny", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Bash"}, AgentIDPattern: "*", Enabled: true, Order: 1},
+	}}
+	svc := &stubService{tools: []mcp.Tool{{Name: "Read", Description: "read a file"}, {Name: "Bash", Description: "run a shell command"}, {Name: "Other"}}}
+	h := NewHandler(svc, stubServerService{}, nil, rules)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	var rpcResp struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				Description string `json:"description"`
+				Annotations *struct {
+					Atryum struct {
+						EffectiveAction string `json:"effective_action"`
+						MatchedRuleID   string `json:"matched_rule_id"`
+					} `json:"atryum"`
+				} `json:"annotations"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &rpcResp); err != nil {
+		t.Fatal(err)
+	}
+	byName := map[string]int{}
+	for i, t := range rpcResp.Result.Tools {
+		byName[t.Name] = i
+	}
+	readTool := rpcResp.Result.Tools[byName["Read"]]
+	if readTool.Annotations == nil || readTool.Annotations.Atryum.EffectiveAction != invocation.RuleActionAutoApprove {
+		t.Fatalf("Read tool annotations: %#v", readTool.Annotations)
+	}
+	if readTool.Annotations.Atryum.MatchedRuleID != "read-auto" {
+		t.Fatalf("Read matched rule: %q", readTool.Annotations.Atryum.MatchedRuleID)
+	}
+	if !strings.HasPrefix(readTool.Description, "[atryum policy: auto_approve]") {
+		t.Fatalf("Read description prefix: %q", readTool.Description)
+	}
+	bashTool := rpcResp.Result.Tools[byName["Bash"]]
+	if bashTool.Annotations == nil || bashTool.Annotations.Atryum.EffectiveAction != invocation.RuleActionAutoDeny {
+		t.Fatalf("Bash tool annotations: %#v", bashTool.Annotations)
+	}
+	otherTool := rpcResp.Result.Tools[byName["Other"]]
+	if otherTool.Annotations == nil || otherTool.Annotations.Atryum.EffectiveAction != invocation.RuleActionHumanApproval {
+		t.Fatalf("Other tool annotations: %#v", otherTool.Annotations)
+	}
+	rulesTool := rpcResp.Result.Tools[byName["atryum.rules.get"]]
+	if rulesTool.Annotations != nil {
+		t.Fatalf("synthetic rules tool should not be annotated, got %#v", rulesTool.Annotations)
+	}
+}
+
+func TestMCPToolsCallDenialIncludesRulesContext(t *testing.T) {
+	now := time.Now().UTC()
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "bash-deny", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Bash"}, AgentIDPattern: "*", Enabled: true, Order: 0},
+	}}
+	svc := &stubService{invoke: invocation.InvocationResponse{
+		InvocationID: "inv_denied", ServerName: "demo", ToolName: "Bash",
+		Status:      invocation.StatusDenied,
+		SubmittedAt: now, CompletedAt: &now,
+		Error: json.RawMessage(`{"content":[{"type":"text","text":"Tool call denied by approval rule (auto_deny)."}],"isError":true}`),
+	}}
+	h := NewHandler(svc, stubServerService{}, nil, rules)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"Bash","arguments":{"cmd":"ls"}}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	var rpcResp struct {
+		Result struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &rpcResp); err != nil {
+		t.Fatal(err)
+	}
+	if !rpcResp.Result.IsError {
+		t.Fatalf("expected isError=true, got %#v", rpcResp.Result)
+	}
+	if len(rpcResp.Result.Content) < 2 {
+		t.Fatalf("expected denial text plus rules context, got %#v", rpcResp.Result.Content)
+	}
+	last := rpcResp.Result.Content[len(rpcResp.Result.Content)-1].Text
+	if !strings.Contains(last, "Atryum approval rules") || !strings.Contains(last, "bash-deny") {
+		t.Fatalf("expected rules context in denial result, got %q", last)
 	}
 }
 


### PR DESCRIPTION
Surface atryum's approval rules to MCP agents so they can prefer auto‑approved tools and avoid ones that require human approval or are auto‑denied.

## Changes (all under `internal/api/`)

**New `GET /api/v1/agent/rules` endpoint**
- Auth‑gated; resolves agent ID from the JWT (falling back to `agent_id` / `request_id` query params).
- Accepts `server` (or `source`) and `tool` query params and returns the applicable rules plus the effective `action` (`auto_approve` / `human_approval` / `auto_deny`) and `matched_rule_id`.
- Default action is `human_approval` when no rule matches.

**MCP proxy now exposes & uses an `atryum.rules.get` tool**
- `initialize` result includes an `instructions` string telling the model to consult `atryum.rules.get` before choosing tools.
- `tools/list` injects a synthetic `atryum.rules.get` tool and annotates every other tool with `annotations.atryum.effective_action` plus an `[atryum policy: …]` description prefix (skipped in aggregate mode where the server isn't known).
- `tools/call` short‑circuits `atryum.rules.get` without creating an invocation, returning the same response payload as the REST endpoint.
- Denied tool calls now include an extra text block describing the applicable rules so the model gets feedback on why it was blocked.

**Tests**
- `TestAgentRulesRequiresAuthAndUsesTokenAgentID` — 401 without bearer; token's `agent_id` overrides query param.
- `TestAgentRulesListsApplicableRulesAndDisposition` — ordering, disabled‑rule filtering, dispositions.
- `TestMCPInitializeNegotiatesProtocolVersion` — instructions mention `atryum.rules.get`.
- `TestMCPToolsList` — synthetic rules tool appears in `tools/list`.
- `TestMCPRulesToolReturnsApplicableRulesWithoutInvocation` — calling the synthetic tool doesn't create an invocation.
- `TestMCPToolsListAnnotatesEffectiveAction` — annotations + description prefix for Read/Bash/Other; synthetic tool not annotated.
- `TestMCPToolsCallDenialIncludesRulesContext` — rules context appended to denial result.

No changes to the underlying invocation/approval flow.
