### PR TITLE
feat: add agent hook examples for Claude Code, Cursor, and Codex

### DIFF
--- a/examples/claude-code-hook/README.md
+++ b/examples/claude-code-hook/README.md
@@ -1,0 +1,66 @@
+# Atryum Claude Code hook
+
+A Claude Code command-hook adapter that gates native Claude Code tools through
+Atryum before execution, then reports successful results back for audit.
+
+This is the Claude Code equivalent of `examples/amp-plugin`: Claude Code runs
+the tool, while Atryum mediates approval and stores the audit trail.
+
+## Install
+
+Copy the shared hook somewhere stable:
+
+```sh
+mkdir -p ~/.atryum/hooks
+cp examples/shared-agent-hook/atryum-hook.mjs ~/.atryum/hooks/atryum-hook.mjs
+chmod +x ~/.atryum/hooks/atryum-hook.mjs
+```
+
+Then add this to `~/.claude/settings.json` for all projects, or to
+`.claude/settings.json` for one project:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ATRYUM_HOOK_HOST=claude ATRYUM_HOOK_EVENT=PreToolUse ATRYUM_SOURCE=claude-code node ~/.atryum/hooks/atryum-hook.mjs"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ATRYUM_HOOK_HOST=claude ATRYUM_HOOK_EVENT=PostToolUse ATRYUM_SOURCE=claude-code node ~/.atryum/hooks/atryum-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Restart Claude Code after changing settings.
+
+## Configure
+
+| var | default | meaning |
+| --- | --- | --- |
+| `ATRYUM_URL` | `http://localhost:8080` | base URL of the Atryum server |
+| `ATRYUM_SOURCE` | `claude-code` in the example | source label in Atryum |
+| `ATRYUM_POLL_MS` | `2000` | approval polling interval |
+| `ATRYUM_STATE_DIR` | `~/.atryum/agent-hook-state` | tool-use to invocation-id state |
+
+## Notes
+
+Claude Code hook support is documented around `PreToolUse` and `PostToolUse`.
+`PreToolUse` receives `tool_name`, `tool_input`, and `tool_use_id`; the hook
+returns a permission decision before the tool executes.

--- a/examples/claude-code-hook/settings.example.json
+++ b/examples/claude-code-hook/settings.example.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ATRYUM_HOOK_HOST=claude ATRYUM_HOOK_EVENT=PreToolUse ATRYUM_SOURCE=claude-code node ~/.atryum/hooks/atryum-hook.mjs"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ATRYUM_HOOK_HOST=claude ATRYUM_HOOK_EVENT=PostToolUse ATRYUM_SOURCE=claude-code node ~/.atryum/hooks/atryum-hook.mjs"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/codex-mcp/README.md
+++ b/examples/codex-mcp/README.md
@@ -1,0 +1,40 @@
+# Atryum Codex MCP setup
+
+Codex does not currently expose a stable public command-hook API equivalent to
+Amp's `tool.call` / `tool.result` events or Claude Code's `PreToolUse` /
+`PostToolUse` hooks.
+
+That means there is no honest Codex-native version of the Amp plugin that can
+gate every native Codex file read, edit, and shell command through
+`/api/v1/external/invocations`.
+
+What Atryum can do for Codex today is mediate MCP calls. Configure Codex to use
+Atryum's MCP proxy instead of connecting directly to the upstream MCP server:
+
+```toml
+# ~/.codex/config.toml
+
+[mcp_servers.leanctx_via_atryum]
+command = "npx"
+args = [
+  "mcp-remote",
+  "http://localhost:8080/mcp/leanctx"
+]
+```
+
+Replace `leanctx` with the Atryum MCP server name you configured in the Atryum
+server registry.
+
+## What this covers
+
+- Codex calls to MCP tools routed through Atryum
+- Atryum approval rules, invocation logging, and admin UI for those MCP calls
+
+## What this does not cover
+
+- Codex native shell execution
+- Codex native file reads
+- Codex native file edits
+
+For those native Codex actions, use Codex's own `approval_policy` and
+`sandbox_mode` controls until Codex exposes a stable pre/post native tool hook.

