### PR TITLE
NOMERGE Add agentforce POC

### DIFF
--- a/examples/agentforce/README.md
+++ b/examples/agentforce/README.md
@@ -1,0 +1,185 @@
+# Atryum Agentforce example
+
+Mediate Salesforce Agentforce Agent tool calls through Atryum by exposing
+Atryum as a set of **Apex Invocable Actions** — sidestepping the Agentforce
+Registry / MCP-connection path entirely.
+
+## Pattern
+
+```
+╭──────────────╮  AtryumDispatcher (Apex action)         ╭────────────╮     ╭──────────╮
+│  Agentforce  │ ─── JSON-RPC tools/call ────────────▶   │  Atryum    │ ──▶ │ upstream │
+│    Agent     │     server, toolName, arguments         │  approval  │     │   MCP    │
+╰──────┬───────╯                                         ╰─────┬──────╯     ╰──────────╯
+       │  synchronous wait                                     │
+       │ ◀───── result | denied | error ──── human/rule ───▶ /ui/
+       ▼
+   agent gets resultText/resultJson or errorMessage
+```
+
+`AtryumDispatcher` POSTs an MCP JSON-RPC `tools/call` envelope to
+`callout:Atryum/mcp/{server}`. Atryum runs its approval gate (rules first,
+human second), proxies to the upstream MCP server on approval, and returns
+the result inline. The agent sees the tool's output without ever talking to
+the upstream directly.
+
+`AtryumListTools` lets the agent discover what servers/tools exist at runtime
+by calling Atryum's admin API (`/api/v1/admin/servers` and
+`/api/v1/admin/servers/{name}/tools`).
+
+## Files
+
+- `force-app/main/default/classes/AtryumDispatcher.cls` — invokes a tool via Atryum's `/mcp/{server}` proxy
+- `force-app/main/default/classes/AtryumListTools.cls` — discover servers & tools at runtime
+- `force-app/main/default/classes/AtryumPoll.cls` — legacy stub for an external-invocations async pattern; not wired into the current dispatcher
+
+## Setup
+
+### 1. Atryum + Keycloak reachable from Salesforce
+
+Salesforce Apex callouts go out from Salesforce's data centers, so both
+Atryum *and* its OAuth issuer (Keycloak in the default `atryum.toml`) need
+public URLs. ngrok works for local development:
+
+```
+atryum    → https://<atryum-host>
+keycloak  → https://<keycloak-host>
+```
+
+In Keycloak (`https://<keycloak-host>/admin/`, realm `atryum`):
+
+1. **Realm Settings → General → Frontend URL** = `https://<keycloak-host>`
+   so tokens are issued with the public `iss` claim.
+2. **Clients → Create**:
+   - Client ID: `salesforce-agentforce`
+   - Client authentication: **On**
+   - Authentication flow: **Service accounts roles** only (= client_credentials)
+   - Copy the generated **Client Secret** from the Credentials tab.
+3. **Client Scopes → atryum:mcp → Mappers → Add → Audience**:
+   - Included Custom Audience: `atryum`
+   - Add to access token: **On**
+   Then assign `atryum:mcp` as a **Default** scope on the
+   `salesforce-agentforce` client.
+
+In `atryum.toml`, point `[[auth]]` at the public Keycloak URL:
+
+```toml
+[[auth]]
+enabled  = true
+issuer   = "https://<keycloak-host>/realms/atryum"
+audience = "atryum"
+```
+
+Verify by hand:
+
+```sh
+TOK=$(curl -s -X POST https://<keycloak-host>/realms/atryum/protocol/openid-connect/token \
+  -d grant_type=client_credentials \
+  -d client_id=salesforce-agentforce \
+  -d client_secret=<secret> \
+  -d scope=atryum:mcp | jq -r .access_token)
+echo "$TOK" | cut -d. -f2 | base64 -d 2>/dev/null | jq '{iss, aud, scope}'
+```
+
+`iss` should be the public Keycloak URL and `aud` should include `atryum`.
+
+### 2. Salesforce: External Auth Identity Provider
+
+Setup → Named Credentials → **External Credentials** → Identity Providers
+tab → New.
+
+- Provider Type: **OpenID Connect** (or "Custom" if the UI differs)
+- **Authorize Endpoint URL**: `https://<keycloak-host>/realms/atryum/protocol/openid-connect/auth`
+- **Token Endpoint URL**: `https://<keycloak-host>/realms/atryum/protocol/openid-connect/token`
+- **Client ID**: `salesforce-agentforce`
+- **Client Secret**: paste from Keycloak
+
+### 3. Salesforce: External Credential
+
+Setup → Named Credentials → **External Credentials** → New.
+
+- Label / Name: `Atryum`
+- Authentication Protocol: **OAuth 2.0**
+- Authentication Flow Type: **Client Credentials with Client Secret Flow**
+- **Scope** parameter: `atryum:mcp`
+- **Identity Provider** parameter: the one created in step 2
+- **Principals → New**: Named Principal, sequence 1
+
+### 4. Salesforce: Permission Set for the principal
+
+External Credentials gate access through Permission Sets, not profiles.
+
+1. Setup → Permission Sets → New → label `Atryum Access`.
+2. Open it → **External Credential Principal Access** → Edit → enable the
+   `Atryum` Principal → Save.
+3. Assign this Permission Set to:
+   - your admin user (for anonymous Apex testing)
+   - the **Agentforce Agent User** (whoever the agent runs as — check Agent
+     Builder → agent settings → User)
+
+### 5. Salesforce: Named Credential
+
+Setup → Named Credentials → **Named Credentials** tab → New.
+
+- Label / Name: `Atryum`
+- URL: `https://<atryum-host>` (base only, no path, no trailing slash)
+- External Credential: `Atryum`
+- Generate Authorization Header: **On**
+
+### 6. Deploy the Apex
+
+```sh
+sf project deploy start -d force-app
+```
+
+### 7. Sanity-check with anonymous Apex
+
+Setup → Developer Console → Debug → Execute Anonymous:
+
+```apex
+HttpRequest req = new HttpRequest();
+req.setEndpoint('callout:Atryum/api/v1/admin/servers');
+req.setMethod('GET');
+HttpResponse r = new Http().send(req);
+System.debug(r.getStatusCode() + ' ' + r.getBody());
+```
+
+Expect `200` plus a JSON list of servers. If 401, decode a fresh token (see
+step 1 verification) and reconcile `iss`/`aud` with `atryum.toml`. If
+"unable to fetch OAuth token", check that the Permission Set is assigned to
+the user running Execute Anonymous.
+
+### 8. Wire actions into an agent
+
+Agent Builder → your agent → Topics → pick or create a topic for external
+tools → Actions tab → Add → From Apex Class → add both `AtryumDispatcher`
+and `AtryumListTools`.
+
+Topic instructions (paste into the topic's Instructions field):
+
+> Whenever the user asks for an action that requires an external system,
+> first call `AtryumListTools` (optionally with `keyword` to narrow to a
+> server name or tool keyword like "github" or "issue") to see what's
+> available. Then call `AtryumDispatcher` with the matching `server`,
+> `toolName`, and `argumentsJson` shaped per the returned `inputSchema`.
+> Report `resultText` to the user. If `status` is `denied`, `error`, or
+> `tool_error`, surface `errorMessage` and stop — do not retry.
+
+## Limits / caveats
+
+- **120s callout ceiling.** Apex synchronous callouts cap at 120 seconds.
+  The dispatcher uses Apex's full timeout (120000 ms) on the call to
+  Atryum, so any human approval that takes longer than ~2 minutes will hit
+  the limit and surface as `error`. Auto-approval rules in Atryum are the
+  intended workaround for the long-tail.
+- **Generic dispatcher routing.** One Apex action handles all tools, so the
+  LLM does the routing from natural language → `server`/`toolName`/`args`.
+  This degrades as the catalog grows. For better routing quality at scale,
+  consider per-tool Apex wrappers, or have Atryum emit an OpenAPI spec and
+  register it via Salesforce **External Services** (one auto-generated
+  action per tool with its real schema).
+- **Auth scope.** Atryum's `[[auth]]` config only protects `/mcp/`; admin
+  endpoints (`/api/v1/admin/*`) are unauthenticated by default, which is
+  why `AtryumListTools` works even if `/mcp/` auth is misconfigured. Put
+  Atryum behind a network boundary or add gateway auth if admin endpoints
+  shouldn't be world-readable in your deployment.

--- a/examples/agentforce/force-app/main/default/classes/AtryumDispatcher.cls
+++ b/examples/agentforce/force-app/main/default/classes/AtryumDispatcher.cls
@@ -1,0 +1,143 @@
+public with sharing class AtryumDispatcher {
+
+    public class Request {
+        @InvocableVariable(required=true label='Tool name'
+            description='Upstream MCP tool name (e.g. create_issue).')
+        public String toolName;
+
+        @InvocableVariable(required=true label='Server'
+            description='Atryum-configured upstream server name (e.g. github).')
+        public String server;
+
+        @InvocableVariable(required=true label='Arguments JSON'
+            description='JSON-encoded arguments object for the tool call.')
+        public String argumentsJson;
+    }
+
+    public class Response {
+        @InvocableVariable(description='ok | denied | error | tool_error')
+        public String status;
+
+        @InvocableVariable(description='Text content returned by the tool (concatenated MCP content blocks).')
+        public String resultText;
+
+        @InvocableVariable(description='Raw JSON of the full MCP result for the agent to inspect when needed.')
+        public String resultJson;
+
+        @InvocableVariable(description='Error or denial message when status != ok.')
+        public String errorMessage;
+    }
+
+    @InvocableMethod(label='Call Atryum-mediated MCP tool'
+        description='Invoke a tool on an Atryum-registered MCP server. Atryum gates approval, audits the call, and proxies to the upstream.'
+        callout=true)
+    public static List<Response> dispatch(List<Request> requests) {
+        List<Response> out = new List<Response>();
+        for (Request r : requests) {
+            out.add(callOne(r));
+        }
+        return out;
+    }
+
+    private static Response callOne(Request r) {
+        Response resp = new Response();
+
+        Map<String,Object> args;
+        try {
+            args = (Map<String,Object>) JSON.deserializeUntyped(
+                String.isBlank(r.argumentsJson) ? '{}' : r.argumentsJson);
+        } catch (Exception e) {
+            resp.status = 'error';
+            resp.errorMessage = 'argumentsJson is not valid JSON: ' + e.getMessage();
+            return resp;
+        }
+
+        Map<String,Object> envelope = new Map<String,Object>{
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'method'  => 'tools/call',
+            'params'  => new Map<String,Object>{
+                'name'      => r.toolName,
+                'arguments' => args
+            }
+        };
+
+        HttpRequest req = new HttpRequest();
+        req.setEndpoint('callout:Atryum/mcp/' + EncodingUtil.urlEncode(r.server, 'UTF-8'));
+        req.setMethod('POST');
+        req.setHeader('Content-Type', 'application/json');
+        req.setHeader('Accept', 'application/json');
+        req.setTimeout(120000);
+        req.setBody(JSON.serialize(envelope));
+
+        HttpResponse hr;
+        try {
+            hr = new Http().send(req);
+        } catch (CalloutException ce) {
+            resp.status = 'error';
+            resp.errorMessage = 'callout failed: ' + ce.getMessage();
+            return resp;
+        }
+
+        Integer code = hr.getStatusCode();
+        String body = hr.getBody();
+
+        if (code == 403) {
+            resp.status = 'denied';
+            resp.errorMessage = body;
+            return resp;
+        }
+        if (code >= 300) {
+            resp.status = 'error';
+            resp.errorMessage = 'HTTP ' + code + ': ' + body;
+            return resp;
+        }
+
+        Map<String,Object> decoded;
+        try {
+            decoded = (Map<String,Object>) JSON.deserializeUntyped(body);
+        } catch (Exception e) {
+            resp.status = 'error';
+            resp.errorMessage = 'non-JSON response from atryum: ' + body;
+            return resp;
+        }
+
+        // JSON-RPC transport-level error
+        if (decoded.get('error') != null) {
+            Map<String,Object> err = (Map<String,Object>) decoded.get('error');
+            resp.status = 'error';
+            resp.errorMessage = String.valueOf(err.get('message'));
+            return resp;
+        }
+
+        Map<String,Object> result = (Map<String,Object>) decoded.get('result');
+        if (result == null) {
+            resp.status = 'error';
+            resp.errorMessage = 'missing result in response: ' + body;
+            return resp;
+        }
+
+        resp.resultJson = JSON.serialize(result);
+        resp.resultText = flattenContent((List<Object>) result.get('content'));
+
+        Boolean isError = result.get('isError') == true;
+        resp.status = isError ? 'tool_error' : 'ok';
+        if (isError && String.isBlank(resp.errorMessage)) {
+            resp.errorMessage = resp.resultText;
+        }
+        return resp;
+    }
+
+    private static String flattenContent(List<Object> content) {
+        if (content == null) return '';
+        List<String> parts = new List<String>();
+        for (Object o : content) {
+            Map<String,Object> block = (Map<String,Object>) o;
+            String t = (String) block.get('type');
+            if (t == 'text' && block.get('text') != null) {
+                parts.add(String.valueOf(block.get('text')));
+            }
+        }
+        return String.join(parts, '\n');
+    }
+}

--- a/examples/agentforce/force-app/main/default/classes/AtryumDispatcher.cls-meta.xml
+++ b/examples/agentforce/force-app/main/default/classes/AtryumDispatcher.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/examples/agentforce/force-app/main/default/classes/AtryumListTools.cls
+++ b/examples/agentforce/force-app/main/default/classes/AtryumListTools.cls
@@ -1,0 +1,104 @@
+public with sharing class AtryumListTools {
+
+    public class Request {
+        @InvocableVariable(label='Server filter'
+            description='Optional: limit results to a single Atryum server name (e.g. "github"). Leave blank for all servers.')
+        public String server;
+
+        @InvocableVariable(label='Keyword filter'
+            description='Optional: case-insensitive substring match against server name, tool name, or tool description. Use this when you only know roughly what you are looking for (e.g. "slack", "issue", "send").')
+        public String keyword;
+    }
+
+    public class Response {
+        @InvocableVariable(description='JSON array of {server, toolName, description, inputSchema} entries.')
+        public String catalogJson;
+
+        @InvocableVariable(description='Human-readable summary suitable for the agent to reason over.')
+        public String summary;
+    }
+
+    @InvocableMethod(label='Discover Atryum tools'
+        description='List MCP tools available through Atryum, optionally filtered by server or keyword. Call this before AtryumDispatcher when you do not already know the correct server/toolName.'
+        callout=true)
+    public static List<Response> discover(List<Request> reqs) {
+        List<Response> out = new List<Response>();
+        for (Request r : reqs) {
+            out.add(discoverOne(r));
+        }
+        return out;
+    }
+
+    private static Response discoverOne(Request r) {
+        Response resp = new Response();
+        List<Map<String,Object>> catalog = new List<Map<String,Object>>();
+
+        // 1. Determine which servers to enumerate
+        List<String> servers = new List<String>();
+        if (String.isNotBlank(r.server)) {
+            servers.add(r.server);
+        } else {
+            HttpRequest listReq = new HttpRequest();
+            listReq.setEndpoint('callout:Atryum/api/v1/admin/servers?enabled=true&limit=200');
+            listReq.setMethod('GET');
+            HttpResponse lr = new Http().send(listReq);
+            if (lr.getStatusCode() >= 300) {
+                resp.summary = 'failed to list servers: ' + lr.getStatus();
+                resp.catalogJson = '[]';
+                return resp;
+            }
+            Map<String,Object> body = (Map<String,Object>) JSON.deserializeUntyped(lr.getBody());
+            List<Object> items = (List<Object>) body.get('items');
+            if (items == null) items = (List<Object>) body.get('servers');
+            if (items != null) {
+                for (Object o : items) {
+                    Map<String,Object> s = (Map<String,Object>) o;
+                    servers.add((String) s.get('name'));
+                }
+            }
+        }
+
+        // 2. Fetch tools for each server
+        String kw = String.isBlank(r.keyword) ? null : r.keyword.toLowerCase();
+        for (String name : servers) {
+            HttpRequest tr = new HttpRequest();
+            tr.setEndpoint('callout:Atryum/api/v1/admin/servers/' + EncodingUtil.urlEncode(name, 'UTF-8') + '/tools');
+            tr.setMethod('GET');
+            HttpResponse trr = new Http().send(tr);
+            if (trr.getStatusCode() >= 300) continue;
+
+            Map<String,Object> body = (Map<String,Object>) JSON.deserializeUntyped(trr.getBody());
+            List<Object> tools = (List<Object>) body.get('items');
+            if (tools == null) tools = (List<Object>) body.get('tools');
+            if (tools == null) continue;
+
+            for (Object o : tools) {
+                Map<String,Object> t = (Map<String,Object>) o;
+                String toolName = (String) t.get('name');
+                String descr = (String) t.get('description');
+                if (kw != null) {
+                    String hay = (name == null ? '' : name.toLowerCase())
+                               + ' ' + (toolName == null ? '' : toolName.toLowerCase())
+                               + ' ' + (descr == null ? '' : descr.toLowerCase());
+                    if (!hay.contains(kw)) continue;
+                }
+                catalog.add(new Map<String,Object>{
+                    'server'      => name,
+                    'toolName'    => toolName,
+                    'description' => descr,
+                    'inputSchema' => t.get('inputSchema')
+                });
+            }
+        }
+
+        // 3. Build summary
+        resp.catalogJson = JSON.serialize(catalog);
+        List<String> lines = new List<String>{ 'Available tools (' + catalog.size() + '):' };
+        for (Map<String,Object> entry : catalog) {
+            lines.add('- ' + entry.get('server') + '.' + entry.get('toolName')
+                + ': ' + (entry.get('description') == null ? '' : entry.get('description')));
+        }
+        resp.summary = String.join(lines, '\n');
+        return resp;
+    }
+}

--- a/examples/agentforce/force-app/main/default/classes/AtryumListTools.cls-meta.xml
+++ b/examples/agentforce/force-app/main/default/classes/AtryumListTools.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/examples/agentforce/force-app/main/default/classes/AtryumPoll.cls
+++ b/examples/agentforce/force-app/main/default/classes/AtryumPoll.cls
@@ -1,0 +1,32 @@
+public with sharing class AtryumPoll {
+
+    public class Request {
+        @InvocableVariable(required=true) public String invocationId;
+    }
+
+    public class Response {
+        @InvocableVariable public String status;
+        @InvocableVariable public String resultJson;
+        @InvocableVariable public String denyReason;
+    }
+
+    @InvocableMethod(label='Re-check Atryum invocation'
+        description='Returns the current status of a previously submitted Atryum invocation.'
+        callout=true)
+    public static List<Response> poll(List<Request> reqs) {
+        List<Response> out = new List<Response>();
+        for (Request r : reqs) {
+            HttpRequest req = new HttpRequest();
+            req.setEndpoint('callout:Atryum/api/v1/external/invocations/' + r.invocationId);
+            req.setMethod('GET');
+            HttpResponse pr = new Http().send(req);
+            Map<String,Object> state = (Map<String,Object>) JSON.deserializeUntyped(pr.getBody());
+            Response resp = new Response();
+            resp.status = (String) state.get('status');
+            resp.resultJson = JSON.serialize(state.get('result'));
+            resp.denyReason = (String) state.get('deny_reason');
+            out.add(resp);
+        }
+        return out;
+    }
+}

--- a/examples/agentforce/force-app/main/default/classes/AtryumPoll.cls-meta.xml
+++ b/examples/agentforce/force-app/main/default/classes/AtryumPoll.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/examples/agentforce/sfdx-project.json
+++ b/examples/agentforce/sfdx-project.json
@@ -1,0 +1,9 @@
+{
+    "packageDirectories": [
+        { "path": "force-app", "default": true }
+    ],
+    "name": "atryum-agentforce",
+    "namespace": "",
+    "sfdcLoginUrl": "https://login.salesforce.com",
+    "sourceApiVersion": "61.0"
+}


### PR DESCRIPTION
Really gotta force this to get it to work.

This doesn't hook into agents to give them permissions to call connections. Claude says "a 'before-action' Apex trigger / webhook that fires before the agent invokes an AgentExchange connection doesn't exist. Connections are first-class — the agent calls them directly through the Agentforce runtime, no Apex in the path."

So Apex (the language arbitrary salesforce plugins are written in) can't intercept them. So what this does is replace connections with using the tools supplied by atryum.

There are three actions that can be attached to an AgentForce Agent (AFA):
- `AtryumListTools` lists upstreams and their tools
- `AtryumDispatcher` allows calling the tools (returns a polling invocation id before the timeout, but I haven't tried that)
- `AtryumPoll` allows for polling on timed out connections (untested)

If we want to get more SRS BIZNS on this:

> Things that might actually work — but require digging:
> 
> 1. Network-redirect the connection. If the AgentExchange connection lets you configure its base URL (some connectors do; many hardcode the vendor's hosted MCP endpoint), you could point it at atryum, and atryum acts as a
> transparent MCP gateway to the real upstream. This is non-circumventable because the agent's traffic literally can't reach the vendor without going through you. Worth inspecting one specific connection (e.g., the GitHub one) in
> Setup to see what's configurable. If the connection exposes a "server URL" field, you win. If not, dead end.
> 2. External Credential / Named Credential interposition. AgentExchange connections may authenticate via a Salesforce External Credential. If you control that credential's token endpoint or callback, you can in principle gate token
>  issuance — but this gates connect-time, not each tool call. Useful for "deny the whole session" only.
> 3. Pressure Salesforce for the hook. This is genuinely the right feature for them to add (every enterprise needs it for SOX/compliance). The lack of it is probably a sales lever for them too — file an Idea on the IdeaExchange,
> mention it on the support ticket you're already opening. The Agentforce Trust Layer team owns this conceptually.
> 
> Honest recommendation: the architecture you have — atryum-as-MCP-proxy, AFA configured to use atryum instead of the AgentExchange connection — is the only currently-enforceable answer. The "use the AgentExchange connection but
> intercept" path requires either a hook Salesforce hasn't shipped, or a per-connection URL-redirect trick that may or may not work depending on the connector.
