### PR TITLE
[SC-16374] Fail closed when AI evaluation lacks agent context

### DIFF
--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -377,18 +377,37 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 	agentVMCUID := ""
 	orgCUID := ""
 	if s.agents != nil && agentID != "" {
-		if rec, err := s.agents.GetByAgentID(ctx, agentID); err == nil {
-			agentVMCUID = rec.VMCUID
-			orgCUID = rec.VMOrganizationCUID
-		} else {
-			slog.Warn("ai_evaluation: could not resolve agent VM CUID; proceeding without constitution",
-				"agent_id", agentID, "error", err)
+		rec, err := s.agents.GetByAgentID(ctx, agentID)
+		if err != nil {
+			slog.Error("ai_evaluation: could not resolve agent record; denying tool call",
+				"rule_id", rule.ID, "agent_id", agentID, "tool", toolName, "error", err)
+			return policy.Decision{
+				Disposition: policy.DispositionNever,
+				Reason:      "ai_evaluation denied: no agent identity (could not resolve agent record)",
+			}, nil
 		}
+		agentVMCUID = rec.VMCUID
+		orgCUID = rec.VMOrganizationCUID
 	}
 
 	constitutionFieldKey := ""
 	if s.syncSettings != nil {
 		constitutionFieldKey = s.syncSettings.ConstitutionFieldKey(ctx)
+	}
+
+	if agentVMCUID == "" || constitutionFieldKey == "" {
+		slog.Error("ai_evaluation: missing agent or constitution context; denying tool call",
+			"rule_id", rule.ID,
+			"server", serverName,
+			"tool", toolName,
+			"agent_id", agentID,
+			"agent_vm_cuid", agentVMCUID,
+			"constitution_field_key", constitutionFieldKey,
+		)
+		return policy.Decision{
+			Disposition: policy.DispositionNever,
+			Reason:      "ai_evaluation denied: no constitution available for this agent",
+		}, nil
 	}
 
 	slog.Info("ai_evaluation: calling LLM",


### PR DESCRIPTION
## Summary

Fixes a governance regression where AI evaluation rules silently approved tool calls when agent identity or constitution context was missing. The LLM was invoked with an empty policy and defaulted to approve.

Part of [SC-16374](https://app.shortcut.com/validmind/story/16374).

## What changed

In `runAIEvaluation`, deny outright (`DispositionNever`) instead of calling `/evaluate` when:
- Agent record lookup fails
- `agent_vm_cuid` is empty (unauthenticated / unassociated agent)
- `constitution_field_key` is unset

## How to test

1. Configure an `ai_evaluation` rule that applies to all agents.
2. Invoke a tool without a resolvable agent identity (no bearer / unknown `azp`).
3. Confirm the invocation is **denied**, not auto-approved.
4. Confirm Atryum logs show `ai_evaluation: missing agent or constitution context; denying tool call`.

## Dependencies

- Companion backend PR for defense-in-depth on `/evaluate`.

## Release notes

AI evaluation now denies tool calls when the agent's constitution cannot be resolved, instead of silently approving them.

Made with [Cursor](https://cursor.com)