### PR TITLE
Update get agent ids to use the agents table

### DIFF
--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -37,9 +37,9 @@ request_timeout_seconds = 30
 # They no longer need to be configured here.
 
 # Static API key/secret pair that protects the read-only invocation reporting
-# endpoint (GET /invocations/{agent_id}). Callers must send both `X-API-Key`
-# and `X-API-Secret` headers matching these values. When either field is empty,
-# that endpoint refuses every request with 503.
+# endpoints (GET /invocations/{agent_id}, GET /agent_ids). Callers must send
+# both `X-API-Key` and `X-API-Secret` headers matching these values. When
+# either field is empty, those endpoints refuse every request with 503.
 [api_key]
 key = ""
 secret = ""

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -37,9 +37,9 @@ request_timeout_seconds = 30
 # They no longer need to be configured here.
 
 # Static API key/secret pair that protects the read-only invocation reporting
-# endpoints (GET /invocations/{agent_id}, GET /agent_ids). Callers must send
-# both `X-API-Key` and `X-API-Secret` headers matching these values. When
-# either field is empty, those endpoints refuse every request with 503.
+# endpoint (GET /invocations/{agent_id}). Callers must send both `X-API-Key`
+# and `X-API-Secret` headers matching these values. When either field is empty,
+# that endpoint refuses every request with 503.
 [api_key]
 key = ""
 secret = ""

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -76,6 +77,7 @@ type rulesRepo interface {
 
 type agentsRepo interface {
 	List(ctx context.Context) ([]store.AgentRecord, error)
+	ListEnabled(ctx context.Context) ([]store.AgentRecord, error)
 	Get(ctx context.Context, id string) (store.AgentRecord, error)
 	UpdateEnabled(ctx context.Context, id string, enabled bool) error
 	UpdateAgentIDs(ctx context.Context, id string, agentIDs string) error
@@ -776,22 +778,44 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 	}
 }
 
-// agentIDs returns the distinct agent IDs that have submitted invocations.
+// agentIDs returns the distinct enabled agent IDs configured on synced agents.
 // Protected by the API key middleware.
 func (h *Handler) agentIDs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	ids, err := h.svc.ListAgentIDs(r.Context())
+	if h.agentsRepo == nil {
+		writeError(w, http.StatusServiceUnavailable, "agents repository not configured")
+		return
+	}
+	records, err := h.agentsRepo.ListEnabled(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	if ids == nil {
-		ids = []string{}
-	}
+	ids := agentIDsFromRecords(records)
 	writeJSON(w, http.StatusOK, map[string]any{"items": ids})
+}
+
+func agentIDsFromRecords(records []store.AgentRecord) []string {
+	seen := make(map[string]struct{})
+	ids := []string{}
+	for _, record := range records {
+		for _, id := range parseAgentIDs(record.AgentIDs) {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 // invocationsByAgentID returns a paginated list of invocations for the given

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -155,6 +155,34 @@ func (s *stubAgentSyncSettingsRepo) Save(_ context.Context, settings store.Agent
 	return nil
 }
 
+type stubAgentsRepo struct {
+	records []store.AgentRecord
+	err     error
+}
+
+func (s *stubAgentsRepo) List(context.Context) ([]store.AgentRecord, error) {
+	return s.records, s.err
+}
+func (s *stubAgentsRepo) ListEnabled(context.Context) ([]store.AgentRecord, error) {
+	var out []store.AgentRecord
+	for _, r := range s.records {
+		if r.Enabled {
+			out = append(out, r)
+		}
+	}
+	return out, s.err
+}
+func (s *stubAgentsRepo) Get(context.Context, string) (store.AgentRecord, error) {
+	return store.AgentRecord{}, nil
+}
+func (s *stubAgentsRepo) UpdateEnabled(context.Context, string, bool) error { return nil }
+func (s *stubAgentsRepo) UpdateAgentIDs(context.Context, string, string) error {
+	return nil
+}
+func (s *stubAgentsRepo) DeleteAll(context.Context) error {
+	return nil
+}
+
 func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`))
@@ -181,6 +209,38 @@ func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 	instructions, ok := result["instructions"].(string)
 	if !ok || !strings.Contains(instructions, "atryum.rules.get") {
 		t.Fatalf("expected initialize instructions to mention atryum.rules.get, got %#v", result["instructions"])
+	}
+}
+
+func TestAgentIDsUsesAgentsTable(t *testing.T) {
+	agents := &stubAgentsRepo{records: []store.AgentRecord{
+		{ID: "agent_a", AgentIDs: `["worker-1","worker-2","worker-1",""]`, Enabled: true},
+		{ID: "agent_b", AgentIDs: `["disabled-worker"]`, Enabled: false},
+		{ID: "agent_c", AgentIDs: `[" worker-3 "]`, Enabled: true},
+	}}
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, agents, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/agent_ids", nil)
+	w := httptest.NewRecorder()
+
+	h.agentIDs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Items []string `json:"items"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"worker-1", "worker-2", "worker-3"}
+	if len(resp.Items) != len(want) {
+		t.Fatalf("expected %v, got %v", want, resp.Items)
+	}
+	for i := range want {
+		if resp.Items[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, resp.Items)
+		}
 	}
 }
 

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -168,10 +168,16 @@ func (r *AgentsRepo) DeleteAll(ctx context.Context) error {
 
 // List returns all agent records ordered by vm_name.
 func (r *AgentsRepo) List(ctx context.Context) ([]AgentRecord, error) {
-	query, args, err := r.sb.Select(agentColumns...).
-		From("agents").
-		OrderBy("vm_name ASC").
-		ToSql()
+	return r.list(ctx, r.sb.Select(agentColumns...).From("agents").OrderBy("vm_name ASC"))
+}
+
+// ListEnabled returns only enabled agent records ordered by vm_name.
+func (r *AgentsRepo) ListEnabled(ctx context.Context) ([]AgentRecord, error) {
+	return r.list(ctx, r.sb.Select(agentColumns...).From("agents").Where(sq.Eq{"enabled": true}).OrderBy("vm_name ASC"))
+}
+
+func (r *AgentsRepo) list(ctx context.Context, b sq.SelectBuilder) ([]AgentRecord, error) {
+	query, args, err := b.ToSql()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I updated the GET agent_ids route to look at the agents table instead of invocations. The route was made prior to the agents table.


Tested with
```
curl -sS \
  -H "X-API-Key: a" \
  -H "X-API-Secret: b" \
  http://localhost:8080/agent_ids
```