### PR TITLE
Reuse recent explicit approvals for duplicate requests

### DIFF
--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -31,6 +31,7 @@ connection_timeout_seconds = 5
 
 [defaults]
 request_timeout_seconds = 30
+approval_reuse_window_seconds = 10
 
 # Agent sync and AI evaluation settings (org, record type, constitution field)
 # are managed through the Atryum Settings UI and stored in the database.

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -34,6 +34,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("load config: %v", err)
 	}
+	if cfg.Defaults.ApprovalReuseWindowSeconds <= 0 {
+		log.Printf("WARNING: defaults.approval_reuse_window_seconds must be greater than 0; got %d, using the default approval reuse window", cfg.Defaults.ApprovalReuseWindowSeconds)
+	}
 	backendClient, err := backendclient.NewClient(cfg.Backend)
 	if err != nil {
 		log.Fatalf("backend config: %v", err)

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -144,7 +144,7 @@ func main() {
 		invEvaluator = &evaluatorAdapter{client: backendClient}
 	}
 
-	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, rulesRepo, invAgents, invEvaluator, &syncSettingsAdapter{repo: agentSyncSettingsRepo})
+	service := invocation.NewService(invRepo, eventRepo, resolver, client, policyRegistry, time.Duration(cfg.Defaults.RequestTimeoutSeconds)*time.Second, time.Duration(cfg.Defaults.ApprovalReuseWindowSeconds)*time.Second, rulesRepo, invAgents, invEvaluator, &syncSettingsAdapter{repo: agentSyncSettingsRepo})
 	if backendClient != nil {
 		service.SetInvocationSummarizer(&summaryAdapter{client: backendClient})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,8 @@ type ServerConfig struct {
 }
 
 type DefaultsConfig struct {
-	RequestTimeoutSeconds int `toml:"request_timeout_seconds"`
+	RequestTimeoutSeconds      int `toml:"request_timeout_seconds"`
+	ApprovalReuseWindowSeconds int `toml:"approval_reuse_window_seconds"`
 }
 
 type UpstreamConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,7 +96,8 @@ func Load(path string) (Config, error) {
 			ConnectionTimeoutSecs: 5,
 		},
 		Defaults: DefaultsConfig{
-			RequestTimeoutSeconds: 30,
+			RequestTimeoutSeconds:      30,
+			ApprovalReuseWindowSeconds: 10,
 		},
 	}
 	_, err := toml.DecodeFile(path, &cfg)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,4 +47,7 @@ connection_timeout_seconds = 7
 	if cfg.Backend.ConnectionTimeoutSecs != 7 {
 		t.Fatalf("Backend.ConnectionTimeoutSecs = %d", cfg.Backend.ConnectionTimeoutSecs)
 	}
+	if cfg.Defaults.ApprovalReuseWindowSeconds != 10 {
+		t.Fatalf("Defaults.ApprovalReuseWindowSeconds = %d", cfg.Defaults.ApprovalReuseWindowSeconds)
+	}
 }

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -117,7 +117,7 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	}
 }
 
