### PR TITLE
[SC-16466] LLM-as-judge: defer to human approval or next rule

### DIFF
--- a/.agents/skills/populate-constitution/assets/constitution-template.md
+++ b/.agents/skills/populate-constitution/assets/constitution-template.md
@@ -32,6 +32,20 @@
 - {Condition requiring human review or escalation}
 - {Condition requiring human review or escalation}
 
+### Human approval required when
+<!-- The LLM-as-judge will route the invocation to the human approval queue
+     when any of these conditions are met. Remove this section if every
+     case is fully handled by the permission tiers below. -->
+- {Condition that requires a human sign-off before the tool call executes}
+- {Condition that requires a human sign-off before the tool call executes}
+
+### Defer to next rule when
+<!-- The LLM-as-judge will pass evaluation to the next matching approval rule
+     when any of these conditions are met, rather than making a final decision.
+     Use sparingly — prefer explicit approve/deny/human-approval tiers. -->
+- {Condition where this constitution has no opinion and should defer}
+- {Condition where this constitution has no opinion and should defer}
+
 ---
 
 ## Permissions

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -236,7 +236,7 @@ func (e *evaluatorAdapter) EvaluateToolCall(ctx context.Context, req invocation.
 	if err != nil {
 		return invocation.EvaluateResponse{}, err
 	}
-	return invocation.EvaluateResponse{Approved: resp.Approved, Reason: resp.Reason}, nil
+	return invocation.EvaluateResponse{Verdict: resp.Verdict, Reason: resp.Reason}, nil
 }
 
 func truthyEnv(name string) bool {

--- a/docs/testing/ai-evaluation.md
+++ b/docs/testing/ai-evaluation.md
@@ -15,9 +15,17 @@ This guide walks through manually testing the AI Evaluation rule type end-to-end
 
 ## Step 1 — Configure `atryum.toml`
 
-You need three sections populated: `[[auth]]`, `[agent_sync]`, and `[ai_evaluation]`.
+`atryum.toml` only needs two sections for AI Evaluation: `[backend]` (ValidMind credentials) and `[[auth]]` (JWT validation). Agent sync and constitution settings have moved to the UI — see **Step 1b** below.
 
 ```toml
+# ValidMind backend connection (machine-user credentials).
+[backend]
+base_url       = "https://api.your-validmind-instance.ai"
+machine_key    = "<your-machine-key>"
+machine_secret = "<your-machine-secret>"
+connection_timeout_seconds = 5
+evaluate_timeout_seconds   = 120   # allow enough time for LLM evaluation
+
 # Validates bearer tokens issued by your IDP.
 # Add one [[auth]] block per issuer you want to accept.
 [[auth]]
@@ -28,27 +36,40 @@ audience       = "https://api.your-validmind-instance.ai"
 # jwks_url     = "https://your-tenant.us.auth0.com/.well-known/jwks.json"
 required_scope = ""
 agent_id_claim = "sub"   # claim that carries the agent's unique identity
-
-# Fetches active Inventory Model records from the backend at startup.
-[agent_sync]
-org_cuid               = "<your-org-cuid>"          # e.g. cl1gr2aiu000309ih76g9cvix
-agent_record_type_slug = "ai-agents"                # primary record type slug in VM
-
-# Tells Atryum which custom field on the Inventory Model holds the constitution.
-[ai_evaluation]
-constitution_field_key = "constitution"
 ```
+
+---
+
+## Step 1b — Configure Agent Sync in the UI
+
+The organization, record type, and constitution field are now configured in the Atryum UI under **Settings → Agent Record Sync**. This replaces the old `[agent_sync]` and `[ai_evaluation]` TOML sections.
+
+1. Open the Atryum UI and navigate to **Settings**.
+2. Under **Agent Record Sync**, fill in the three fields:
+
+   | Field | What to enter |
+   |---|---|
+   | **Organization** | Select the ValidMind organization whose agent records should be synced |
+   | **Record Type** | Select the primary record type that identifies agent inventory models (e.g. `ai-agents`) |
+   | **Constitution Field** | Select the custom field key on inventory models that stores the constitution text (e.g. `constitution`) |
+
+   The dropdowns are cascading — selecting an organization loads its record types; selecting a record type loads the custom fields available on that type.
+
+3. Click **Save Settings**. Atryum will immediately sync agent records from the selected org and record type and confirm with a toast notification.
+
+> **Note:** Changing the organization or record type deletes and re-syncs all agent records. Atryum will prompt you to confirm before proceeding.
+
 ---
 
 ## Step 2 — Restart Atryum
 
-Stop and restart the Atryum server. On startup it will:
+Stop and restart the Atryum server so it picks up the `atryum.toml` changes. On startup it will:
 
 1. Verify the backend connection using your machine-user credentials.
-2. Fetch all active Inventory Model records for the configured org and record type slug.
+2. Fetch all active Inventory Model records for the org and record type configured in Settings (Step 1b).
 3. Log each fetched agent: `agent cuid=… name="…" description="…"`.
 
-Confirm the agents appear in the startup log before proceeding.
+Confirm the agents appear in the startup log before proceeding. Agent sync settings saved in the UI persist across restarts — you do not need to re-enter them.
 
 ---
 
@@ -72,7 +93,65 @@ Atryum will now recognise bearer tokens issued for that user as belonging to thi
 
 ---
 
-## Step 5 — Create an AI Evaluation Approval Rule
+## Step 5 — Author the Agent Constitution
+
+The constitution is stored as a custom field (key = `constitution_field_key`) on the agent's Inventory Model in ValidMind. It is free-form Markdown, but the LLM-as-judge recognises the following sections to decide its verdict:
+
+### Permission tiers (tool-level)
+
+| Tier | Verdict | When to use |
+|------|---------|-------------|
+| **Auto** | `approved` | Low-risk, read-only actions the agent may perform silently |
+| **Approve** | `human_approval` | Risky or sensitive actions that require a human sign-off |
+| **Never** | `denied` | Prohibited actions — hard block, no exceptions |
+
+### `### Human approval required when`
+
+List conditions under which the LLM should route the invocation to the human approval queue instead of deciding automatically. The judge returns `human_approval` when any condition is met.
+
+```markdown
+### Human approval required when
+- The SQL query modifies data (INSERT, UPDATE, DELETE, DROP, …)
+- The request targets a table not explicitly listed in the constitution
+- The query returns more than 10,000 rows
+```
+
+### `### Defer to next rule when`
+
+List conditions under which the LLM should pass evaluation to the next matching approval rule rather than making a final decision. The judge returns `next_rule` when any condition is met. Use sparingly — prefer explicit tiers above.
+
+```markdown
+### Defer to next rule when
+- The tool is not a database tool (let downstream rules handle it)
+```
+
+### Constitution chain and precedence
+
+If the agent's Inventory Model has upstream dependencies, Atryum collects constitutions from the entire chain (most-upstream ancestor first, this agent last) and presents them all to the LLM. The judge applies these precedence rules:
+
+1. **Downstream wins**: later constitutions in the chain are more specific and override earlier ones when they conflict.
+2. **Explicit delegation is honoured**: if an upstream says "downstream constitutions may override this", a downstream grant (even conditional) replaces the upstream rule.
+3. **Most specific match first**: apply the innermost rule that covers the action; fall back to upstream only when no downstream constitution addresses it.
+4. **Grants override blanket denials**: a downstream "allow with human approval" beats an upstream "deny all".
+
+**Example:**
+
+```
+[Upstream agent]
+Deny all Postgres queries. Downstream constitutions may override this.
+
+---
+
+[This agent]
+### Human approval required when
+- The query is a read-only SELECT on the inventory_models table
+```
+
+Result: `human_approval` (downstream grant overrides upstream blanket denial).
+
+---
+
+## Step 6 — Create an AI Evaluation Approval Rule
 
 1. In the Atryum UI, go to **Rules** and click **New Rule**.
 2. Fill in the rule:
@@ -87,17 +166,28 @@ Atryum will now recognise bearer tokens issued for that user as belonging to thi
 
 3. Save the rule.
 
+### Chaining rules with `next_rule`
+
+You can stack multiple AI Evaluation rules in priority order. When the LLM returns `next_rule`, Atryum advances to the next matching rule rather than making a final decision. If all matching rules defer, the invocation falls back to human approval.
+
 ---
 
-## Step 6 — Trigger an Invocation and Observe the Evaluation
+## Step 7 — Trigger an Invocation and Observe the Evaluation
 
 Send a tool call through Atryum using a bearer token issued for the agent identity created in Step 3. The flow is:
 
 1. Atryum receives the invocation and matches it to the AI Evaluation rule.
 2. It resolves the agent's Inventory Model CUID and org CUID from the stored record.
 3. It calls `POST /internal/v1/atryum/evaluate` on the ValidMind backend with the agent details, constitution field key, and tool call context.
-4. The backend fetches the constitution from the Inventory Model's custom fields, builds a prompt, and asks the configured LLM to approve or deny.
-5. Atryum receives `{ approved, reason }` and either auto-approves (executes the tool) or auto-denies (returns an error to the caller).
+4. The backend fetches the constitution chain from the Inventory Model's custom fields, builds a prompt with precedence rules, and asks the configured LLM for a verdict.
+5. Atryum receives `{ verdict, reason }` and routes the invocation accordingly:
+
+   | Verdict | Disposition | UI outcome |
+   |---------|-------------|------------|
+   | `approved` | Auto-execute | `Succeeded` · **AI Evaluation** badge (purple) |
+   | `denied` | Hard deny | `Denied` · **AI Evaluation** badge (purple) |
+   | `human_approval` | Human queue | `Pending` · **AI Escalated** badge (yellow); after decision: **AI Escalated** + **Human** |
+   | `next_rule` | Continue to next rule | *(internal — not a final state)* |
 
 In the Atryum UI, open **Invocations** to see the outcome and the disposition reason logged against the invocation.
 
@@ -111,3 +201,5 @@ In the Atryum UI, open **Invocations** to see the outcome and the disposition re
 | Rule never matches | Agent IDs field is empty, the user's `sub` doesn't match `agent_id_claim`, or the bearer token is not being sent by the agent |
 | Evaluation falls back to `human_approval` | `constitution_field_key` doesn't match the custom field name in VM, or the LLM call failed (check logs) |
 | 403 from `/evaluate` | `org_cuid` in the request doesn't match the agent's organization in ValidMind |
+| Upstream deny overrides downstream grant | Backend not yet redeployed with the precedence-rules prompt update; check that `verdict` (not `approved`) is present in the `/evaluate` response |
+| `next_rule` never advances | Rules are not stacked in priority order, or the constitution does not contain a `### Defer to next rule when` section |

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -928,7 +928,7 @@ func (h *Handler) annotateToolsWithPolicy(ctx context.Context, server string, to
 }
 
 // effectiveActionForTool returns the action of the first enabled rule that
-// matches (server, tool, agentID), mirroring invocation.matchRule semantics.
+// matches (server, tool, agentID), mirroring invocation.matchRules priority order.
 // When no rule matches, it returns RuleActionHumanApproval (the default).
 func effectiveActionForTool(rules []store.Rule, server, tool, agentID string) (string, string) {
 	for _, r := range rules {

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -303,9 +303,10 @@ type EvaluateRequest struct {
 }
 
 // EvaluateResponse is the result returned by the VM backend after LLM evaluation.
+// Verdict is one of: "approved", "denied", "human_approval", "next_rule".
 type EvaluateResponse struct {
-	Approved bool   `json:"approved"`
-	Reason   string `json:"reason"`
+	Verdict string `json:"verdict"`
+	Reason  string `json:"reason"`
 }
 
 // EvaluateToolCall calls the VM backend's evaluate endpoint and returns whether

--- a/internal/invocation/rules.go
+++ b/internal/invocation/rules.go
@@ -33,14 +33,17 @@ type rulesStore interface {
 	ListApprovalRules(ctx context.Context) ([]ApprovalRule, error)
 }
 
-// matchRule returns the first enabled rule that matches the given invocation
-// parameters, or nil if no rule matches (fall back to human approval).
-// The agentID is the authenticated agent identity (empty when auth is
-// disabled — callers fall back to request_id for parity with pre-auth behavior).
+// matchRules returns all enabled rules that match the given invocation parameters,
+// preserving their stored order (priority order). Callers iterate through the slice
+// and stop at the first rule that produces a final verdict; an empty slice means no
+// rule matches and the caller should fall back to the global policy.
+//
+// The agentID is the authenticated agent identity (empty when auth is disabled —
+// callers fall back to request_id for parity with pre-auth behavior).
 // The agentCUID is the Atryum-local agent record CUID used by ai_evaluation rules.
-func matchRule(rules []ApprovalRule, server, tool, agentID, agentCUID string) *ApprovalRule {
-	for i := range rules {
-		r := &rules[i]
+func matchRules(rules []ApprovalRule, server, tool, agentID, agentCUID string) []ApprovalRule {
+	var matched []ApprovalRule
+	for _, r := range rules {
 		if !r.Enabled {
 			continue
 		}
@@ -56,9 +59,9 @@ func matchRule(rules []ApprovalRule, server, tool, agentID, agentCUID string) *A
 		if !matchAgentCUIDs(r.AgentCUIDs, agentCUID) {
 			continue
 		}
-		return r
+		matched = append(matched, r)
 	}
-	return nil
+	return matched
 }
 
 // matchAgentCUIDs returns true when cuids is empty (match all) or contains agentCUID.

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -16,6 +16,36 @@ import (
 	"atryum/internal/mcp"
 )
 
+// dispositionContinue is an internal sentinel returned by runAIEvaluation when the
+// LLM verdict is "next_rule". It is never persisted or returned to clients — the
+// Invoke/Submit rule-iteration loop uses it to advance to the next matching approval
+// rule. If all matching rules defer, the call falls back to human_approval.
+const dispositionContinue policy.Disposition = "continue"
+
+// dispositionAIEscalated is an internal sentinel returned by runAIEvaluation when
+// the LLM verdict is "human_approval". It routes to the same human-approval queue as
+// DispositionHuman but marks the invocation's approval record with status
+// "ai_escalated" so the UI can distinguish a deliberate LLM escalation from a
+// direct human_approval rule or an error fallback.
+const dispositionAIEscalated policy.Disposition = "ai_escalated"
+
+// humanDecisionStatus returns the approval status string to write when a human
+// approves or denies an invocation. If the invocation was AI-escalated the composite
+// statuses ("ai_escalated_approved" / "ai_escalated_denied") preserve the origin so
+// the UI can show both badges.
+func humanDecisionStatus(current *Approval, approved bool) string {
+	if current != nil && current.Status == "ai_escalated" {
+		if approved {
+			return "ai_escalated_approved"
+		}
+		return "ai_escalated_denied"
+	}
+	if approved {
+		return "approved"
+	}
+	return "denied"
+}
+
 // AgentLookup is the minimal interface required by the invocation service to
 // resolve an agent's VM CUID from its runtime agent ID.
 type AgentLookup interface {
@@ -58,9 +88,10 @@ type EvaluateRequest struct {
 }
 
 // EvaluateResponse mirrors backend.EvaluateResponse.
+// Verdict is one of: "approved", "denied", "human_approval", "next_rule".
 type EvaluateResponse struct {
-	Approved bool   `json:"approved"`
-	Reason   string `json:"reason"`
+	Verdict string `json:"verdict"`
+	Reason  string `json:"reason"`
 }
 
 type approvalDecision struct {
@@ -195,21 +226,32 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 			if user == "" && req.RequestID != nil {
 				user = *req.RequestID
 			}
-			if matched := matchRule(approvalRules, upstream.Name, req.Tool, user, agentRec.ID); matched != nil {
+			for _, rule := range matchRules(approvalRules, upstream.Name, req.Tool, user, agentRec.ID) {
+				r := rule
 				ruleMatched = true
-				if matched.ID != "" {
-					matchedRuleID = &matched.ID
+				if r.ID != "" {
+					id := r.ID
+					matchedRuleID = &id
 				}
-				switch matched.Action {
+				switch r.Action {
 				case RuleActionAutoDeny:
 					decision = policy.Decision{Disposition: policy.DispositionNever, Reason: "matched approval rule (auto_deny)"}
 				case RuleActionAutoApprove:
 					decision = policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (auto_approve)"}
 				case RuleActionAIEvaluation:
-					decision = s.runAIEvaluation(ctx, matched, upstream.Name, req.Tool, req.Input, agentID)
+					decision = s.runAIEvaluation(ctx, &r, upstream.Name, req.Tool, req.Input, agentID)
 				default:
 					decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (human_approval)"}
 				}
+				if decision.Disposition != dispositionContinue {
+					break
+				}
+				slog.Info("ai_evaluation: LLM deferred to next rule; continuing rule iteration",
+					"rule_id", r.ID, "server", upstream.Name, "tool", req.Tool)
+			}
+			// If every matching ai_evaluation rule deferred, treat as human approval.
+			if ruleMatched && decision.Disposition == dispositionContinue {
+				decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
 			}
 		}
 	}
@@ -222,8 +264,12 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		}
 	}
 	// Persist matched_rule_id for human-approval invocations so approve/deny handlers can reference it.
-	if decision.Disposition == policy.DispositionHuman || decision.Disposition == policy.DispositionWorkflow {
+	// Also tag AI-escalated invocations so the UI can distinguish them from direct human_approval rules.
+	if decision.Disposition == policy.DispositionHuman || decision.Disposition == policy.DispositionWorkflow || decision.Disposition == dispositionAIEscalated {
 		inv.MatchedRuleID = matchedRuleID
+		if decision.Disposition == dispositionAIEscalated {
+			inv.Approval = &Approval{Status: "ai_escalated", Reason: stringPtr(decision.Reason)}
+		}
 		_ = s.invocations.UpdateResult(ctx, inv)
 	}
 
@@ -249,7 +295,9 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 	case policy.DispositionAuto:
 		return s.executeNow(ctx, inv, upstream, req, decision.Reason)
 	default:
-		// DispositionHuman and DispositionWorkflow both gate on a human decision.
+		// DispositionHuman, DispositionWorkflow, and dispositionAIEscalated all gate
+		// on a human decision. AI-escalated invocations are already tagged on inv.Approval
+		// above; waitForHumanApproval will persist the pending_approval status.
 		return s.waitForHumanApproval(ctx, inv, upstream, req)
 	}
 }
@@ -329,12 +377,8 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 		return policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: LLM call failed (falling back to human_approval)"}
 	}
 
-	verdict := "APPROVED"
-	if !resp.Approved {
-		verdict = "DENIED"
-	}
 	slog.Info("ai_evaluation: result",
-		"verdict", verdict,
+		"verdict", resp.Verdict,
 		"rule_id", rule.ID,
 		"server", serverName,
 		"tool", toolName,
@@ -342,10 +386,16 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 		"reason", resp.Reason,
 	)
 
-	if resp.Approved {
+	switch resp.Verdict {
+	case "approved":
 		return policy.Decision{Disposition: policy.DispositionAuto, Reason: "ai_evaluation approved: " + resp.Reason}
+	case "denied":
+		return policy.Decision{Disposition: policy.DispositionNever, Reason: "ai_evaluation denied: " + resp.Reason}
+	case "human_approval":
+		return policy.Decision{Disposition: dispositionAIEscalated, Reason: "ai_evaluation requires human approval: " + resp.Reason}
+	default: // "next_rule" or any unrecognised value
+		return policy.Decision{Disposition: dispositionContinue, Reason: "ai_evaluation deferred to next rule: " + resp.Reason}
 	}
-	return policy.Decision{Disposition: policy.DispositionNever, Reason: "ai_evaluation denied: " + resp.Reason}
 }
 
 // denyByPolicy hard-denies the call without execution.
@@ -422,7 +472,7 @@ func (s *Service) waitForHumanApproval(ctx context.Context, inv Invocation, upst
 			completed := time.Now().UTC()
 			inv.Status = StatusDenied
 			inv.CompletedAt = &completed
-			inv.Approval = &Approval{Status: "denied", Reason: stringPtr("human")}
+			inv.Approval = &Approval{Status: humanDecisionStatus(inv.Approval, false), Reason: stringPtr("human")}
 			msg := "Tool call denied by the MCP permissions system."
 			if d.message != "" {
 				msg += "\n\nReason: " + d.message
@@ -448,7 +498,7 @@ func (s *Service) waitForHumanApproval(ctx context.Context, inv Invocation, upst
 	}
 
 	inv.Status = StatusExecuting
-	inv.Approval = &Approval{Status: "approved", Reason: stringPtr("human")}
+	inv.Approval = &Approval{Status: humanDecisionStatus(inv.Approval, true), Reason: stringPtr("human")}
 	if err := s.invocations.UpdateResult(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
@@ -544,7 +594,7 @@ func (s *Service) recordExternalDecision(ctx context.Context, invocationID strin
 	now := time.Now().UTC()
 	if approved {
 		inv.Status = StatusApproved
-		inv.Approval = &Approval{Status: "approved", Reason: stringPtr("human")}
+		inv.Approval = &Approval{Status: humanDecisionStatus(inv.Approval, true), Reason: stringPtr("human")}
 		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
 			return err
 		}
@@ -553,7 +603,7 @@ func (s *Service) recordExternalDecision(ctx context.Context, invocationID strin
 	}
 	inv.Status = StatusDenied
 	inv.CompletedAt = &now
-	inv.Approval = &Approval{Status: "denied", Reason: stringPtr("human")}
+	inv.Approval = &Approval{Status: humanDecisionStatus(inv.Approval, false), Reason: stringPtr("human")}
 	msg := "Tool call denied by the MCP permissions system."
 	if message != "" {
 		msg += "\n\nReason: " + message
@@ -617,17 +667,29 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	if err := s.invocations.Create(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
-	var matchedRule *ApprovalRule
 	ruleAction := ""
+	var resolvedAIDecision *policy.Decision
 	if s.rules != nil {
 		if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
 			user := agentID
 			if user == "" && req.RequestID != nil {
 				user = *req.RequestID
 			}
-			matchedRule = matchRule(approvalRules, source, req.Tool, user, agentRec.ID)
-			if matchedRule != nil {
-				ruleAction = matchedRule.Action
+			for _, rule := range matchRules(approvalRules, source, req.Tool, user, agentRec.ID) {
+				r := rule
+				if r.Action == RuleActionAIEvaluation {
+					d := s.runAIEvaluation(ctx, &r, source, req.Tool, req.Input, agentID)
+					if d.Disposition == dispositionContinue {
+						slog.Info("ai_evaluation: LLM deferred to next rule; continuing rule iteration",
+							"rule_id", r.ID, "server", source, "tool", req.Tool)
+						continue
+					}
+					ruleAction = r.Action
+					resolvedAIDecision = &d
+					break
+				}
+				ruleAction = r.Action
+				break
 			}
 		}
 	}
@@ -668,7 +730,14 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 		return s.toResponse(inv), nil
 
 	case RuleActionAIEvaluation:
-		aiDecision := s.runAIEvaluation(ctx, matchedRule, source, req.Tool, req.Input, agentID)
+		// resolvedAIDecision is always populated when ruleAction == RuleActionAIEvaluation
+		// because runAIEvaluation is called during rule iteration above (never twice).
+		var aiDecision policy.Decision
+		if resolvedAIDecision != nil {
+			aiDecision = *resolvedAIDecision
+		} else {
+			aiDecision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: decision unavailable; falling back to human_approval"}
+		}
 		if aiDecision.Disposition == policy.DispositionAuto {
 			inv.Status = StatusApproved
 			inv.Approval = &Approval{Status: "auto_approved", Reason: stringPtr(aiDecision.Reason)}
@@ -688,7 +757,12 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 			_ = s.events.Create(context.Background(), Event{InvocationID: inv.InvocationID, EventType: "invocation.denied", Payload: mustJSON(map[string]any{"reason": aiDecision.Reason, "disposition": "never"}), CreatedAt: completed})
 			return s.toResponse(inv), nil
 		}
-		// Fall through to human approval on fallback.
+		// Tag AI-escalated invocations before falling through to human approval so the
+		// UI can distinguish them from direct human_approval rules.
+		if aiDecision.Disposition == dispositionAIEscalated {
+			inv.Approval = &Approval{Status: "ai_escalated", Reason: stringPtr(aiDecision.Reason)}
+		}
+		// Fall through to human approval for human_approval verdict or unexpected fallback.
 	}
 
 	// Default: human approval required.


### PR DESCRIPTION
## What and why?

Extends the LLM-as-judge (`ai_evaluation` rule action) from a binary approve/deny to a four-way verdict system:

- **`approved`** — auto-execute (existing)
- **`denied`** — hard deny (existing)
- **`human_approval`** *(new)* — LLM deliberately routes the invocation to the human approval queue
- **`next_rule`** *(new)* — LLM defers to the next matching approval rule in priority order

**Before:** The judge could only approve or deny. "Human Approval" only happened on LLM error/fallback.
**After:** The judge can intentionally escalate to a human or pass to the next rule, driven by conditions authored in the agent's constitution.

Key changes:
- `EvaluateResponse`: `Approved bool` → `Verdict string`
- `matchRule` → `matchRules`: returns all matching rules in order; `Invoke`/`Submit` iterate and stop at the first final verdict
- `runAIEvaluation`: switches on `resp.Verdict`; introduces `dispositionAIEscalated` and `dispositionContinue` internal sentinels
- AI-escalated invocations tagged `approval.status = "ai_escalated"` (pending) → `"ai_escalated_approved/denied"` after human decides
- Constitution template: adds `### Human approval required when` and `### Defer to next rule when` authoring sections

## How to test

1. Author a constitution with a `### Human approval required when` condition (e.g. "write operations require human approval")
2. Set up an `ai_evaluation` approval rule pointing at that agent
3. Trigger a tool call matching the condition → invocation should enter the human approval queue with `approval.status = "ai_escalated"`
4. Approve/deny it → `approval.status` should become `"ai_escalated_approved"` / `"ai_escalated_denied"`
5. For `next_rule`: add a `### Defer to next rule when` condition and stack two `ai_evaluation` rules; first should defer, second should decide

Requires backend PR [SC-16466] to be deployed for the 4-way verdict response shape.

## What needs special review?

- `humanDecisionStatus` helper: ensures `ai_escalated` origin is preserved through the human approve/deny write paths
- `dispositionContinue` and `dispositionAIEscalated` are internal sentinels — they must never reach `invocation.received` event payloads as final dispositions

## Dependencies, breaking changes, and deployment notes

**Breaking change on the `/internal/v1/atryum/evaluate` contract** — response shape changes from `{approved: bool}` to `{verdict: str}`. Backend and Atryum must be deployed together.

Depends on: backend PR [SC-16466]

## Release notes

The LLM-as-judge can now deliberately escalate invocations to human review or defer to the next approval rule, based on conditions authored in the agent's constitution. Previously the judge could only approve or deny automatically.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

Made with [Cursor](https://cursor.com)