### PR TITLE
Store LLM invocation summaries

### DIFF
--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -145,6 +145,9 @@ func main() {
 	}
 
 	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo, invAgents, invEvaluator, &syncSettingsAdapter{repo: agentSyncSettingsRepo})
+	if backendClient != nil {
+		service.SetInvocationSummarizer(&summaryAdapter{client: backendClient})
+	}
 	serverAdmin := api.NewServerAdminService(serverRepo, oauthRepo, client, 5*time.Second, cfg.Server.PublicBaseURL)
 	handler := api.NewHandler(service, serverAdmin, policyRegistry, rulesRepo, agentsRepo, agentSyncSettingsRepo, syncAgents, backendClient)
 
@@ -217,6 +220,11 @@ func (a *syncSettingsAdapter) ConstitutionFieldKey(ctx context.Context) string {
 	return s.ConstitutionFieldKey
 }
 
+func (a *syncSettingsAdapter) SummarySettings(ctx context.Context) (string, string) {
+	s, _ := a.repo.Get(ctx)
+	return s.OrgCUID, s.SummaryModelConfigCUID
+}
+
 // evaluatorAdapter bridges backendclient.Client → invocation.EvaluatorClient.
 type evaluatorAdapter struct {
 	client *backendclient.Client
@@ -241,6 +249,23 @@ func (e *evaluatorAdapter) EvaluateToolCall(ctx context.Context, req invocation.
 		Reason:     resp.Reason,
 		Confidence: resp.Confidence,
 	}, nil
+}
+
+// summaryAdapter bridges backendclient.Client → invocation.SummaryClient.
+type summaryAdapter struct {
+	client *backendclient.Client
+}
+
+func (s *summaryAdapter) SummarizeInvocation(ctx context.Context, req invocation.SummaryRequest) (invocation.SummaryResponse, error) {
+	resp, err := s.client.SummarizeInvocation(ctx, backendclient.SummarizeInvocationRequest{
+		ModelConfigCUID: req.ModelConfigCUID,
+		OrgCUID:         req.OrgCUID,
+		Invocation:      req.Invocation,
+	})
+	if err != nil {
+		return invocation.SummaryResponse{}, err
+	}
+	return invocation.SummaryResponse{Summary: resp.Summary}, nil
 }
 
 func truthyEnv(name string) bool {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1279,16 +1279,16 @@ func (h *Handler) summarizeInvocation(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 
+	// Body is optional; when present it may override the model config from
+	// settings. Empty body or empty model_config_cuid means "use settings".
 	var req SummarizeInvocationRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid json")
-		return
+	if r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid json")
+			return
+		}
 	}
 	modelConfigCUID := strings.TrimSpace(req.ModelConfigCUID)