-func TestInvokeReusesRecentExplicitExternalApprovalForSameAgentServerAndTool(t *testing.T) {
+func TestInvokeReusesRecentExplicitExternalApprovalForSameAgentServerToolAndArguments(t *testing.T) {
 	var upstreamCalls int
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		upstreamCalls++
@@ -163,9 +163,12 @@ func TestInvokeReusesRecentExplicitExternalApprovalForSameAgentServerAndTool(t *
 	if _, err := svc.RecordExecution(context.Background(), submitted.InvocationID, invocation.ExternalExecutionUpdate{ExecutionStatus: "running"}); err != nil {
 		t.Fatalf("RecordExecution running: %v", err)
 	}
+	if _, err := svc.RecordExecution(context.Background(), submitted.InvocationID, invocation.ExternalExecutionUpdate{ExecutionStatus: "completed", Result: json.RawMessage(`{"ok":true}`)}); err != nil {
+		t.Fatalf("RecordExecution completed: %v", err)
+	}
 
 	reused, err := svc.Invoke(ctx, invocation.CreateInvocationRequest{
-		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 2},
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 1},
 	})
 	if err != nil {
 		t.Fatalf("Invoke with reusable approval: %v", err)
@@ -180,9 +183,19 @@ func TestInvokeReusesRecentExplicitExternalApprovalForSameAgentServerAndTool(t *
 		t.Fatal("expected MCP upstream to be invoked")
 	}
 
+	changedArgs, err := svc.Invoke(ctx, invocation.CreateInvocationRequest{
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 2},
+	})
+	if err != nil {
+		t.Fatalf("Invoke with changed args: %v", err)
+	}
+	if changedArgs.Status != invocation.StatusDenied {
+		t.Fatalf("expected changed args to follow deny policy, got %s", changedArgs.Status)
+	}
+
 	otherCtx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-008", Issuer: "https://idp.test"})
 	denied, err := svc.Invoke(otherCtx, invocation.CreateInvocationRequest{
-		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 3},
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 1},
 	})
 	if err != nil {
 		t.Fatalf("Invoke with other agent: %v", err)

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -65,7 +65,7 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	svc := invocation.NewService(
 		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
 		mcp.NewHTTPClient(), policy.AlwaysDenyProvider{}, // would deny if the rule didn't match
-		5*time.Second, rules, nil, nil, nil,
+		5*time.Second, 0, rules, nil, nil, nil,
 	)
 
 	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-007", Issuer: "https://idp.test"})
@@ -117,6 +117,81 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	}
 }
 
+func TestInvokeReusesRecentExplicitExternalApprovalForSameAgentServerAndTool(t *testing.T) {
+	var upstreamCalls int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+	}))
+	defer upstream.Close()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Config{
+		Defaults:  config.DefaultsConfig{RequestTimeoutSeconds: 5},
+		Upstreams: []config.UpstreamConfig{{Name: "demo", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+	}
+	resolver := mcp.NewResolver(store.NewServerRepo(db), cfg)
+	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	svc := invocation.NewService(
+		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
+		mcp.NewHTTPClient(), policy.AlwaysDenyProvider{},
+		5*time.Second, 0, nil, nil, nil, nil,
+	)
+
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-007", Issuer: "https://idp.test"})
+	submitted, err := svc.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source: "demo", Tool: "demo_tool", Input: map[string]any{"x": 1},
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if submitted.Status != invocation.StatusPendingApproval {
+		t.Fatalf("expected external submit to require approval, got %s", submitted.Status)
+	}
+	if err := svc.Approve(context.Background(), submitted.InvocationID); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if _, err := svc.RecordExecution(context.Background(), submitted.InvocationID, invocation.ExternalExecutionUpdate{ExecutionStatus: "running"}); err != nil {
+		t.Fatalf("RecordExecution running: %v", err)
+	}
+
+	reused, err := svc.Invoke(ctx, invocation.CreateInvocationRequest{
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 2},
+	})
+	if err != nil {
+		t.Fatalf("Invoke with reusable approval: %v", err)
+	}
+	if reused.Status != invocation.StatusSucceeded {
+		t.Fatalf("expected reused approval to execute despite deny policy, got %s", reused.Status)
+	}
+	if reused.Approval == nil || reused.Approval.Status != "auto_approved" || !strings.Contains(deref(reused.Approval.Reason), submitted.InvocationID) {
+		t.Fatalf("expected reused approval reason to reference %s, got %#v", submitted.InvocationID, reused.Approval)
+	}
+	if upstreamCalls == 0 {
+		t.Fatal("expected MCP upstream to be invoked")
+	}
+
+	otherCtx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-008", Issuer: "https://idp.test"})
+	denied, err := svc.Invoke(otherCtx, invocation.CreateInvocationRequest{
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 3},
+	})
+	if err != nil {
+		t.Fatalf("Invoke with other agent: %v", err)
+	}
+	if denied.Status != invocation.StatusDenied {
+		t.Fatalf("expected other agent to follow deny policy, got %s", denied.Status)
+	}
+}
+
 func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