--- a/examples/cursor-hook/.cursor-plugin/plugin.json
+++ b/examples/cursor-hook/.cursor-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "atryum",
+  "displayName": "Atryum",
+  "description": "Gate Cursor agent tool calls through Atryum approval.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Atryum"
+  },
+  "license": "MIT",
+  "category": "Security",
+  "hooks": "hooks.example.json"
+}

--- a/examples/cursor-hook/README.md
+++ b/examples/cursor-hook/README.md
@@ -1,0 +1,57 @@
+# Atryum Cursor hook
+
+A Cursor command-hook adapter that gates Cursor agent tool calls through Atryum
+before execution, then reports successful results back for audit.
+
+Cursor's hook surface is still evolving. This adapter targets the current
+`preToolUse` / `postToolUse` command hook shape used by Cursor plugins and
+`.cursor/hooks.json`.
+
+## Install
+
+Copy the shared hook somewhere stable:
+
+```sh
+mkdir -p ~/.atryum/hooks
+cp examples/shared-agent-hook/atryum-hook.mjs ~/.atryum/hooks/atryum-hook.mjs
+chmod +x ~/.atryum/hooks/atryum-hook.mjs
+```
+
+Then add this to `~/.cursor/hooks.json` for all projects, or to
+`.cursor/hooks.json` for one project:
+
+```json
+{
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "command": "ATRYUM_HOOK_HOST=cursor ATRYUM_HOOK_EVENT=preToolUse ATRYUM_SOURCE=cursor node ~/.atryum/hooks/atryum-hook.mjs"
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "command": "ATRYUM_HOOK_HOST=cursor ATRYUM_HOOK_EVENT=postToolUse ATRYUM_SOURCE=cursor node ~/.atryum/hooks/atryum-hook.mjs"
+      }
+    ]
+  }
+}
+```
+
+Restart Cursor after changing hooks.
+
+## Configure
+
+| var | default | meaning |
+| --- | --- | --- |
+| `ATRYUM_URL` | `http://localhost:8080` | base URL of the Atryum server |
+| `ATRYUM_SOURCE` | `cursor` in the example | source label in Atryum |
+| `ATRYUM_POLL_MS` | `2000` | approval polling interval |
+| `ATRYUM_STATE_DIR` | `~/.atryum/agent-hook-state` | tool-use to invocation-id state |
+
+## Plugin packaging
+
+For a Cursor plugin, point the plugin manifest at a hooks file that contains
+the same `preToolUse` and `postToolUse` entries. Cursor plugin manifests support
+a `hooks` path or inline hooks object.

--- a/examples/cursor-hook/hooks.example.json
+++ b/examples/cursor-hook/hooks.example.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "command": "ATRYUM_HOOK_HOST=cursor ATRYUM_HOOK_EVENT=preToolUse ATRYUM_SOURCE=cursor node ~/.atryum/hooks/atryum-hook.mjs"
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "command": "ATRYUM_HOOK_HOST=cursor ATRYUM_HOOK_EVENT=postToolUse ATRYUM_SOURCE=cursor node ~/.atryum/hooks/atryum-hook.mjs"
+      }
+    ]
+  }
+}

--- a/examples/shared-agent-hook/atryum-hook.mjs
+++ b/examples/shared-agent-hook/atryum-hook.mjs
@@ -188,6 +188,14 @@ function toolResult(event) {
   return event.tool_response || event.toolResponse || event.output || event.result;
 }
 