-	if modelConfigCUID == "" {
-		writeError(w, http.StatusBadRequest, "model_config_cuid is required")
-		return
-	}
 
 	inv, err := h.svc.Get(r.Context(), id)
 	if err != nil {
@@ -1320,9 +1320,17 @@ func (h *Handler) summarizeInvocation(w http.ResponseWriter, r *http.Request, id
 	if h.agentSyncSettingsRepo != nil {
 		if s, sErr := h.agentSyncSettingsRepo.Get(r.Context()); sErr == nil {
 			orgCUID = s.OrgCUID
+			if modelConfigCUID == "" {
+				modelConfigCUID = strings.TrimSpace(s.SummaryModelConfigCUID)
+			}
 		} else {
 			log.Printf("[summarizeInvocation] read agent_sync_settings failed: %v", sErr)
 		}
+	}
+
+	if modelConfigCUID == "" {
+		writeError(w, http.StatusBadRequest, "summary model configuration is not set; configure one on the Settings page")
+		return
 	}
 
 	resp, err := h.summarizeClient.SummarizeInvocation(r.Context(), backendclient.SummarizeInvocationRequest{
@@ -1768,18 +1776,20 @@ func (h *Handler) adminModelConfigs(w http.ResponseWriter, r *http.Request) {
 // and PUT /admin/settings. SyncError is non-empty when the post-save agent
 // sync failed; settings are persisted regardless.
 type AgentSyncSettingsResponse struct {
-	OrgCUID              string `json:"org_cuid"`
-	AgentRecordTypeSlug  string `json:"agent_record_type_slug"`
-	ConstitutionFieldKey string `json:"constitution_field_key"`
-	UpdatedAt            string `json:"updated_at,omitempty"`
-	SyncError            string `json:"sync_error,omitempty"`
+	OrgCUID                string `json:"org_cuid"`
+	AgentRecordTypeSlug    string `json:"agent_record_type_slug"`
+	ConstitutionFieldKey   string `json:"constitution_field_key"`
+	SummaryModelConfigCUID string `json:"summary_model_config_cuid"`
+	UpdatedAt              string `json:"updated_at,omitempty"`
+	SyncError              string `json:"sync_error,omitempty"`
 }
 
 // AgentSyncSettingsInput is the JSON body accepted by PUT /admin/settings.
 type AgentSyncSettingsInput struct {
-	OrgCUID              string `json:"org_cuid"`
-	AgentRecordTypeSlug  string `json:"agent_record_type_slug"`
-	ConstitutionFieldKey string `json:"constitution_field_key"`
+	OrgCUID                string `json:"org_cuid"`
+	AgentRecordTypeSlug    string `json:"agent_record_type_slug"`
+	ConstitutionFieldKey   string `json:"constitution_field_key"`
+	SummaryModelConfigCUID string `json:"summary_model_config_cuid"`
 }
 
 func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
@@ -1795,9 +1805,10 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		resp := AgentSyncSettingsResponse{
-			OrgCUID:              s.OrgCUID,
-			AgentRecordTypeSlug:  s.AgentRecordTypeSlug,
-			ConstitutionFieldKey: s.ConstitutionFieldKey,
+			OrgCUID:                s.OrgCUID,
+			AgentRecordTypeSlug:    s.AgentRecordTypeSlug,
+			ConstitutionFieldKey:   s.ConstitutionFieldKey,
+			SummaryModelConfigCUID: s.SummaryModelConfigCUID,
 		}
 		if !s.UpdatedAt.IsZero() {
 			resp.UpdatedAt = s.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z")
@@ -1824,9 +1835,10 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if err := h.agentSyncSettingsRepo.Save(r.Context(), store.AgentSyncSettings{
-			OrgCUID:              input.OrgCUID,
-			AgentRecordTypeSlug:  input.AgentRecordTypeSlug,
-			ConstitutionFieldKey: input.ConstitutionFieldKey,
+			OrgCUID:                input.OrgCUID,
+			AgentRecordTypeSlug:    input.AgentRecordTypeSlug,
+			ConstitutionFieldKey:   input.ConstitutionFieldKey,
+			SummaryModelConfigCUID: input.SummaryModelConfigCUID,
 		}); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to save settings: "+err.Error())
 			return
@@ -1848,10 +1860,11 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 		}
 		log.Printf("[adminSettings] GET after save: org_cuid=%q record_type=%q", s.OrgCUID, s.AgentRecordTypeSlug)
 		resp := AgentSyncSettingsResponse{
-			OrgCUID:              s.OrgCUID,
-			AgentRecordTypeSlug:  s.AgentRecordTypeSlug,
-			ConstitutionFieldKey: s.ConstitutionFieldKey,
-			SyncError:            syncErr,
+			OrgCUID:                s.OrgCUID,
+			AgentRecordTypeSlug:    s.AgentRecordTypeSlug,
+			ConstitutionFieldKey:   s.ConstitutionFieldKey,
+			SummaryModelConfigCUID: s.SummaryModelConfigCUID,
+			SyncError:              syncErr,
 		}
 		if !s.UpdatedAt.IsZero() {
 			resp.UpdatedAt = s.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -48,6 +48,10 @@ type mcpEnvelopeForwarder interface {
 	ForwardEnvelope(ctx context.Context, upstream mcp.Upstream, envelope mcp.Envelope, protocolVersion string) (mcp.ForwardResult, error)
 }
 
+type invocationSummarizer interface {
+	SummarizeInvocation(ctx context.Context, req backendclient.SummarizeInvocationRequest) (backendclient.SummarizeInvocationResponse, error)
+}
+
 type serverService interface {
 	List(ctx context.Context, filter mcp.ServerFilter) (ServerListResponse, error)
 	Get(ctx context.Context, name string) (AdminServer, error)
@@ -91,6 +95,7 @@ type Handler struct {
 	agentsRepo            agentsRepo
 	agentSyncSettingsRepo agentSyncSettingsRepo
 	backendClient         *backendclient.Client
+	summarizeClient       invocationSummarizer
 	syncAgentsFn          func(ctx context.Context) error
 	forwarder             mcpEnvelopeForwarder
 	staticHTTP            http.Handler
@@ -364,7 +369,7 @@ func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Reg
 	if f, ok := svc.(mcpEnvelopeForwarder); ok {
 		forwarder = f
 	}
-	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, agentsRepo: agents, agentSyncSettingsRepo: agentSyncSettings, backendClient: bc, syncAgentsFn: syncAgents, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
+	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, agentsRepo: agents, agentSyncSettingsRepo: agentSyncSettings, backendClient: bc, summarizeClient: bc, syncAgentsFn: syncAgents, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
 }
 
 // SetAuthValidator installs the inbound auth validator. When non-nil, the
@@ -1269,7 +1274,7 @@ func (h *Handler) summarizeInvocation(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 	h.debugf("summarizing invocation %s", id)
-	if h.backendClient == nil {
+	if h.summarizeClient == nil {
 		writeError(w, http.StatusServiceUnavailable, "backend not configured")
 		return
 	}
@@ -1320,7 +1325,7 @@ func (h *Handler) summarizeInvocation(w http.ResponseWriter, r *http.Request, id
 		}
 	}
 
-	resp, err := h.backendClient.SummarizeInvocation(r.Context(), backendclient.SummarizeInvocationRequest{
+	resp, err := h.summarizeClient.SummarizeInvocation(r.Context(), backendclient.SummarizeInvocationRequest{
 		ModelConfigCUID: modelConfigCUID,
 		OrgCUID:         orgCUID,
 		Invocation:      invMap,
@@ -1772,8 +1777,8 @@ type AgentSyncSettingsResponse struct {
 
 // AgentSyncSettingsInput is the JSON body accepted by PUT /admin/settings.
 type AgentSyncSettingsInput struct {
-	OrgCUID             string `json:"org_cuid"`
-	AgentRecordTypeSlug string `json:"agent_record_type_slug"`
+	OrgCUID              string `json:"org_cuid"`
+	AgentRecordTypeSlug  string `json:"agent_record_type_slug"`
 	ConstitutionFieldKey string `json:"constitution_field_key"`
 }
 
@@ -1790,8 +1795,8 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		resp := AgentSyncSettingsResponse{
-			OrgCUID:             s.OrgCUID,
-			AgentRecordTypeSlug: s.AgentRecordTypeSlug,
+			OrgCUID:              s.OrgCUID,
+			AgentRecordTypeSlug:  s.AgentRecordTypeSlug,
 			ConstitutionFieldKey: s.ConstitutionFieldKey,
 		}
 		if !s.UpdatedAt.IsZero() {
@@ -2708,7 +2713,7 @@ func invocationSignature(items []invocation.InvocationResponse) string {
 		if item.CompletedAt != nil {
 			completed = item.CompletedAt.UTC().Format(time.RFC3339Nano)
 		}
-		parts = append(parts, item.InvocationID+"|"+string(item.Status)+"|"+completed)
+		parts = append(parts, item.InvocationID+"|"+string(item.Status)+"|"+completed+"|"+item.Summary)
 	}
 	return strings.Join(parts, ",")
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -41,6 +41,7 @@ type service interface {
 	Deny(ctx context.Context, invocationID string, message string) error
 	Submit(ctx context.Context, req invocation.ExternalSubmitRequest) (invocation.InvocationResponse, error)
 	RecordExecution(ctx context.Context, invocationID string, update invocation.ExternalExecutionUpdate) (invocation.InvocationResponse, error)
+	SetSummary(ctx context.Context, invocationID string, summary string) (invocation.InvocationResponse, error)
 }
 
 type mcpEnvelopeForwarder interface {
@@ -1170,6 +1171,16 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 		return
 	}
+	if strings.HasSuffix(trimmed, "/summarize") {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		id := strings.TrimSuffix(trimmed, "/summarize")
+		id = strings.TrimSuffix(id, "/")
+		h.summarizeInvocation(w, r, id)
+		return
+	}
 	if strings.HasSuffix(trimmed, "/deny") {
 		if r.Method != http.MethodPost {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -1234,6 +1245,105 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// SummarizeInvocationRequest is the JSON body accepted by
+// POST /api/v1/admin/invocations/{id}/summarize.
+type SummarizeInvocationRequest struct {
+	ModelConfigCUID string `json:"model_config_cuid"`
+}
+
+// SummarizeInvocationResponse is the JSON shape returned by
+// POST /api/v1/admin/invocations/{id}/summarize.
+type SummarizeInvocationResponse struct {
+	InvocationID string `json:"invocation_id"`
+	Summary      string `json:"summary"`
+}
+
+// summarizeInvocation loads the invocation by id, forwards it to the VM
+// backend's /summarize-invocation endpoint, and returns the LLM-generated
+// summary.
+func (h *Handler) summarizeInvocation(w http.ResponseWriter, r *http.Request, id string) {
+	if id == "" {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+	h.debugf("summarizing invocation %s", id)
+	if h.backendClient == nil {
+		writeError(w, http.StatusServiceUnavailable, "backend not configured")
+		return
+	}
+
+	var req SummarizeInvocationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	modelConfigCUID := strings.TrimSpace(req.ModelConfigCUID)
+	if modelConfigCUID == "" {
+		writeError(w, http.StatusBadRequest, "model_config_cuid is required")
+		return
+	}
+
+	inv, err := h.svc.Get(r.Context(), id)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if err == sql.ErrNoRows {
+			status = http.StatusNotFound
+		}
+		log.Printf("[summarizeInvocation] load invocation %s failed: %v", id, err)
+		writeError(w, status, err.Error())
+		return
+	}
+
+	// Round-trip via JSON so the backend sees the same shape as the admin
+	// detail endpoint (input/result/error are json.RawMessage on the wire).
+	raw, err := json.Marshal(inv)
+	if err != nil {
+		log.Printf("[summarizeInvocation] encode invocation %s failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, "failed to encode invocation: "+err.Error())
+		return
+	}
+	var invMap map[string]any
+	if err := json.Unmarshal(raw, &invMap); err != nil {
+		log.Printf("[summarizeInvocation] normalize invocation %s failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, "failed to normalize invocation: "+err.Error())
+		return
+	}
+
+	orgCUID := ""
+	if h.agentSyncSettingsRepo != nil {
+		if s, sErr := h.agentSyncSettingsRepo.Get(r.Context()); sErr == nil {
+			orgCUID = s.OrgCUID
+		} else {
+			log.Printf("[summarizeInvocation] read agent_sync_settings failed: %v", sErr)
+		}
+	}
+
+	resp, err := h.backendClient.SummarizeInvocation(r.Context(), backendclient.SummarizeInvocationRequest{
+		ModelConfigCUID: modelConfigCUID,
+		OrgCUID:         orgCUID,
+		Invocation:      invMap,
+	})
+	if err != nil {
+		log.Printf("[summarizeInvocation] backend call failed for invocation %s (model_config_cuid=%s): %v", id, modelConfigCUID, err)
+		writeError(w, http.StatusBadGateway, "failed to summarize invocation: "+err.Error())
+		return
+	}
+
+	// Persist the generated summary on the invocation row so subsequent
+	// Get/List calls expose it and the UI can render it without re-calling the LLM.
+	updated, err := h.svc.SetSummary(r.Context(), inv.InvocationID, resp.Summary)
+	if err != nil {
+		log.Printf("[summarizeInvocation] persist summary for invocation %s failed: %v", id, err)
+		writeError(w, http.StatusInternalServerError, "failed to persist summary: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, SummarizeInvocationResponse{
+		InvocationID: updated.InvocationID,
+		Summary:      updated.Summary,
+	})
 }
 
 func (h *Handler) adminServers(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -58,6 +58,9 @@ func (s *stubService) Deny(context.Context, string, string) error { return nil }
 func (s *stubService) Submit(context.Context, invocation.ExternalSubmitRequest) (invocation.InvocationResponse, error) {
 	return invocation.InvocationResponse{}, nil
 }
+func (s *stubService) SetSummary(context.Context, string, string) (invocation.InvocationResponse, error) {
+	return invocation.InvocationResponse{}, nil
+}
 func (s *stubService) RecordExecution(context.Context, string, invocation.ExternalExecutionUpdate) (invocation.InvocationResponse, error) {
 	return invocation.InvocationResponse{}, nil
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	backendclient "atryum/internal/backend"
 	"atryum/internal/invocation"
 	"atryum/internal/mcp"
 	"atryum/internal/store"
@@ -18,6 +19,10 @@ type stubService struct {
 	tools    []mcp.Tool
 	invoke   invocation.InvocationResponse
 	invErr   error
+	getErr   error
+	setResp  invocation.InvocationResponse
+	setID    string
+	setText  string
 	listErr  error
 	upstream mcp.Upstream
 	forward  mcp.ForwardResult
@@ -41,8 +46,8 @@ func (s *stubService) ListAllTools(context.Context) ([]mcp.Tool, error) {
 func (s *stubService) ResolveToolServer(_ context.Context, _ string) (string, error) {
 	return s.upstream.Name, nil
 }
-func (s *stubService) Get(context.Context, string) (invocation.InvocationResponse, error) {
-	return s.invoke, nil
+func (s *stubService) Get(_ context.Context, _ string) (invocation.InvocationResponse, error) {
+	return s.invoke, s.getErr
 }
 func (s *stubService) List(context.Context, invocation.InvocationListFilter) (invocation.InvocationListResponse, error) {
 	return invocation.InvocationListResponse{Items: []invocation.InvocationResponse{s.invoke}, Total: 1, Limit: 50}, nil
@@ -58,8 +63,15 @@ func (s *stubService) Deny(context.Context, string, string) error { return nil }
 func (s *stubService) Submit(context.Context, invocation.ExternalSubmitRequest) (invocation.InvocationResponse, error) {
 	return invocation.InvocationResponse{}, nil
 }
-func (s *stubService) SetSummary(context.Context, string, string) (invocation.InvocationResponse, error) {
-	return invocation.InvocationResponse{}, nil
+func (s *stubService) SetSummary(_ context.Context, id string, summary string) (invocation.InvocationResponse, error) {
+	s.setID = id
+	s.setText = summary
+	if s.setResp.InvocationID != "" {
+		return s.setResp, nil
+	}
+	resp := s.invoke
+	resp.Summary = summary
+	return resp, nil
 }
 func (s *stubService) RecordExecution(context.Context, string, invocation.ExternalExecutionUpdate) (invocation.InvocationResponse, error) {
 	return invocation.InvocationResponse{}, nil
@@ -119,6 +131,17 @@ func (s *stubRulesRepo) Move(context.Context, string, string) ([]store.Rule, err
 }
 func (s *stubRulesRepo) InsertBefore(context.Context, string, store.Rule) error { return nil }
 
+type stubSummarizer struct {
+	req  backendclient.SummarizeInvocationRequest
+	resp backendclient.SummarizeInvocationResponse
+	err  error
+}
+
+func (s *stubSummarizer) SummarizeInvocation(_ context.Context, req backendclient.SummarizeInvocationRequest) (backendclient.SummarizeInvocationResponse, error) {
+	s.req = req
+	return s.resp, s.err
+}
+
 func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`))
@@ -145,6 +168,71 @@ func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 	instructions, ok := result["instructions"].(string)
 	if !ok || !strings.Contains(instructions, "atryum.rules.get") {
 		t.Fatalf("expected initialize instructions to mention atryum.rules.get, got %#v", result["instructions"])
+	}
+}
+
+func TestSummarizeInvocationPersistsBackendSummary(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	svc := &stubService{invoke: invocation.InvocationResponse{
+		InvocationID: "inv_123",
+		ServerName:   "demo",
+		ToolName:     "read_file",
+		Status:       invocation.StatusSucceeded,
+		Input:        json.RawMessage(`{"path":"/tmp/a"}`),
+		Result:       json.RawMessage(`{"content":"hello"}`),
+		SubmittedAt:  now,
+		CompletedAt:  &now,
+	}}
+	summarizer := &stubSummarizer{resp: backendclient.SummarizeInvocationResponse{Summary: "Read /tmp/a and returned hello."}}
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil)
+	h.summarizeClient = summarizer
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/invocations/inv_123/summarize", strings.NewReader(`{"model_config_cuid":" model_abc "}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if summarizer.req.ModelConfigCUID != "model_abc" {
+		t.Fatalf("model_config_cuid = %q", summarizer.req.ModelConfigCUID)
+	}
+	if summarizer.req.Invocation["invocation_id"] != "inv_123" {
+		t.Fatalf("backend invocation payload = %#v", summarizer.req.Invocation)
+	}
+	input, ok := summarizer.req.Invocation["input"].(map[string]any)
+	if !ok || input["path"] != "/tmp/a" {
+		t.Fatalf("backend invocation input = %#v", summarizer.req.Invocation["input"])
+	}
+	if svc.setID != "inv_123" || svc.setText != "Read /tmp/a and returned hello." {
+		t.Fatalf("SetSummary called with id=%q summary=%q", svc.setID, svc.setText)
+	}
+	var resp SummarizeInvocationResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.InvocationID != "inv_123" || resp.Summary != "Read /tmp/a and returned hello." {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestInvocationSignatureChangesWhenSummaryChanges(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	base := []invocation.InvocationResponse{{
+		InvocationID: "inv_123",
+		Status:       invocation.StatusSucceeded,
+		CompletedAt:  &now,
+	}}
+	withSummary := []invocation.InvocationResponse{{
+		InvocationID: "inv_123",
+		Status:       invocation.StatusSucceeded,
+		CompletedAt:  &now,
+		Summary:      "Read /tmp/a.",
+	}}
+
+	if invocationSignature(base) == invocationSignature(withSummary) {
+		t.Fatal("expected summary-only update to change invocation signature")
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -142,6 +142,19 @@ func (s *stubSummarizer) SummarizeInvocation(_ context.Context, req backendclien
 	return s.resp, s.err
 }
 
+type stubAgentSyncSettingsRepo struct {
+	settings store.AgentSyncSettings
+}
+
+func (s *stubAgentSyncSettingsRepo) Get(context.Context) (store.AgentSyncSettings, error) {
+	return s.settings, nil
+}
+
+func (s *stubAgentSyncSettingsRepo) Save(_ context.Context, settings store.AgentSyncSettings) error {
+	s.settings = settings
+	return nil
+}
+
 func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`))
@@ -214,6 +227,44 @@ func TestSummarizeInvocationPersistsBackendSummary(t *testing.T) {
 	}
 	if resp.InvocationID != "inv_123" || resp.Summary != "Read /tmp/a and returned hello." {
 		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestSummarizeInvocationUsesSettingsModelConfigWhenRequestBodyEmpty(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	svc := &stubService{invoke: invocation.InvocationResponse{
+		InvocationID: "inv_123",
+		ServerName:   "demo",
+		ToolName:     "read_file",
+		Status:       invocation.StatusSucceeded,
+		Input:        json.RawMessage(`{"path":"/tmp/a"}`),
+		Result:       json.RawMessage(`{"content":"hello"}`),
+		SubmittedAt:  now,
+		CompletedAt:  &now,
+	}}
+	settings := &stubAgentSyncSettingsRepo{settings: store.AgentSyncSettings{
+		OrgCUID:                "org_abc",
+		SummaryModelConfigCUID: " model_from_settings ",
+	}}
+	summarizer := &stubSummarizer{resp: backendclient.SummarizeInvocationResponse{Summary: "Read /tmp/a."}}
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, settings, nil, nil)
+	h.summarizeClient = summarizer
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/invocations/inv_123/summarize", nil)
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if summarizer.req.ModelConfigCUID != "model_from_settings" {
+		t.Fatalf("model_config_cuid = %q", summarizer.req.ModelConfigCUID)
+	}
+	if summarizer.req.OrgCUID != "org_abc" {
+		t.Fatalf("org_cuid = %q", summarizer.req.OrgCUID)
+	}
+	if svc.setID != "inv_123" || svc.setText != "Read /tmp/a." {
+		t.Fatalf("SetSummary called with id=%q summary=%q", svc.setID, svc.setText)
 	}
 }
 

--- a/internal/api/web/app.js
+++ b/internal/api/web/app.js
@@ -249,7 +249,7 @@ async function loadInvocations() {
 }
 
 function applyInvocationStreamData(items) {
-  const signature = JSON.stringify(items.map((item) => [item.invocation_id, item.status, item.completed_at || '']));
+  const signature = JSON.stringify(items.map((item) => [item.invocation_id, item.status, item.completed_at || '', item.summary || '']));
   const changed = signature !== state.lastInvocationSignature;
   state.lastInvocationSignature = signature;
   if (!changed) {

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -16,6 +16,7 @@ const connectionPath = "/internal/v1/atryum/connection"
 const agentsPath = "/internal/v1/atryum/agents"
 const modelConfigsPath = "/internal/v1/atryum/model-configs"
 const evaluatePath = "/internal/v1/atryum/evaluate"
+const summarizeInvocationPath = "/internal/v1/atryum/summarize-invocation"
 const organizationsPath = "/internal/v1/atryum/organizations"
 const primaryRecordTypesPath = "/internal/v1/atryum/primary-record-types"
 const customFieldsPath = "/internal/v1/atryum/custom-fields"
@@ -346,6 +347,61 @@ func (c *Client) EvaluateToolCall(ctx context.Context, req EvaluateRequest) (Eva
 	var payload EvaluateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 		return EvaluateResponse{}, fmt.Errorf("decode evaluate response: %w", err)
+	}
+	return payload, nil
+}
+
+// SummarizeInvocationRequest is sent to the VM backend to ask an LLM to
+// produce a short human-readable summary of a single invocation.
+type SummarizeInvocationRequest struct {
+	ModelConfigCUID string         `json:"model_config_cuid"`
+	OrgCUID         string         `json:"org_cuid,omitempty"`
+	Invocation      map[string]any `json:"invocation"`
+}
+
+// SummarizeInvocationResponse is the result returned by the VM backend after
+// LLM summarization.
+type SummarizeInvocationResponse struct {
+	Summary string `json:"summary"`
+}
+
+// SummarizeInvocation calls the VM backend's summarize-invocation endpoint and
+// returns the produced summary.
+func (c *Client) SummarizeInvocation(ctx context.Context, req SummarizeInvocationRequest) (SummarizeInvocationResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return SummarizeInvocationResponse{}, fmt.Errorf("marshal summarize-invocation request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, c.baseURL+summarizeInvocationPath,
+		strings.NewReader(string(body)),
+	)
+	if err != nil {
+		return SummarizeInvocationResponse{}, fmt.Errorf("build summarize-invocation request: %w", err)
+	}
+	httpReq.Header.Set("X-MACHINE-KEY", c.machineKey)
+	httpReq.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	if req.OrgCUID != "" {
+		httpReq.Header.Set("X-Org-CUID", req.OrgCUID)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	// Reuse the longer-timeout client since this is an LLM completion call.
+	resp, err := c.evaluateClient.Do(httpReq)
+	if err != nil {
+		return SummarizeInvocationResponse{}, fmt.Errorf("call summarize-invocation endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return SummarizeInvocationResponse{}, fmt.Errorf("summarize-invocation endpoint returned %s", resp.Status)
+	}
+
+	var payload SummarizeInvocationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return SummarizeInvocationResponse{}, fmt.Errorf("decode summarize-invocation response: %w", err)
 	}
 	return payload, nil
 }

--- a/internal/backend/client_test.go
+++ b/internal/backend/client_test.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -77,5 +78,81 @@ func TestCheckConnectionReturnsErrorOnNonSuccessStatus(t *testing.T) {
 
 	if _, err := client.CheckConnection(context.Background()); err == nil {
 		t.Fatalf("expected status error")
+	}
+}
+
+func TestSummarizeInvocationSendsContractAndDecodesSummary(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q", r.Method)
+		}
+		if r.URL.Path != summarizeInvocationPath {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.Header.Get("X-MACHINE-KEY"); got != "machine-key" {
+			t.Errorf("X-MACHINE-KEY = %q", got)
+		}
+		if got := r.Header.Get("X-MACHINE-SECRET"); got != "machine-secret" {
+			t.Errorf("X-MACHINE-SECRET = %q", got)
+		}
+		if got := r.Header.Get("X-Org-CUID"); got != "org_123" {
+			t.Errorf("X-Org-CUID = %q", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept = %q", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request body: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"summary":"Read /tmp/a and returned hello."}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(config.BackendConfig{
+		BaseURL:       server.URL,
+		MachineKey:    "machine-key",
+		MachineSecret: "machine-secret",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	resp, err := client.SummarizeInvocation(context.Background(), SummarizeInvocationRequest{
+		ModelConfigCUID: "model_abc",
+		OrgCUID:         "org_123",
+		Invocation: map[string]any{
+			"invocation_id": "inv_123",
+			"input":         map[string]any{"path": "/tmp/a"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SummarizeInvocation: %v", err)
+	}
+	if resp.Summary != "Read /tmp/a and returned hello." {
+		t.Fatalf("summary = %q", resp.Summary)
+	}
+	if gotBody["model_config_cuid"] != "model_abc" {
+		t.Fatalf("model_config_cuid = %#v", gotBody["model_config_cuid"])
+	}
+	if gotBody["org_cuid"] != "org_123" {
+		t.Fatalf("org_cuid = %#v", gotBody["org_cuid"])
+	}
+	invocation, ok := gotBody["invocation"].(map[string]any)
+	if !ok {
+		t.Fatalf("invocation = %#v", gotBody["invocation"])
+	}
+	if invocation["invocation_id"] != "inv_123" {
+		t.Fatalf("invocation_id = %#v", invocation["invocation_id"])
+	}
+	input, ok := invocation["input"].(map[string]any)
+	if !ok || input["path"] != "/tmp/a" {
+		t.Fatalf("input = %#v", invocation["input"])
 	}
 }

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -42,6 +42,7 @@ type Invocation struct {
 	Input          []byte     `json:"-"`
 	Response       []byte     `json:"-"`
 	Error          []byte     `json:"-"`
+	Summary        *string    `json:"summary,omitempty"`
 	SubmittedAt    time.Time  `json:"submitted_at"`
 	CompletedAt    *time.Time `json:"completed_at,omitempty"`
 }
@@ -123,6 +124,7 @@ type InvocationResponse struct {
 	CompletedAt   *time.Time      `json:"completed_at,omitempty"`
 	Result        json.RawMessage `json:"result,omitempty"`
 	Error         json.RawMessage `json:"error,omitempty"`
+	Summary       string          `json:"summary,omitempty"`
 }
 
 type InvocationListResponse struct {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -111,6 +111,7 @@ type approvalDecision struct {
 type invocationRepo interface {
 	Create(ctx context.Context, inv Invocation) error
 	UpdateResult(ctx context.Context, inv Invocation) error
+	UpdateSummary(ctx context.Context, id string, summary string) error
 	Get(ctx context.Context, id string) (Invocation, error)
 	GetByIdempotencyKey(ctx context.Context, key string) (Invocation, error)
 	List(ctx context.Context, filter InvocationListFilter) ([]Invocation, int, error)
@@ -960,8 +961,34 @@ func (s *Service) Events(ctx context.Context, invocationID string, filter EventL
 	return EventListResponse{Items: out, Total: total, Offset: filter.Offset, Limit: normalizedLimit(filter.Limit, 200)}, nil
 }
 
+// SetSummary persists an LLM-generated summary for the invocation and records
+// a lifecycle event. Callers (handlers) are responsible for producing the
+// summary text; the service simply stores it and surfaces it via Get/List.
+func (s *Service) SetSummary(ctx context.Context, invocationID string, summary string) (InvocationResponse, error) {
+	if invocationID == "" {
+		return InvocationResponse{}, fmt.Errorf("invocation_id is required")
+	}
+	if err := s.invocations.UpdateSummary(ctx, invocationID, summary); err != nil {
+		return InvocationResponse{}, err
+	}
+	inv, err := s.invocations.Get(ctx, invocationID)
+	if err != nil {
+		return InvocationResponse{}, err
+	}
+	_ = s.events.Create(ctx, Event{
+		InvocationID: invocationID,
+		EventType:    "invocation.summarized",
+		Payload:      mustJSON(map[string]any{"summary": summary}),
+		CreatedAt:    time.Now().UTC(),
+	})
+	return s.toResponse(inv), nil
+}
+
 func (s *Service) toResponse(inv Invocation) InvocationResponse {
 	resp := InvocationResponse{InvocationID: inv.InvocationID, ServerName: inv.Upstream, ToolName: inv.Tool, Status: inv.Status, Approval: inv.Approval, MatchedRuleID: inv.MatchedRuleID, AgentID: inv.AgentID, RequestID: inv.RequestID, SubmittedAt: inv.SubmittedAt, CompletedAt: inv.CompletedAt}
+	if inv.Summary != nil {
+		resp.Summary = *inv.Summary
+	}
 	if len(inv.Input) > 0 {
 		resp.Input = json.RawMessage(inv.Input)
 	}

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -74,12 +75,19 @@ type EvaluatorClient interface {
 	EvaluateToolCall(ctx context.Context, req EvaluateRequest) (EvaluateResponse, error)
 }
 
+// SummaryClient is the minimal interface required by the invocation service to
+// call the VM backend for an invocation summary.
+type SummaryClient interface {
+	SummarizeInvocation(ctx context.Context, req SummaryRequest) (SummaryResponse, error)
+}
+
 // SyncSettingsProvider lets the invocation service read the current agent sync
 // configuration on demand without importing the store package. The service
 // calls ConstitutionFieldKey on every AI evaluation so that changes saved via
 // the Settings UI are picked up immediately without a restart.
 type SyncSettingsProvider interface {
 	ConstitutionFieldKey(ctx context.Context) string
+	SummarySettings(ctx context.Context) (orgCUID string, modelConfigCUID string)
 }
 
 // EvaluateRequest mirrors backend.EvaluateRequest so the service package does
@@ -101,6 +109,19 @@ type EvaluateResponse struct {
 	Verdict    string   `json:"verdict"`
 	Reason     string   `json:"reason"`
 	Confidence *float64 `json:"confidence,omitempty"`
+}
+
+// SummaryRequest mirrors backend.SummarizeInvocationRequest so the service
+// package does not import the backend package directly.
+type SummaryRequest struct {
+	ModelConfigCUID string         `json:"model_config_cuid"`
+	OrgCUID         string         `json:"org_cuid,omitempty"`
+	Invocation      map[string]any `json:"invocation"`
+}
+
+// SummaryResponse mirrors backend.SummarizeInvocationResponse.
+type SummaryResponse struct {
+	Summary string `json:"summary"`
 }
 
 type approvalDecision struct {
@@ -143,6 +164,7 @@ type Service struct {
 	rules            rulesStore // nil = no rule evaluation
 	agents           AgentLookup
 	evaluator        EvaluatorClient
+	summarizer       SummaryClient
 	syncSettings     SyncSettingsProvider // nil = no constitution lookup
 	defaultTimeout   time.Duration
 	mu               sync.Mutex
@@ -174,6 +196,12 @@ func NewService(
 		defaultTimeout:   defaultTimeout,
 		pendingApprovals: make(map[string]chan approvalDecision),
 	}
+}
+
+// SetInvocationSummarizer installs the optional backend summarizer used to
+// summarize invocations automatically when they enter human approval.
+func (s *Service) SetInvocationSummarizer(client SummaryClient) {
+	s.summarizer = client
 }
 
 func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (InvocationResponse, error) {
@@ -481,6 +509,7 @@ func (s *Service) waitForHumanApproval(ctx context.Context, inv Invocation, upst
 		}),
 		CreatedAt: time.Now().UTC(),
 	})
+	s.summarizePendingApproval(inv.InvocationID)
 
 	select {
 	case d := <-ch:
@@ -789,7 +818,63 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 		return InvocationResponse{}, err
 	}
 	_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.pending_approval", Payload: mustJSON(receivedPayload), CreatedAt: time.Now().UTC()})
+	s.summarizePendingApproval(inv.InvocationID)
 	return s.toResponse(inv), nil
+}
+
+func (s *Service) summarizePendingApproval(invocationID string) {
+	if s.summarizer == nil || invocationID == "" {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		orgCUID := ""
+		modelConfigCUID := ""
+		if s.syncSettings != nil {
+			orgCUID, modelConfigCUID = s.syncSettings.SummarySettings(ctx)
+			orgCUID = strings.TrimSpace(orgCUID)
+			modelConfigCUID = strings.TrimSpace(modelConfigCUID)
+		}
+		if modelConfigCUID == "" {
+			slog.Debug("invocation summary skipped: summary model config is not set", "invocation_id", invocationID)
+			return
+		}
+
+		inv, err := s.invocations.Get(ctx, invocationID)
+		if err != nil {
+			slog.Warn("invocation summary skipped: load invocation failed", "invocation_id", invocationID, "error", err)
+			return
+		}
+		if inv.Summary != nil && *inv.Summary != "" {
+			return
+		}
+
+		raw, err := json.Marshal(s.toResponse(inv))
+		if err != nil {
+			slog.Warn("invocation summary skipped: encode invocation failed", "invocation_id", invocationID, "error", err)
+			return
+		}
+		var invMap map[string]any
+		if err := json.Unmarshal(raw, &invMap); err != nil {
+			slog.Warn("invocation summary skipped: normalize invocation failed", "invocation_id", invocationID, "error", err)
+			return
+		}
+
+		resp, err := s.summarizer.SummarizeInvocation(ctx, SummaryRequest{
+			ModelConfigCUID: modelConfigCUID,
+			OrgCUID:         orgCUID,
+			Invocation:      invMap,
+		})
+		if err != nil {
+			slog.Warn("invocation summary failed", "invocation_id", invocationID, "model_config_cuid", modelConfigCUID, "error", err)
+			return
+		}
+		if _, err := s.SetSummary(ctx, invocationID, resp.Summary); err != nil {
+			slog.Warn("invocation summary persist failed", "invocation_id", invocationID, "error", err)
+		}
+	}()
 }
 
 // RecordExecution updates an externally-executed invocation with the outcome

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -248,6 +249,67 @@ func TestSetSummaryPersistsSummaryAndRecordsEvent(t *testing.T) {
 	}
 }
 
+func TestSubmitPendingApprovalAutomaticallySummarizesInvocation(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	invRepo := store.NewInvocationRepo(db)
+	eventRepo := store.NewEventRepo(db)
+	service := invocation.NewService(invRepo, eventRepo, nil, nil, nil, 5*time.Second, nil, nil, nil, summarySettingsStub{
+		orgCUID:         " org_123 ",
+		modelConfigCUID: " model_123 ",
+	})
+	summarizer := &summaryClientStub{summary: "Run shell command ls."}
+	service.SetInvocationSummarizer(summarizer)
+
+	resp, err := service.Submit(context.Background(), invocation.ExternalSubmitRequest{
+		Source: "amp",
+		Tool:   "bash",
+		Input:  map[string]any{"cmd": "ls"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusPendingApproval {
+		t.Fatalf("expected pending approval, got %s", resp.Status)
+	}
+
+	var got invocation.InvocationResponse
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err = service.Get(context.Background(), resp.InvocationID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Summary == "Run shell command ls." {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got.Summary != "Run shell command ls." {
+		t.Fatalf("expected automatic summary, got %q", got.Summary)
+	}
+	summaryReq := summarizer.request()
+	if summaryReq.ModelConfigCUID != "model_123" {
+		t.Fatalf("model_config_cuid = %q", summaryReq.ModelConfigCUID)
+	}
+	if summaryReq.OrgCUID != "org_123" {
+		t.Fatalf("org_cuid = %q", summaryReq.OrgCUID)
+	}
+	if summaryReq.Invocation["invocation_id"] != resp.InvocationID {
+		t.Fatalf("backend invocation payload = %#v", summaryReq.Invocation)
+	}
+	input, ok := summaryReq.Invocation["input"].(map[string]any)
+	if !ok || input["cmd"] != "ls" {
+		t.Fatalf("backend invocation input = %#v", summaryReq.Invocation["input"])
+	}
+}
+
 func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
@@ -264,6 +326,38 @@ func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 		t.Fatal(err)
 	}
 	return invocation.NewService(store.NewInvocationRepo(db), store.NewEventRepo(db), resolver, mcp.NewHTTPClient(), policy.AlwaysApproveProvider{}, 5*time.Second, nil, nil, nil, nil)
+}
+
+type summaryClientStub struct {
+	mu      sync.Mutex
+	summary string
+	req     invocation.SummaryRequest
+}
+
+func (s *summaryClientStub) SummarizeInvocation(_ context.Context, req invocation.SummaryRequest) (invocation.SummaryResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.req = req
+	return invocation.SummaryResponse{Summary: s.summary}, nil
+}
+
+func (s *summaryClientStub) request() invocation.SummaryRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.req
+}
+
+type summarySettingsStub struct {
+	orgCUID         string
+	modelConfigCUID string
+}
+
+func (s summarySettingsStub) ConstitutionFieldKey(context.Context) string {
+	return ""
+}
+
+func (s summarySettingsStub) SummarySettings(context.Context) (string, string) {
+	return s.orgCUID, s.modelConfigCUID
 }
 
 func approveNextInvocation(t *testing.T, service *invocation.Service, delay time.Duration) {

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -192,6 +192,62 @@ func TestServerStatusPersistsAfterUpdate(t *testing.T) {
 	}
 }
 
+func TestSetSummaryPersistsSummaryAndRecordsEvent(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	invRepo := store.NewInvocationRepo(db)
+	eventRepo := store.NewEventRepo(db)
+	service := invocation.NewService(invRepo, eventRepo, nil, nil, policy.AlwaysApproveProvider{}, 5*time.Second, nil, nil, nil, nil)
+	now := time.Now().UTC()
+	inv := invocation.Invocation{
+		InvocationID: "inv-summary",
+		Tool:         "read_file",
+		Upstream:     "demo",
+		Status:       invocation.StatusSucceeded,
+		Input:        []byte(`{"path":"/tmp/a"}`),
+		SubmittedAt:  now,
+		CompletedAt:  &now,
+	}
+	if err := invRepo.Create(context.Background(), inv); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := service.SetSummary(context.Background(), "inv-summary", "Read /tmp/a.")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.InvocationID != "inv-summary" || resp.Summary != "Read /tmp/a." {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	stored, err := invRepo.Get(context.Background(), "inv-summary")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Summary == nil || *stored.Summary != "Read /tmp/a." {
+		t.Fatalf("stored summary = %#v", stored.Summary)
+	}
+	events, err := service.Events(context.Background(), "inv-summary", invocation.EventListFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events.Items) != 1 {
+		t.Fatalf("expected one event, got %d", len(events.Items))
+	}
+	if events.Items[0].Type != "invocation.summarized" {
+		t.Fatalf("event type = %q", events.Items[0].Type)
+	}
+	if !jsonContains(events.Items[0].Data, `"summary":"Read /tmp/a."`) {
+		t.Fatalf("event payload = %s", string(events.Items[0].Data))
+	}
+}
+
 func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")

--- a/internal/store/agent_sync_settings.go
+++ b/internal/store/agent_sync_settings.go
@@ -14,14 +14,15 @@ import (
 // synchronisation from the ValidMind backend. All fields are empty strings
 // when the user has not yet configured sync (i.e. no row exists yet).
 type AgentSyncSettings struct {
-	OrgCUID             string
-	AgentRecordTypeSlug string
-	ConstitutionFieldKey string
-	UpdatedAt           time.Time
+	OrgCUID                string
+	AgentRecordTypeSlug    string
+	ConstitutionFieldKey   string
+	SummaryModelConfigCUID string
+	UpdatedAt              time.Time
 }
 
 var agentSyncSettingsColumns = []string{
-	"org_cuid", "agent_record_type_slug", "constitution_field_key", "updated_at",
+	"org_cuid", "agent_record_type_slug", "constitution_field_key", "summary_model_config_cuid", "updated_at",
 }
 
 // AgentSyncSettingsRepo provides read/write access to the singleton
@@ -71,18 +72,19 @@ func (r *AgentSyncSettingsRepo) Save(ctx context.Context, s AgentSyncSettings) e
 	var args []any
 	if r.dialect == DialectPostgres {
 		// PostgreSQL upsert
-		query = `INSERT INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, updated_at)
-VALUES (1, $1, $2, $3, $4)
+		query = `INSERT INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, updated_at)
+VALUES (1, $1, $2, $3, $4, $5)
 ON CONFLICT (id) DO UPDATE SET
-  org_cuid               = EXCLUDED.org_cuid,
-  agent_record_type_slug = EXCLUDED.agent_record_type_slug,
-  constitution_field_key = EXCLUDED.constitution_field_key,
-  updated_at             = EXCLUDED.updated_at`
-		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, now}
+  org_cuid                  = EXCLUDED.org_cuid,
+  agent_record_type_slug    = EXCLUDED.agent_record_type_slug,
+  constitution_field_key    = EXCLUDED.constitution_field_key,
+  summary_model_config_cuid = EXCLUDED.summary_model_config_cuid,
+  updated_at                = EXCLUDED.updated_at`
+		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, now}
 	} else {
 		// SQLite: INSERT OR REPLACE replaces the row when the primary key conflicts.
-		query = `INSERT OR REPLACE INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, updated_at) VALUES (1, ?, ?, ?, ?)`
-		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, now}
+		query = `INSERT OR REPLACE INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, updated_at) VALUES (1, ?, ?, ?, ?, ?)`
+		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, now}
 	}
 	result, err := r.db.ExecContext(ctx, query, args...)
 	if err != nil {
@@ -100,6 +102,7 @@ func scanAgentSyncSettings(row interface{ Scan(dest ...any) error }) (AgentSyncS
 		&s.OrgCUID,
 		&s.AgentRecordTypeSlug,
 		&s.ConstitutionFieldKey,
+		&s.SummaryModelConfigCUID,
 		&s.UpdatedAt,
 	); err != nil {
 		return AgentSyncSettings{}, err

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 12 {
+	if len(migrations) != 13 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -65,6 +65,7 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{10, "010_ai_evaluation_rule"},
 		{11, "011_agent_sync_settings"},
 		{12, "012_invocation_summary"},
+		{13, "013_summary_model_config"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -75,10 +76,10 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 11 {
+	if len(pending) != 12 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}
 	for i, want := range wantVersions {
 		if pending[i].Version != want {
 			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 11 {
+	if len(migrations) != 12 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -64,6 +64,7 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{9, "009_agents_table"},
 		{10, "010_ai_evaluation_rule"},
 		{11, "011_agent_sync_settings"},
+		{12, "012_invocation_summary"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -74,10 +75,10 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 10 {
+	if len(pending) != 11 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
+	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 	for i, want := range wantVersions {
 		if pending[i].Version != want {
 			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)

--- a/internal/store/migrations/012_invocation_summary.go
+++ b/internal/store/migrations/012_invocation_summary.go
@@ -1,0 +1,11 @@
+package migrations
+
+func migration012() Definition {
+	return Definition{
+		Version: 12,
+		Name:    "012_invocation_summary",
+		Steps: []Step{
+			Raw("add summary to invocations", `ALTER TABLE invocations ADD COLUMN summary TEXT`),
+		},
+	}
+}

--- a/internal/store/migrations/013_summary_model_config.go
+++ b/internal/store/migrations/013_summary_model_config.go
@@ -1,0 +1,14 @@
+package migrations
+
+func migration013() Definition {
+	return Definition{
+		Version: 13,
+		Name:    "013_summary_model_config",
+		Steps: []Step{
+			Raw(
+				"add summary_model_config_cuid to agent_sync_settings",
+				`ALTER TABLE agent_sync_settings ADD COLUMN summary_model_config_cuid TEXT NOT NULL DEFAULT ''`,
+			),
+		},
+	}
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -46,5 +46,6 @@ func All() []Definition {
 		migration010(),
 		migration011(),
 		migration012(),
+		migration013(),
 	}
 }

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -45,5 +45,6 @@ func All() []Definition {
 		migration009(),
 		migration010(),
 		migration011(),
+		migration012(),
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -82,9 +82,9 @@ func (r *InvocationRepo) Create(ctx context.Context, inv invocation.Invocation) 
 		approval = string(b)
 	}
 	query, args, err := r.sb.Insert("invocations").Columns(
-		"invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id",
+		"invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary",
 	).Values(
-		inv.InvocationID, inv.RequestID, inv.IdempotencyKey, inv.Tool, inv.Upstream, inv.Status, approval, string(inv.Input), nullableString(inv.Response), nullableString(inv.Error), inv.SubmittedAt, inv.CompletedAt, inv.MatchedRuleID, inv.AgentID,
+		inv.InvocationID, inv.RequestID, inv.IdempotencyKey, inv.Tool, inv.Upstream, inv.Status, approval, string(inv.Input), nullableString(inv.Response), nullableString(inv.Error), inv.SubmittedAt, inv.CompletedAt, inv.MatchedRuleID, inv.AgentID, inv.Summary,
 	).ToSql()
 	if err != nil {
 		return err
@@ -107,8 +107,23 @@ func (r *InvocationRepo) UpdateResult(ctx context.Context, inv invocation.Invoca
 	return err
 }
 
+// UpdateSummary persists the LLM-generated summary for an invocation. The
+// summary is stored verbatim; an empty string clears any prior value.
+func (r *InvocationRepo) UpdateSummary(ctx context.Context, id string, summary string) error {
+	var value any
+	if summary != "" {
+		value = summary
+	}
+	query, args, err := r.sb.Update("invocations").Set("summary", value).Where(sq.Eq{"invocation_id": id}).ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = r.db.ExecContext(ctx, query, args...)
+	return err
+}
+
 func (r *InvocationRepo) Get(ctx context.Context, id string) (invocation.Invocation, error) {
-	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").From("invocations").Where(sq.Eq{"invocation_id": id}).ToSql()
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary").From("invocations").Where(sq.Eq{"invocation_id": id}).ToSql()
 	if err != nil {
 		return invocation.Invocation{}, err
 	}
@@ -117,7 +132,7 @@ func (r *InvocationRepo) Get(ctx context.Context, id string) (invocation.Invocat
 }
 
 func (r *InvocationRepo) GetByIdempotencyKey(ctx context.Context, key string) (invocation.Invocation, error) {
-	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").From("invocations").Where(sq.Eq{"idempotency_key": key}).ToSql()
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary").From("invocations").Where(sq.Eq{"idempotency_key": key}).ToSql()
 	if err != nil {
 		return invocation.Invocation{}, err
 	}
@@ -129,7 +144,7 @@ func (r *InvocationRepo) List(ctx context.Context, filter invocation.InvocationL
 	if filter.Limit == 0 {
 		filter.Limit = 50
 	}
-	builder := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").From("invocations")
+	builder := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary").From("invocations")
 	countBuilder := r.sb.Select("COUNT(*)").From("invocations")
 	builder, countBuilder = applyInvocationFilter(builder, countBuilder, filter)
 	query, args, err := builder.OrderBy("submitted_at DESC").Limit(filter.Limit).Offset(filter.Offset).ToSql()
@@ -526,7 +541,8 @@ func scanInvocation(scanner interface{ Scan(dest ...any) error }) (invocation.In
 	var completedAt sql.NullTime
 	var matchedRuleID sql.NullString
 	var agentID sql.NullString
-	if err := scanner.Scan(&inv.InvocationID, &requestID, &idempotencyKey, &inv.Tool, &inv.Upstream, &inv.Status, &approval, &requestJSON, &responseJSON, &errorJSON, &inv.SubmittedAt, &completedAt, &matchedRuleID, &agentID); err != nil {
+	var summary sql.NullString
+	if err := scanner.Scan(&inv.InvocationID, &requestID, &idempotencyKey, &inv.Tool, &inv.Upstream, &inv.Status, &approval, &requestJSON, &responseJSON, &errorJSON, &inv.SubmittedAt, &completedAt, &matchedRuleID, &agentID, &summary); err != nil {
 		return invocation.Invocation{}, err
 	}
 	if requestID.Valid {
@@ -557,6 +573,9 @@ func scanInvocation(scanner interface{ Scan(dest ...any) error }) (invocation.In
 	}
 	if agentID.Valid {
 		inv.AgentID = &agentID.String
+	}
+	if summary.Valid {
+		inv.Summary = &summary.String
 	}
 	return inv, nil
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -41,8 +41,8 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 12 {
-		t.Fatalf("expected 12 migrations, got %d", count)
+	if count != 13 {
+		t.Fatalf("expected 13 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 12 {
-		t.Fatalf("expected 12 migrations after double init, got %d", count)
+	if count != 13 {
+		t.Fatalf("expected 13 migrations after double init, got %d", count)
 	}
 }
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -41,8 +41,8 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 11 {
-		t.Fatalf("expected 11 migrations, got %d", count)
+	if count != 12 {
+		t.Fatalf("expected 12 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 11 {
-		t.Fatalf("expected 11 migrations after double init, got %d", count)
+	if count != 12 {
+		t.Fatalf("expected 12 migrations after double init, got %d", count)
 	}
 }
 

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -173,6 +173,68 @@ func TestInvocationRepo_CRUD(t *testing.T) {
 	}
 }
 
+func TestInvocationRepo_UpdateSummary(t *testing.T) {
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+	if err := InitDB(db); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	repo := NewInvocationRepo(db)
+	ctx := context.Background()
+	inv := invocation.Invocation{
+		InvocationID:   "inv-summary",
+		Tool:           "read_file",
+		Upstream:       "github",
+		Status:         "completed",
+		Input:          []byte(`{"path":"/tmp/test"}`),
+		IdempotencyKey: strPtr("summary-key"),
+		SubmittedAt:    time.Now().UTC(),
+	}
+	if err := repo.Create(ctx, inv); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := repo.UpdateSummary(ctx, "inv-summary", "Read /tmp/test."); err != nil {
+		t.Fatalf("UpdateSummary: %v", err)
+	}
+
+	got, err := repo.Get(ctx, "inv-summary")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Summary == nil || *got.Summary != "Read /tmp/test." {
+		t.Fatalf("Get summary = %#v", got.Summary)
+	}
+	byKey, err := repo.GetByIdempotencyKey(ctx, "summary-key")
+	if err != nil {
+		t.Fatalf("GetByIdempotencyKey: %v", err)
+	}
+	if byKey.Summary == nil || *byKey.Summary != "Read /tmp/test." {
+		t.Fatalf("GetByIdempotencyKey summary = %#v", byKey.Summary)
+	}
+	items, total, err := repo.List(ctx, invocation.InvocationListFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("List total=%d len=%d", total, len(items))
+	}
+	if items[0].Summary == nil || *items[0].Summary != "Read /tmp/test." {
+		t.Fatalf("List summary = %#v", items[0].Summary)
+	}
+
+	if err := repo.UpdateSummary(ctx, "inv-summary", ""); err != nil {
+		t.Fatalf("UpdateSummary clear: %v", err)
+	}
+	cleared, err := repo.Get(ctx, "inv-summary")
+	if err != nil {
+		t.Fatalf("Get after clear: %v", err)
+	}
+	if cleared.Summary != nil {
+		t.Fatalf("expected cleared summary, got %#v", cleared.Summary)
+	}
+}
+
 func TestInvocationRepo_AgentIDPersistedAndFilterable(t *testing.T) {
 	db, cleanup := openTestDB(t)
 	defer cleanup()
@@ -696,8 +758,8 @@ func TestAgentSyncSettingsRepo_UpsertOnEmptyTable(t *testing.T) {
 
 	// Save should create the row
 	err = repo.Save(ctx, AgentSyncSettings{
-		OrgCUID:             "org-abc",
-		AgentRecordTypeSlug: "ai-agents",
+		OrgCUID:              "org-abc",
+		AgentRecordTypeSlug:  "ai-agents",
 		ConstitutionFieldKey: "constitution",
 	})
 	if err != nil {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -758,9 +758,10 @@ func TestAgentSyncSettingsRepo_UpsertOnEmptyTable(t *testing.T) {
 
 	// Save should create the row
 	err = repo.Save(ctx, AgentSyncSettings{
-		OrgCUID:              "org-abc",
-		AgentRecordTypeSlug:  "ai-agents",
-		ConstitutionFieldKey: "constitution",
+		OrgCUID:                "org-abc",
+		AgentRecordTypeSlug:    "ai-agents",
+		ConstitutionFieldKey:   "constitution",
+		SummaryModelConfigCUID: "model-abc",
 	})
 	if err != nil {
 		t.Fatalf("Save: %v", err)
@@ -776,5 +777,8 @@ func TestAgentSyncSettingsRepo_UpsertOnEmptyTable(t *testing.T) {
 	}
 	if s.AgentRecordTypeSlug != "ai-agents" {
 		t.Fatalf("expected AgentRecordTypeSlug=ai-agents, got %q", s.AgentRecordTypeSlug)
+	}
+	if s.SummaryModelConfigCUID != "model-abc" {
+		t.Fatalf("expected SummaryModelConfigCUID=model-abc, got %q", s.SummaryModelConfigCUID)
 	}
 }


### PR DESCRIPTION
## Summary
We want to be able to provide llm summarizations of invocations

- add an admin summarize endpoint that sends invocation details to the backend LLM summarization endpoint and persists the returned summary
- store invocation summaries in the database and expose them through get/list responses
- add API, backend client, service, and store coverage for invocation summaries
- include summaries in SSE/list dedupe signatures so summary-only updates refresh the live UI

## Tests
- GOCACHE=/tmp/atryum-go-build go test ./internal/api ./internal/backend ./internal/invocation ./internal/store
- git diff --check

Checkout https://github.com/validmind/backend/pull/3182 and https://github.com/validmind/frontend/pull/2593
Go to the invocations tab and summarize results.