@@ -148,7 +223,7 @@ func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 	svc := invocation.NewService(
 		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
 		mcp.NewHTTPClient(), policy.AlwaysDenyProvider{},
-		5*time.Second, rules, nil, nil, nil,
+		5*time.Second, 0, rules, nil, nil, nil,
 	)
 
 	rid := "legacy-request-id"
@@ -161,6 +236,13 @@ func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 	if resp.Status != invocation.StatusSucceeded {
 		t.Fatalf("expected succeeded via request_id fallback, got %s", resp.Status)
 	}
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 func eventsAsJSON(items []invocation.EventResponse) string {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -137,7 +137,7 @@ type invocationRepo interface {
 	UpdateSummary(ctx context.Context, id string, summary string) error
 	Get(ctx context.Context, id string) (Invocation, error)
 	GetByIdempotencyKey(ctx context.Context, key string) (Invocation, error)
-	FindRecentExplicitApproval(ctx context.Context, agentID string, upstream string, tool string, since time.Time) (Invocation, error)
+	FindRecentExplicitApproval(ctx context.Context, agentID string, upstream string, tool string, input []byte, since time.Time) (Invocation, error)
 	List(ctx context.Context, filter InvocationListFilter) ([]Invocation, int, error)
 	ListAgentIDs(ctx context.Context) ([]string, error)
 }
@@ -262,7 +262,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		return InvocationResponse{}, err
 	}
 	if agentID != "" {
-		if approved, err := s.invocations.FindRecentExplicitApproval(ctx, agentID, upstream.Name, req.Tool, now.Add(-s.approvalReuseWindow)); err == nil {
+		if approved, err := s.invocations.FindRecentExplicitApproval(ctx, agentID, upstream.Name, req.Tool, inv.Input, now.Add(-s.approvalReuseWindow)); err == nil {
 			reason := "reused explicit approval from " + approved.InvocationID
 			_ = s.events.Create(ctx, Event{
 				InvocationID: inv.InvocationID,
@@ -280,7 +280,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 				}),
 				CreatedAt: now,
 			})
-			return s.executeNow(ctx, inv, upstream, req, reason)
+			return s.executeNow(ctx, inv, upstream, req, reason, nil)
 		} else if err != sql.ErrNoRows {
 			slog.Warn("could not check for reusable prior approval; continuing normal policy evaluation",
 				"agent_id", agentID, "server", upstream.Name, "tool", req.Tool, "error", err)

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -30,6 +30,8 @@ const dispositionContinue policy.Disposition = "continue"
 // direct human_approval rule or an error fallback.
 const dispositionAIEscalated policy.Disposition = "ai_escalated"
 
+const defaultApprovalReuseWindow = 10 * time.Second
+
 // humanDecisionStatus returns the approval status string to write when a human
 // approves or denies an invocation. If the invocation was AI-escalated the composite
 // statuses ("ai_escalated_approved" / "ai_escalated_denied") preserve the origin so
@@ -135,6 +137,7 @@ type invocationRepo interface {
 	UpdateSummary(ctx context.Context, id string, summary string) error
 	Get(ctx context.Context, id string) (Invocation, error)
 	GetByIdempotencyKey(ctx context.Context, key string) (Invocation, error)
+	FindRecentExplicitApproval(ctx context.Context, agentID string, upstream string, tool string, since time.Time) (Invocation, error)
 	List(ctx context.Context, filter InvocationListFilter) ([]Invocation, int, error)
 	ListAgentIDs(ctx context.Context) ([]string, error)
 }
@@ -156,19 +159,20 @@ type upstreamClient interface {
 }
 
 type Service struct {
-	invocations      invocationRepo
-	events           eventRepo
-	resolver         resolver
-	client           upstreamClient
-	policy           policy.Provider
-	rules            rulesStore // nil = no rule evaluation
-	agents           AgentLookup
-	evaluator        EvaluatorClient
-	summarizer       SummaryClient
-	syncSettings     SyncSettingsProvider // nil = no constitution lookup
-	defaultTimeout   time.Duration
-	mu               sync.Mutex
-	pendingApprovals map[string]chan approvalDecision
+	invocations         invocationRepo
+	events              eventRepo
+	resolver            resolver
+	client              upstreamClient
+	policy              policy.Provider
+	rules               rulesStore // nil = no rule evaluation
+	agents              AgentLookup
+	evaluator           EvaluatorClient
+	summarizer          SummaryClient
+	syncSettings        SyncSettingsProvider // nil = no constitution lookup
+	defaultTimeout      time.Duration
+	approvalReuseWindow time.Duration
+	mu                  sync.Mutex
+	pendingApprovals    map[string]chan approvalDecision
 }
 
 func NewService(
@@ -178,23 +182,28 @@ func NewService(
 	client upstreamClient,
 	policyProvider policy.Provider,
 	defaultTimeout time.Duration,
+	approvalReuseWindow time.Duration,
 	rules rulesStore,
 	agents AgentLookup,
 	evaluator EvaluatorClient,
 	syncSettings SyncSettingsProvider,
 ) *Service {
+	if approvalReuseWindow <= 0 {
+		approvalReuseWindow = defaultApprovalReuseWindow
+	}
 	return &Service{
-		invocations:      inv,
-		events:           evt,
-		resolver:         resolver,
-		client:           client,
-		policy:           policyProvider,
-		rules:            rules,
-		agents:           agents,
-		evaluator:        evaluator,
-		syncSettings:     syncSettings,
-		defaultTimeout:   defaultTimeout,
-		pendingApprovals: make(map[string]chan approvalDecision),
+		invocations:         inv,
+		events:              evt,
+		resolver:            resolver,
+		client:              client,
+		policy:              policyProvider,
+		rules:               rules,
+		agents:              agents,
+		evaluator:           evaluator,
+		syncSettings:        syncSettings,
+		defaultTimeout:      defaultTimeout,
+		approvalReuseWindow: approvalReuseWindow,
+		pendingApprovals:    make(map[string]chan approvalDecision),
 	}
 }
 
@@ -251,6 +260,31 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 	}
 	if err := s.invocations.Create(ctx, inv); err != nil {
 		return InvocationResponse{}, err
+	}
+	if agentID != "" {
+		if approved, err := s.invocations.FindRecentExplicitApproval(ctx, agentID, upstream.Name, req.Tool, now.Add(-s.approvalReuseWindow)); err == nil {
+			reason := "reused explicit approval from " + approved.InvocationID
+			_ = s.events.Create(ctx, Event{
+				InvocationID: inv.InvocationID,
+				EventType:    "invocation.received",
+				Payload: mustJSON(map[string]any{
+					"tool":               req.Tool,
+					"upstream":           upstream.Name,
+					"request_id":         req.RequestID,
+					"input":              json.RawMessage(inv.Input),
+					"arguments":          json.RawMessage(inv.Input),
+					"agent_id":           agentID,
+					"disposition":        string(policy.DispositionAuto),
+					"disposition_reason": reason,
+					"reused_approval_id": approved.InvocationID,
+				}),
+				CreatedAt: now,
+			})
+			return s.executeNow(ctx, inv, upstream, req, reason)
+		} else if err != sql.ErrNoRows {
+			slog.Warn("could not check for reusable prior approval; continuing normal policy evaluation",
+				"agent_id", agentID, "server", upstream.Name, "tool", req.Tool, "error", err)
+		}
 	}
 
 	// Determine disposition: check rules first (fine-grained), then fall back to policy (global).

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -204,7 +204,7 @@ func TestSetSummaryPersistsSummaryAndRecordsEvent(t *testing.T) {
 	}
 	invRepo := store.NewInvocationRepo(db)
 	eventRepo := store.NewEventRepo(db)
-	service := invocation.NewService(invRepo, eventRepo, nil, nil, policy.AlwaysApproveProvider{}, 5*time.Second, nil, nil, nil, nil)
+	service := invocation.NewService(invRepo, eventRepo, nil, nil, policy.AlwaysApproveProvider{}, 5*time.Second, 0, nil, nil, nil, nil)
 	now := time.Now().UTC()
 	inv := invocation.Invocation{
 		InvocationID: "inv-summary",
@@ -260,7 +260,7 @@ func TestSubmitPendingApprovalAutomaticallySummarizesInvocation(t *testing.T) {
 	}
 	invRepo := store.NewInvocationRepo(db)
 	eventRepo := store.NewEventRepo(db)
-	service := invocation.NewService(invRepo, eventRepo, nil, nil, nil, 5*time.Second, nil, nil, nil, summarySettingsStub{
+	service := invocation.NewService(invRepo, eventRepo, nil, nil, nil, 5*time.Second, 0, nil, nil, nil, summarySettingsStub{
 		orgCUID:         " org_123 ",
 		modelConfigCUID: " model_123 ",
 	})

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -325,7 +325,7 @@ func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	return invocation.NewService(store.NewInvocationRepo(db), store.NewEventRepo(db), resolver, mcp.NewHTTPClient(), policy.AlwaysApproveProvider{}, 5*time.Second, nil, nil, nil, nil)
+	return invocation.NewService(store.NewInvocationRepo(db), store.NewEventRepo(db), resolver, mcp.NewHTTPClient(), policy.AlwaysApproveProvider{}, 5*time.Second, 0, nil, nil, nil, nil)
 }
 
 type summaryClientStub struct {

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -123,6 +123,32 @@ func TestStatementBuilderForDialectUsesDialectPlaceholders(t *testing.T) {
 	}
 }
 
+func TestExplicitApprovalStatusPredicateUsesDialectSQL(t *testing.T) {
+	sqliteSQL, _, err := statementBuilderForDialect(DialectSQLite).
+		Select("*").
+		From("invocations").
+		Where(explicitApprovalStatusPredicate(DialectSQLite)).
+		ToSql()
+	if err != nil {
+		t.Fatalf("sqlite ToSql: %v", err)
+	}
+	if !contains(sqliteSQL, "json_extract(approval_json, '$.status')") {
+		t.Fatalf("sqlite SQL should use json_extract, got %s", sqliteSQL)
+	}
+
+	postgresSQL, _, err := statementBuilderForDialect(DialectPostgres).
+		Select("*").
+		From("invocations").
+		Where(explicitApprovalStatusPredicate(DialectPostgres)).
+		ToSql()
+	if err != nil {
+		t.Fatalf("postgres ToSql: %v", err)
+	}
+	if !contains(postgresSQL, "approval_json::jsonb ->> 'status'") || contains(postgresSQL, "json_extract") {
+		t.Fatalf("postgres SQL should use jsonb extraction only, got %s", postgresSQL)
+	}
+}
+
 func contains(s, substr string) bool {
 	for i := 0; i+len(substr) <= len(s); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -14,8 +14,9 @@ import (
 )
 
 type InvocationRepo struct {
-	db *sql.DB
-	sb sq.StatementBuilderType
+	db      *sql.DB
+	sb      sq.StatementBuilderType
+	dialect Dialect
 }
 type EventRepo struct {
 	db *sql.DB
@@ -60,7 +61,7 @@ func NewServerRepo(db *sql.DB) *ServerRepo { return NewServerRepoWithDialect(db,
 func NewOAuthRepo(db *sql.DB) *OAuthRepo   { return NewOAuthRepoWithDialect(db, DialectSQLite) }
 
 func NewInvocationRepoWithDialect(db *sql.DB, dialect Dialect) *InvocationRepo {
-	return &InvocationRepo{db: db, sb: statementBuilderForDialect(dialect)}
+	return &InvocationRepo{db: db, sb: statementBuilderForDialect(dialect), dialect: dialect}
 }
 func NewEventRepoWithDialect(db *sql.DB, dialect Dialect) *EventRepo {
 	return &EventRepo{db: db, sb: statementBuilderForDialect(dialect)}
@@ -138,6 +139,33 @@ func (r *InvocationRepo) GetByIdempotencyKey(ctx context.Context, key string) (i
 	}
 	row := r.db.QueryRowContext(ctx, query, args...)
 	return scanInvocation(row)
+}
+
+func (r *InvocationRepo) FindRecentExplicitApproval(ctx context.Context, agentID string, upstream string, tool string, since time.Time) (invocation.Invocation, error) {
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").
+		From("invocations").
+		Where(sq.Eq{
+			"agent_id":      agentID,
+			"upstream_name": upstream,
+			"tool_name":     tool,
+			"status":        []invocation.Status{invocation.StatusApproved, invocation.StatusExecuting},
+		}).
+		Where(sq.GtOrEq{"submitted_at": since}).
+		Where(explicitApprovalStatusPredicate(r.dialect)).
+		OrderBy("submitted_at DESC").
+		Limit(1).
+		ToSql()
+	if err != nil {
+		return invocation.Invocation{}, err
+	}
+	return scanInvocation(r.db.QueryRowContext(ctx, query, args...))
+}
+
+func explicitApprovalStatusPredicate(dialect Dialect) sq.Sqlizer {
+	if dialect == DialectPostgres {
+		return sq.Expr("(approval_json::jsonb ->> 'status') IN ('approved', 'ai_escalated_approved')")
+	}
+	return sq.Expr("json_extract(approval_json, '$.status') IN ('approved', 'ai_escalated_approved')")
 }
 
 func (r *InvocationRepo) List(ctx context.Context, filter invocation.InvocationListFilter) ([]invocation.Invocation, int, error) {
@@ -256,28 +284,28 @@ func (r *ServerRepo) UpsertServer(ctx context.Context, upstream mcp.Upstream) er
 	now := time.Now().UTC()
 
 	updateMap := map[string]interface{}{
-		"mode":                 string(upstream.Mode),
-		"base_url":             emptyToNil(upstream.BaseURL),
-		"auth_token":           emptyToNil(upstream.AuthToken),
-		"timeout_seconds":      int(upstream.Timeout / time.Second),
-		"command":              emptyToNil(upstream.Command),
-		"args_json":            argsJSON,
-		"env_json":             envJSON,
-		"enabled":              boolToInt(upstream.Enabled),
-		"auth_type":            string(upstream.Status.AuthType),
-		"connection_status":    string(upstream.Status.ConnectionStatus),
-		"auth_status":          string(upstream.Status.AuthStatus),
-		"reauth_needed":        boolToInt(upstream.Status.ReauthNeeded),
-		"last_checked_at":      upstream.Status.LastCheckedAt,
-		"last_check_ok":        boolToInt(upstream.Status.LastCheckOK),
-		"last_error_summary":   emptyToNil(derefString(upstream.Status.LastErrorSummary)),
-		"action_required":      emptyToNil(derefString(upstream.Status.ActionRequired)),
-		"oauth_provider_id":    emptyToNil(upstream.OAuthProviderID),
-		"oauth_provider_label": emptyToNil(upstream.OAuthProviderLabel),
-		"oauth_authorize_url":  emptyToNil(upstream.OAuthAuthorizeURL),
-		"oauth_token_url":      emptyToNil(upstream.OAuthTokenURL),
-		"oauth_client_id":      emptyToNil(upstream.OAuthClientID),
-		"oauth_client_secret":  emptyToNil(upstream.OAuthClientSecret),
+		"mode":                      string(upstream.Mode),
+		"base_url":                  emptyToNil(upstream.BaseURL),
+		"auth_token":                emptyToNil(upstream.AuthToken),
+		"timeout_seconds":           int(upstream.Timeout / time.Second),
+		"command":                   emptyToNil(upstream.Command),
+		"args_json":                 argsJSON,
+		"env_json":                  envJSON,
+		"enabled":                   boolToInt(upstream.Enabled),
+		"auth_type":                 string(upstream.Status.AuthType),
+		"connection_status":         string(upstream.Status.ConnectionStatus),
+		"auth_status":               string(upstream.Status.AuthStatus),
+		"reauth_needed":             boolToInt(upstream.Status.ReauthNeeded),
+		"last_checked_at":           upstream.Status.LastCheckedAt,
+		"last_check_ok":             boolToInt(upstream.Status.LastCheckOK),
+		"last_error_summary":        emptyToNil(derefString(upstream.Status.LastErrorSummary)),
+		"action_required":           emptyToNil(derefString(upstream.Status.ActionRequired)),
+		"oauth_provider_id":         emptyToNil(upstream.OAuthProviderID),
+		"oauth_provider_label":      emptyToNil(upstream.OAuthProviderLabel),
+		"oauth_authorize_url":       emptyToNil(upstream.OAuthAuthorizeURL),
+		"oauth_token_url":           emptyToNil(upstream.OAuthTokenURL),
+		"oauth_client_id":           emptyToNil(upstream.OAuthClientID),
+		"oauth_client_secret":       emptyToNil(upstream.OAuthClientSecret),
 		"oauth_scopes":              emptyToNil(upstream.OAuthScopes),
 		"oauth_client_registration": emptyToNil(string(upstream.OAuthClientRegistration)),
 		"updated_at":                now,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -141,14 +141,15 @@ func (r *InvocationRepo) GetByIdempotencyKey(ctx context.Context, key string) (i
 	return scanInvocation(row)
 }
 
-func (r *InvocationRepo) FindRecentExplicitApproval(ctx context.Context, agentID string, upstream string, tool string, since time.Time) (invocation.Invocation, error) {
-	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id").
+func (r *InvocationRepo) FindRecentExplicitApproval(ctx context.Context, agentID string, upstream string, tool string, input []byte, since time.Time) (invocation.Invocation, error) {
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary").
 		From("invocations").
 		Where(sq.Eq{
 			"agent_id":      agentID,
 			"upstream_name": upstream,
 			"tool_name":     tool,
-			"status":        []invocation.Status{invocation.StatusApproved, invocation.StatusExecuting},
+			"request_json":  string(input),
+			"status":        []invocation.Status{invocation.StatusApproved, invocation.StatusExecuting, invocation.StatusSucceeded},
 		}).
 		Where(sq.GtOrEq{"submitted_at": since}).
 		Where(explicitApprovalStatusPredicate(r.dialect)).


### PR DESCRIPTION
## Summary
- add an approval reuse window for authenticated agents so duplicate tool calls can proceed without a second manual approval
- limit reuse to explicit human approvals for the same agent, server/source, tool, and serialized request arguments
- include recently succeeded invocations in the reusable approval lookup, in addition to approved/executing invocations
- add SQLite/Postgres predicate coverage and invocation tests for same-args reuse, changed-args rejection, and cross-agent isolation

## Testing
- go test ./internal/invocation ./internal/store ./cmd/atryum


I manually tested this by setting all rules to human approve.

Then i ran the curl twice. The first time I required human approval. The second time it automatically approved via rule.
```
curl -sS localhost:8080/mcp/shortcut \
    -H "Authorization: Bearer $TOKEN" \
    -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"teams-list","arguments":{"x":1}}}'
```

Changing the arguments led to human approval and not another auto approval so atryum does check the tool call. 