+function isFailedResult(result) {
+  if (!result || typeof result !== "object") return false;
+  if (result.isError === true) return true;
+  if (result.success === false) return true;
+  if (result.error != null) return true;
+  return false;
+}
+
 async function handlePreToolUse(event) {
   const submitted = await submit(event);
   const id = toolUseID(event);
@@ -226,15 +234,16 @@ async function handlePostToolUse(event) {
   }
   await deleteInvocation(id);
   const status = event.tool_response_status || event.status;
-  if (status === "error") {
+  const result = toolResult(event);
+  if (status === "error" || isFailedResult(result)) {
     await patchExecution(invocationId, {
       execution_status: "failed",
-      error: toolResult(event),
+      error: result,
     });
   } else {
     await patchExecution(invocationId, {
       execution_status: "completed",
-      result: toolResult(event),
+      result,
     });
   }
   jsonOut({});

--- a/examples/shared-agent-hook/atryum-hook.mjs
+++ b/examples/shared-agent-hook/atryum-hook.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+// Atryum command hook for agents that expose PreToolUse/PostToolUse style hooks.
+//
+// Supported host modes:
+//   ATRYUM_HOOK_HOST=claude  Claude Code settings hooks
+//   ATRYUM_HOOK_HOST=cursor  Cursor hooks
+//
+// The hook submits PreToolUse events to Atryum's external invocation API, blocks
+// until the invocation is approved or denied, and reports successful PostToolUse
+// results back to the same invocation.
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const API = process.env.ATRYUM_URL || "http://localhost:8080";
+const SOURCE = process.env.ATRYUM_SOURCE || process.env.ATRYUM_HOOK_HOST || "agent";
+const POLL_INTERVAL = Number(process.env.ATRYUM_POLL_MS || 2000);
+const HOST = (process.env.ATRYUM_HOOK_HOST || "claude").toLowerCase();
+const STATE_DIR =
+  process.env.ATRYUM_STATE_DIR ||
+  path.join(os.homedir(), ".atryum", "agent-hook-state");
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function jsonOut(value) {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function toolName(event) {
+  return event.tool_name || event.toolName || event.tool || event.name || "unknown";
+}
+
+function toolInput(event) {
+  return event.tool_input || event.toolInput || event.input || event.args || {};
+}
+
+function toolUseID(event) {
+  return (
+    event.tool_use_id ||
+    event.toolUseId ||
+    event.toolUseID ||
+    event.id ||
+    event.request_id ||
+    `${toolName(event)}:${createHash("sha256")
+      .update(JSON.stringify(toolInput(event)))
+      .digest("hex")
+      .slice(0, 24)}`
+  );
+}
+
+function eventName(event) {
+  return String(
+    process.env.ATRYUM_HOOK_EVENT ||
+      event.hook_event_name ||
+      event.hookEventName ||
+      event.event ||
+      event.type ||
+      ""
+  );
+}
+
+function isPreToolUse(event) {
+  return /pretooluse/i.test(eventName(event));
+}
+
+function isPostToolUse(event) {
+  return /posttooluse/i.test(eventName(event));
+}
+
+function describe(input) {
+  const parts = Object.entries(input || {})
+    .filter(([, value]) => typeof value === "string")
+    .map(([key, value]) => {
+      const text = String(value);
+      return `${key}: ${text.length > 200 ? `${text.slice(0, 200)}...` : text}`;
+    });
+  return parts.join(" | ") || "(no string params)";
+}
+
+function statePath(id) {
+  const safe = createHash("sha256").update(id).digest("hex");
+  return path.join(STATE_DIR, `${safe}.json`);
+}
+
+async function saveInvocation(toolUseId, invocationId) {
+  await mkdir(STATE_DIR, { recursive: true });
+  await writeFile(
+    statePath(toolUseId),
+    JSON.stringify({ invocation_id: invocationId }),
+    "utf8"
+  );
+}
+
+async function loadInvocation(toolUseId) {
+  try {
+    const raw = await readFile(statePath(toolUseId), "utf8");
+    return JSON.parse(raw).invocation_id || "";
+  } catch {
+    return "";
+  }
+}
+
+async function deleteInvocation(toolUseId) {
+  await rm(statePath(toolUseId), { force: true });
+}
+
+async function submit(event) {
+  const name = toolName(event);
+  const input = toolInput(event);
+  const id = toolUseID(event);
+  const res = await fetch(`${API}/api/v1/external/invocations`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      source: SOURCE,
+      tool: name,
+      description: describe(input),
+      input,
+      request_id: id,
+      thread_id: event.session_id || event.sessionId || undefined,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`atryum submit failed: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function poll(invocationId) {
+  while (true) {
+    const res = await fetch(`${API}/api/v1/external/invocations/${invocationId}`);
+    if (!res.ok) {
+      throw new Error(`atryum poll failed: ${res.status}`);
+    }
+    const inv = await res.json();
+    if (inv.status !== "pending_approval" && inv.status !== "received" && inv.status !== "executing") {
+      return inv;
+    }
+    await sleep(POLL_INTERVAL);
+  }
+}
+
+async function patchExecution(invocationId, body) {
+  const res = await fetch(`${API}/api/v1/external/invocations/${invocationId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`atryum patch failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+function allowOutput() {
+  if (HOST === "cursor") return { permission: "allow" };
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+    },
+  };
+}
+
+function denyOutput(reason) {
+  if (HOST === "cursor") {
+    return { permission: "deny", message: reason };
+  }
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+function toolResult(event) {
+  return event.tool_response || event.toolResponse || event.output || event.result;
+}
+
+async function handlePreToolUse(event) {
+  const submitted = await submit(event);
+  const id = toolUseID(event);
+  await saveInvocation(id, submitted.invocation_id);
+
+  let decided = submitted;
+  if (
+    submitted.status === "pending_approval" ||
+    submitted.status === "received"
+  ) {
+    decided = await poll(submitted.invocation_id);
+  }
+
+  if (decided.status === "approved") {
+    await patchExecution(submitted.invocation_id, {
+      execution_status: "running",
+    });
+    jsonOut(allowOutput());
+    return;
+  }
+
+  await deleteInvocation(id);
+  jsonOut(
+    denyOutput(
+      `atryum: tool call '${toolName(event)}' was ${decided.status} by reviewer.`
+    )
+  );
+}
+
+async function handlePostToolUse(event) {
+  const id = toolUseID(event);
+  const invocationId = await loadInvocation(id);
+  if (!invocationId) {
+    jsonOut({});
+    return;
+  }
+  await deleteInvocation(id);
+  const status = event.tool_response_status || event.status;
+  if (status === "error") {
+    await patchExecution(invocationId, {
+      execution_status: "failed",
+      error: toolResult(event),
+    });
+  } else {
+    await patchExecution(invocationId, {
+      execution_status: "completed",
+      result: toolResult(event),
+    });
+  }
+  jsonOut({});
+}
+
+async function main() {
+  const raw = await readStdin();
+  const event = raw.trim() ? JSON.parse(raw) : {};
+
+  if (isPreToolUse(event)) {
+    await handlePreToolUse(event);
+  } else if (isPostToolUse(event)) {
+    await handlePostToolUse(event);
+  } else {
+    jsonOut({});
+  }
+}
+
+main().catch((err) => {
+  jsonOut(denyOutput(`atryum: failed to gate tool call: ${err.message || err}`));
+  process.exitCode = 0;
+});


### PR DESCRIPTION
## Summary

- Adds `shared-agent-hook/atryum-hook.mjs` — a single Node.js hook script supporting Claude Code and Cursor via env var configuration (`ATRYUM_HOOK_HOST`)
- Adds per-client config examples: `claude-code-hook/settings.example.json` and `cursor-hook/hooks.example.json`
- Adds `codex-mcp/README.md` explaining the MCP proxy approach for Codex (no native hook API available)

## Testing
I tested this with Claude.