### PR TITLE
[SC-16270] Surface MCP client identity on invocations

### DIFF
--- a/examples/amp-plugin/atryum.ts
+++ b/examples/amp-plugin/atryum.ts
@@ -19,6 +19,13 @@ const SOURCE = process.env.ATRYUM_SOURCE || "amp";
 const POLL_INTERVAL = Number(process.env.ATRYUM_POLL_MS || 2000);
 // Amp exposes the current thread ID as $THREAD_ID in the plugin process env.
 const THREAD_ID = process.env.THREAD_ID || "";
+// Harness identity for the Atryum invocations UI Agent column. Falls back
+// to SOURCE for the name. ATRYUM_CLIENT_VERSION / AMP_VERSION are checked
+// in case a deployment plumbs the build version through the env; safe to
+// leave empty.
+const CLIENT_NAME = process.env.ATRYUM_CLIENT_NAME || SOURCE;
+const CLIENT_VERSION =
+  process.env.ATRYUM_CLIENT_VERSION || process.env.AMP_VERSION || "";
 
 type InvocationStatus =
   | "received"
@@ -65,6 +72,8 @@ async function submit(
       input,
       request_id: toolUseID,
       thread_id: THREAD_ID || undefined,
+      client_name: CLIENT_NAME,
+      client_version: CLIENT_VERSION || undefined,
     }),
   });
   if (!res.ok) {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"atryum/internal/auth"
@@ -89,6 +90,13 @@ type agentSyncSettingsRepo interface {
 	Save(ctx context.Context, s store.AgentSyncSettings) error
 }
 
+// clientInfoSnapshot is what the agent reported in `initialize.clientInfo`.
+type clientInfoSnapshot struct {
+	Name    string
+	Version string
+	At      time.Time
+}
+
 type Handler struct {
 	svc                   service
 	serverSvc             serverService
@@ -105,6 +113,14 @@ type Handler struct {
 	authDebugSkip         bool
 	authValidator         *auth.Validator
 	apiKeyAuth            auth.APIKeyConfig
+
+	// clientInfoCache remembers the most recent `initialize.clientInfo`
+	// per MCP session key so that subsequent tools/call requests on the
+	// same session can attach client_name / client_version. The key is the
+	// `Mcp-Session-Id` header (per MCP streamable HTTP transport); when
+	// absent we fall back to remote IP + User-Agent.
+	clientInfoMu    sync.RWMutex
+	clientInfoCache map[string]clientInfoSnapshot
 }
 
 type PolicyStatusResponse struct {
@@ -371,7 +387,7 @@ func NewHandler(svc service, serverSvc serverService, policyRegistry *policy.Reg
 	if f, ok := svc.(mcpEnvelopeForwarder); ok {
 		forwarder = f
 	}
-	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, agentsRepo: agents, agentSyncSettingsRepo: agentSyncSettings, backendClient: bc, summarizeClient: bc, syncAgentsFn: syncAgents, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug}
+	return &Handler{svc: svc, serverSvc: serverSvc, policyRegistry: policyRegistry, rulesRepo: rules, agentsRepo: agents, agentSyncSettingsRepo: agentSyncSettings, backendClient: bc, summarizeClient: bc, syncAgentsFn: syncAgents, forwarder: forwarder, staticHTTP: http.FileServer(http.FS(staticSub)), debug: debug, clientInfoCache: make(map[string]clientInfoSnapshot)}
 }
 
 // SetAuthValidator installs the inbound auth validator. When non-nil, the
@@ -673,6 +689,7 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 
 	switch req.Method {
 	case "initialize":
+		h.recordInitializeClientInfo(r, req.Params)
 		result := map[string]any{
 			"protocolVersion": protocolVersion,
 			"serverInfo": map[string]any{
@@ -734,6 +751,13 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 		toolReq := invocation.CreateInvocationRequest{Server: callServer, Tool: params.Name, Input: params.Arguments}
 		if requestID != "" {
 			toolReq.RequestID = stringPtr(requestID)
+		}
+		// Carry forward the harness-reported clientInfo captured at
+		// `initialize` time on this same session. Lets the invocations UI
+		// show Agent context even when /mcp/ is anonymous (no [[auth]]).
+		if snap, ok := h.lookupClientInfo(r); ok {
+			toolReq.ClientName = snap.Name
+			toolReq.ClientVersion = snap.Version
 		}
 		resp, err := h.svc.Invoke(r.Context(), toolReq)
 		if err != nil {
@@ -1073,11 +1097,12 @@ func (h *Handler) adminInvocations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	filter := invocation.InvocationListFilter{
-		Offset: readUintQuery(r, "offset", 0),
-		Limit:  readUintQuery(r, "limit", 50),
-		Server: strings.TrimSpace(r.URL.Query().Get("server")),
-		Tool:   strings.TrimSpace(r.URL.Query().Get("tool")),
-		Status: strings.TrimSpace(r.URL.Query().Get("status")),
+		Offset:     readUintQuery(r, "offset", 0),
+		Limit:      readUintQuery(r, "limit", 50),
+		Server:     strings.TrimSpace(r.URL.Query().Get("server")),
+		Tool:       strings.TrimSpace(r.URL.Query().Get("tool")),
+		Status:     strings.TrimSpace(r.URL.Query().Get("status")),
+		ClientName: strings.TrimSpace(r.URL.Query().Get("client_name")),
 	}
 	resp, err := h.svc.List(r.Context(), filter)
 	if err != nil {
@@ -1097,11 +1122,12 @@ func (h *Handler) adminInvocationStream(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	filter := invocation.InvocationListFilter{
-		Offset: 0,
-		Limit:  readUintQuery(r, "limit", 50),
-		Server: strings.TrimSpace(r.URL.Query().Get("server")),
-		Tool:   strings.TrimSpace(r.URL.Query().Get("tool")),
-		Status: strings.TrimSpace(r.URL.Query().Get("status")),
+		Offset:     0,
+		Limit:      readUintQuery(r, "limit", 50),
+		Server:     strings.TrimSpace(r.URL.Query().Get("server")),
+		Tool:       strings.TrimSpace(r.URL.Query().Get("tool")),
+		Status:     strings.TrimSpace(r.URL.Query().Get("status")),
+		ClientName: strings.TrimSpace(r.URL.Query().Get("client_name")),
 	}
 	ctx := r.Context()
 	lastSignature := ""
@@ -2504,6 +2530,25 @@ func (h *Handler) externalInvocations(w http.ResponseWriter, r *http.Request) {
 			req.IdempotencyKey = &key
 		}
 	}
+	// Header fallbacks for callers that can't (or don't) put their
+	// harness identity in the JSON body. Body fields win.
+	if req.ClientName == "" {
+		if v := strings.TrimSpace(r.Header.Get("X-Atryum-Client-Name")); v != "" {
+			req.ClientName = v
+		}
+	}
+	if req.ClientVersion == "" {
+		if v := strings.TrimSpace(r.Header.Get("X-Atryum-Client-Version")); v != "" {
+			req.ClientVersion = v
+		}
+	}
+	// TODO(sc-16270): the User-Agent header is an additional fallback signal
+	// for identifying raw-script callers (curl, python-requests, etc.). We're
+	// leaving it as a debug log for now while we figure out what shapes
+	// actually show up in the wild. If patterns emerge, plumb through a
+	// real user_agent column and capture here.
+	h.debugf("external submit user-agent=%q", r.Header.Get("User-Agent"))
+
 	resp, err := h.svc.Submit(r.Context(), req)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -2732,6 +2777,86 @@ func normalizeToolCallResult(raw json.RawMessage, isError bool) any {
 		}
 	}
 	return map[string]any{"content": []map[string]any{{"type": "text", "text": string(raw)}}, "isError": isError}
+}
+
+// recordInitializeClientInfo captures the MCP `initialize.clientInfo` so it
+// can later be attached to invocations. It:
+//   - Always stashes the snapshot in the in-memory session cache keyed by
+//     `Mcp-Session-Id` (or remote-addr + UA fallback) so anonymous /mcp/
+//     callers still get an Agent column populated for follow-up tools/call
+//     requests on the same session.
+//   - Additionally upserts into the agent_clients table when both an
+//     authenticated agent_id and a configured recorder are present.
+//
+// Best-effort throughout: parse errors or repo failures must not break the
+// initialize handshake.
+func (h *Handler) recordInitializeClientInfo(r *http.Request, params json.RawMessage) {
+	var payload struct {
+		ClientInfo struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"clientInfo"`
+	}
+	if len(params) > 0 {
+		_ = json.Unmarshal(params, &payload)
+	}
+	name := strings.TrimSpace(payload.ClientInfo.Name)
+	version := strings.TrimSpace(payload.ClientInfo.Version)
+	if name == "" && version == "" {
+		return
+	}
+	snap := clientInfoSnapshot{Name: name, Version: version, At: time.Now().UTC()}
+	if key := sessionKeyFromRequest(r); key != "" {
+		h.clientInfoMu.Lock()
+		h.clientInfoCache[key] = snap
+		// Bound the cache so a noisy fleet of agents can't grow it
+		// unboundedly. 1024 entries is plenty for a dev / single-tenant
+		// instance; oldest evicted opportunistically.
+		if len(h.clientInfoCache) > 1024 {
+			var oldestKey string
+			var oldestAt time.Time
+			for k, v := range h.clientInfoCache {
+				if oldestKey == "" || v.At.Before(oldestAt) {
+					oldestKey, oldestAt = k, v.At
+				}
+			}
+			delete(h.clientInfoCache, oldestKey)
+		}
+		h.clientInfoMu.Unlock()
+	}
+}
+
+// lookupClientInfo returns any clientInfo captured for the request's session
+// key (set on a prior `initialize` call). Used so that anonymous tools/call
+// requests can still carry through "Amp 0.0.1234"-style context.
+func (h *Handler) lookupClientInfo(r *http.Request) (clientInfoSnapshot, bool) {
+	key := sessionKeyFromRequest(r)
+	if key == "" {
+		return clientInfoSnapshot{}, false
+	}
+	h.clientInfoMu.RLock()
+	snap, ok := h.clientInfoCache[key]
+	h.clientInfoMu.RUnlock()
+	return snap, ok
+}
+
+// sessionKeyFromRequest produces a best-effort identifier for the agent
+// session originating this HTTP request. Prefers the standard MCP
+// `Mcp-Session-Id` header when the client sets it; falls back to remote
+// IP + User-Agent which is usually distinct enough for local dev.
+func sessionKeyFromRequest(r *http.Request) string {
+	if v := strings.TrimSpace(r.Header.Get("Mcp-Session-Id")); v != "" {
+		return "sid:" + v
+	}
+	host := r.RemoteAddr
+	if i := strings.LastIndex(host, ":"); i > -1 {
+		host = host[:i]
+	}
+	ua := strings.TrimSpace(r.Header.Get("User-Agent"))
+	if host == "" && ua == "" {
+		return ""
+	}
+	return "addr:" + host + "|ua:" + ua
 }
 
 func compactRequestID(id json.RawMessage) string {

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -117,6 +117,62 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	}
 }
 
+// Anonymous (no [[auth]]) callers should still surface MCP clientInfo on
+// the invocation row when the API layer passes it through.
+func TestInvokeWithoutAgentIDPersistsClientInfoFromRequest(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+	}))
+	defer upstream.Close()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Config{
+		Defaults:  config.DefaultsConfig{RequestTimeoutSeconds: 5},
+		Upstreams: []config.UpstreamConfig{{Name: "demo", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+	}
+	resolver := mcp.NewResolver(store.NewServerRepo(db), cfg)
+	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	svc := invocation.NewService(
+		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,
+		mcp.NewHTTPClient(), policy.AlwaysApproveProvider{},
+		5*time.Second, nil, nil, nil, nil,
+	)
+
+	resp, err := svc.Invoke(context.Background(), invocation.CreateInvocationRequest{
+		Server: "demo", Tool: "demo_tool", Input: map[string]any{"x": 1},
+		ClientName: "amp", ClientVersion: "0.0.1234",
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if resp.AgentID != nil {
+		t.Fatalf("expected no agent_id, got %v", resp.AgentID)
+	}
+	if resp.AgentClientName == nil || *resp.AgentClientName != "amp" {
+		t.Fatalf("AgentClientName = %v, want amp", resp.AgentClientName)
+	}
+	if resp.AgentClientVersion == nil || *resp.AgentClientVersion != "0.0.1234" {
+		t.Fatalf("AgentClientVersion = %v, want 0.0.1234", resp.AgentClientVersion)
+	}
+
+	got, err := svc.Get(context.Background(), resp.InvocationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentClientName == nil || *got.AgentClientName != "amp" {
+		t.Fatalf("Get AgentClientName = %v, want amp", got.AgentClientName)
+	}
+}
+
 func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -39,12 +39,18 @@ type Invocation struct {
 	Approval       *Approval  `json:"approval"`
 	MatchedRuleID  *string    `json:"matched_rule_id,omitempty"`
 	AgentID        *string    `json:"agent_id,omitempty"`
-	Input          []byte     `json:"-"`
-	Response       []byte     `json:"-"`
-	Error          []byte     `json:"-"`
-	Summary        *string    `json:"summary,omitempty"`
-	SubmittedAt    time.Time  `json:"submitted_at"`
-	CompletedAt    *time.Time `json:"completed_at,omitempty"`
+	// ClientName / ClientVersion mirror the MCP `initialize.clientInfo`
+	// the harness reported on the connection that issued this invocation.
+	// Captured even when auth is disabled (no agent_id) so the UI can still
+	// show "Amp 0.0.1234" for anonymous traffic.
+	ClientName    *string    `json:"client_name,omitempty"`
+	ClientVersion *string    `json:"client_version,omitempty"`
+	Input         []byte     `json:"-"`
+	Response      []byte     `json:"-"`
+	Error         []byte     `json:"-"`
+	Summary       *string    `json:"summary,omitempty"`
+	SubmittedAt   time.Time  `json:"submitted_at"`
+	CompletedAt   *time.Time `json:"completed_at,omitempty"`
 }
 
 type Event struct {
@@ -56,14 +62,15 @@ type Event struct {
 }
 
 type InvocationListFilter struct {
-	Offset    uint64
-	Limit     uint64
-	Server    string
-	Tool      string
-	Status    string
-	AgentID   string
-	StartDate *time.Time
-	EndDate   *time.Time
+	Offset     uint64
+	Limit      uint64
+	Server     string
+	Tool       string
+	Status     string
+	AgentID    string
+	ClientName string
+	StartDate  *time.Time
+	EndDate    *time.Time
 }
 
 type EventListFilter struct {
@@ -83,6 +90,11 @@ type CreateInvocationRequest struct {
 	Input          map[string]any `json:"input"`
 	RequestID      *string        `json:"request_id,omitempty"`
 	IdempotencyKey *string        `json:"idempotency_key,omitempty"`
+	// ClientName / ClientVersion let the caller pass through the harness's
+	// MCP `initialize.clientInfo` for this specific call. Used to populate
+	// the per-row fallback for anonymous (no agent_id) invocations.
+	ClientName    string `json:"-"`
+	ClientVersion string `json:"-"`
 }
 
 // ExternalSubmitRequest is used by callers that execute the tool themselves
@@ -97,6 +109,13 @@ type ExternalSubmitRequest struct {
 	RequestID      *string        `json:"request_id,omitempty"`
 	IdempotencyKey *string        `json:"idempotency_key,omitempty"`
 	ThreadID       string         `json:"thread_id,omitempty"`
+	// ClientName / ClientVersion identify the harness making the call.
+	// Optional — when omitted, Source is used for ClientName. Prefer these
+	// when the caller knows its own identity (e.g. amp plugin sending
+	// "amp" + its build version) rather than relying on Source which
+	// doubles as the approval-rule matching key.
+	ClientName    string `json:"client_name,omitempty"`
+	ClientVersion string `json:"client_version,omitempty"`
 }
 
 // ExternalExecutionUpdate is sent by the external executor to report on a
@@ -118,13 +137,23 @@ type InvocationResponse struct {
 	Approval      *Approval       `json:"approval"`
 	MatchedRuleID *string         `json:"matched_rule_id,omitempty"`
 	AgentID       *string         `json:"agent_id,omitempty"`
-	RequestID     *string         `json:"request_id,omitempty"`
-	Input         json.RawMessage `json:"input,omitempty"`
-	SubmittedAt   time.Time       `json:"submitted_at"`
-	CompletedAt   *time.Time      `json:"completed_at,omitempty"`
-	Result        json.RawMessage `json:"result,omitempty"`
-	Error         json.RawMessage `json:"error,omitempty"`
-	Summary       string          `json:"summary,omitempty"`
+	// AgentClientName / AgentClientVersion identify the MCP client software
+	// (e.g. "amp", "cursor", "claude-code") captured from the most recent
+	// `initialize` handshake associated with this AgentID. They describe the
+	// agent type/harness, not the human user.
+	AgentClientName    *string `json:"agent_client_name,omitempty"`
+	AgentClientVersion *string `json:"agent_client_version,omitempty"`
+	// UserID is the JWT subject claim (`sub`) captured alongside the agent's
+	// most recent `initialize` — the human/service principal behind the agent
+	// when available.
+	UserID      *string         `json:"user_id,omitempty"`
+	RequestID   *string         `json:"request_id,omitempty"`
+	Input       json.RawMessage `json:"input,omitempty"`
+	SubmittedAt time.Time       `json:"submitted_at"`
+	CompletedAt *time.Time      `json:"completed_at,omitempty"`
+	Result      json.RawMessage `json:"result,omitempty"`
+	Error       json.RawMessage `json:"error,omitempty"`
+	Summary     string          `json:"summary,omitempty"`
 }
 
 type InvocationListResponse struct {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -249,6 +249,14 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 	if agentID != "" {
 		inv.AgentID = &agentID
 	}
+	if req.ClientName != "" {
+		v := req.ClientName
+		inv.ClientName = &v
+	}
+	if req.ClientVersion != "" {
+		v := req.ClientVersion
+		inv.ClientVersion = &v
+	}
 	if err := s.invocations.Create(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
@@ -701,10 +709,28 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 		RequestID:      req.RequestID,
 		IdempotencyKey: req.IdempotencyKey,
 		Tool:           req.Tool,
-		Upstream:       source,
-		Status:         StatusReceived,
-		Input:          inputJSON,
-		SubmittedAt:    now,
+		// Upstream is intentionally left empty for external/non-MCP
+		// invocations — the harness ran the tool itself, there is no
+		// MCP server in the loop. The UI renders an empty server as
+		// "none". The harness identity is recorded as ClientName below
+		// so it shows up in the Agent column instead.
+		Upstream:    "",
+		Status:      StatusReceived,
+		Input:       inputJSON,
+		SubmittedAt: now,
+	}
+	// Prefer explicit ClientName/ClientVersion from the request; fall back
+	// to Source when the caller didn't tell us anything more specific.
+	if cn := req.ClientName; cn != "" {
+		v := cn
+		inv.ClientName = &v
+	} else if source != "" && source != "external" {
+		s := source
+		inv.ClientName = &s
+	}
+	if cv := req.ClientVersion; cv != "" {
+		v := cv
+		inv.ClientVersion = &v
 	}
 	if agentID != "" {
 		inv.AgentID = &agentID
@@ -1015,7 +1041,8 @@ func (s *Service) Get(ctx context.Context, id string) (InvocationResponse, error
 	if err != nil {
 		return InvocationResponse{}, err
 	}
-	return s.toResponse(inv), nil
+	resp := s.toResponse(inv)
+	return resp, nil
 }
 
 func (s *Service) ListAgentIDs(ctx context.Context) ([]string, error) {
@@ -1073,6 +1100,12 @@ func (s *Service) toResponse(inv Invocation) InvocationResponse {
 	resp := InvocationResponse{InvocationID: inv.InvocationID, ServerName: inv.Upstream, ToolName: inv.Tool, Status: inv.Status, Approval: inv.Approval, MatchedRuleID: inv.MatchedRuleID, AgentID: inv.AgentID, RequestID: inv.RequestID, SubmittedAt: inv.SubmittedAt, CompletedAt: inv.CompletedAt}
 	if inv.Summary != nil {
 		resp.Summary = *inv.Summary
+	}
+	if inv.ClientName != nil {
+		resp.AgentClientName = inv.ClientName
+	}
+	if inv.ClientVersion != nil {
+		resp.AgentClientVersion = inv.ClientVersion
 	}
 	if len(inv.Input) > 0 {
 		resp.Input = json.RawMessage(inv.Input)

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 13 {
+	if len(migrations) != 14 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -66,6 +66,7 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{11, "011_agent_sync_settings"},
 		{12, "012_invocation_summary"},
 		{13, "013_summary_model_config"},
+		{14, "014_invocation_client_info.sql"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -76,10 +77,10 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 12 {
+	if len(pending) != 13 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}
+	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
 	for i, want := range wantVersions {
 		if pending[i].Version != want {
 			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)

--- a/internal/store/migrations/014_invocation_client_info.go
+++ b/internal/store/migrations/014_invocation_client_info.go
@@ -1,0 +1,12 @@
+package migrations
+
+func migration014() Definition {
+	return Definition{
+		Version: 14,
+		Name:    "014_invocation_client_info.sql",
+		Steps: []Step{
+			Raw("add client_name to invocations", `ALTER TABLE invocations ADD COLUMN client_name TEXT`),
+			Raw("add client_version to invocations", `ALTER TABLE invocations ADD COLUMN client_version TEXT`),
+		},
+	}
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -47,5 +47,6 @@ func All() []Definition {
 		migration011(),
 		migration012(),
 		migration013(),
+		migration014(),
 	}
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -82,9 +82,9 @@ func (r *InvocationRepo) Create(ctx context.Context, inv invocation.Invocation) 
 		approval = string(b)
 	}
 	query, args, err := r.sb.Insert("invocations").Columns(
-		"invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary",
+		"invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary", "client_name", "client_version",
 	).Values(
-		inv.InvocationID, inv.RequestID, inv.IdempotencyKey, inv.Tool, inv.Upstream, inv.Status, approval, string(inv.Input), nullableString(inv.Response), nullableString(inv.Error), inv.SubmittedAt, inv.CompletedAt, inv.MatchedRuleID, inv.AgentID, inv.Summary,
+		inv.InvocationID, inv.RequestID, inv.IdempotencyKey, inv.Tool, inv.Upstream, inv.Status, approval, string(inv.Input), nullableString(inv.Response), nullableString(inv.Error), inv.SubmittedAt, inv.CompletedAt, inv.MatchedRuleID, inv.AgentID, inv.Summary, inv.ClientName, inv.ClientVersion,
 	).ToSql()
 	if err != nil {
 		return err
@@ -123,7 +123,7 @@ func (r *InvocationRepo) UpdateSummary(ctx context.Context, id string, summary s
 }
 
 func (r *InvocationRepo) Get(ctx context.Context, id string) (invocation.Invocation, error) {
-	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary").From("invocations").Where(sq.Eq{"invocation_id": id}).ToSql()
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary", "client_name", "client_version").From("invocations").Where(sq.Eq{"invocation_id": id}).ToSql()
 	if err != nil {
 		return invocation.Invocation{}, err
 	}
@@ -132,7 +132,7 @@ func (r *InvocationRepo) Get(ctx context.Context, id string) (invocation.Invocat
 }
 
 func (r *InvocationRepo) GetByIdempotencyKey(ctx context.Context, key string) (invocation.Invocation, error) {
-	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary").From("invocations").Where(sq.Eq{"idempotency_key": key}).ToSql()
+	query, args, err := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary", "client_name", "client_version").From("invocations").Where(sq.Eq{"idempotency_key": key}).ToSql()
 	if err != nil {
 		return invocation.Invocation{}, err
 	}
@@ -144,7 +144,7 @@ func (r *InvocationRepo) List(ctx context.Context, filter invocation.InvocationL
 	if filter.Limit == 0 {
 		filter.Limit = 50
 	}
-	builder := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary").From("invocations")
+	builder := r.sb.Select("invocation_id", "request_id", "idempotency_key", "tool_name", "upstream_name", "status", "approval_json", "request_json", "response_json", "error_json", "submitted_at", "completed_at", "matched_rule_id", "agent_id", "summary", "client_name", "client_version").From("invocations")
 	countBuilder := r.sb.Select("COUNT(*)").From("invocations")
 	builder, countBuilder = applyInvocationFilter(builder, countBuilder, filter)
 	query, args, err := builder.OrderBy("submitted_at DESC").Limit(filter.Limit).Offset(filter.Offset).ToSql()
@@ -541,8 +541,8 @@ func scanInvocation(scanner interface{ Scan(dest ...any) error }) (invocation.In
 	var completedAt sql.NullTime
 	var matchedRuleID sql.NullString
 	var agentID sql.NullString
-	var summary sql.NullString
-	if err := scanner.Scan(&inv.InvocationID, &requestID, &idempotencyKey, &inv.Tool, &inv.Upstream, &inv.Status, &approval, &requestJSON, &responseJSON, &errorJSON, &inv.SubmittedAt, &completedAt, &matchedRuleID, &agentID, &summary); err != nil {
+	var summary, clientName, clientVersion sql.NullString
+	if err := scanner.Scan(&inv.InvocationID, &requestID, &idempotencyKey, &inv.Tool, &inv.Upstream, &inv.Status, &approval, &requestJSON, &responseJSON, &errorJSON, &inv.SubmittedAt, &completedAt, &matchedRuleID, &agentID, &summary, &clientName, &clientVersion); err != nil {
 		return invocation.Invocation{}, err
 	}
 	if requestID.Valid {
@@ -576,6 +576,12 @@ func scanInvocation(scanner interface{ Scan(dest ...any) error }) (invocation.In
 	}
 	if summary.Valid {
 		inv.Summary = &summary.String
+	}
+	if clientName.Valid {
+		inv.ClientName = &clientName.String
+	}
+	if clientVersion.Valid {
+		inv.ClientVersion = &clientVersion.String
 	}
 	return inv, nil
 }
@@ -654,6 +660,10 @@ func applyInvocationFilter(builder sq.SelectBuilder, countBuilder sq.SelectBuild
 	if filter.AgentID != "" {
 		builder = builder.Where(sq.Eq{"agent_id": filter.AgentID})
 		countBuilder = countBuilder.Where(sq.Eq{"agent_id": filter.AgentID})
+	}
+	if filter.ClientName != "" {
+		builder = builder.Where(sq.Eq{"client_name": filter.ClientName})
+		countBuilder = countBuilder.Where(sq.Eq{"client_name": filter.ClientName})
 	}
 	if filter.StartDate != nil {
 		builder = builder.Where(sq.GtOrEq{"submitted_at": *filter.StartDate})

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -41,8 +41,8 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 13 {
-		t.Fatalf("expected 13 migrations, got %d", count)
+	if count != 14 {
+		t.Fatalf("expected 14 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 13 {
-		t.Fatalf("expected 13 migrations after double init, got %d", count)
+	if count != 14 {
+		t.Fatalf("expected 14 migrations after double init, got %d", count)
 	}
 }
 

--- a/scripts/fake_agent.py
+++ b/scripts/fake_agent.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""
+fake_agent.py — pretend to be an agent talking to Atryum, so you can test
+the approval UI / invocation pipeline without running a real coding harness
+or MCP client.
+
+Two modes, mirroring the two real integrations Atryum supports today:
+
+  1. harness  — pretend to be a coding harness like Amp using the
+                /api/v1/external/invocations endpoints (the amp-plugin path,
+                see atryum/examples/amp-plugin/). Atryum does NOT execute
+                the tool; we (the fake harness) "execute" it locally and
+                PATCH the result back.
+
+  2. mcp      — pretend to be an MCP client talking JSON-RPC to
+                POST /mcp/{server}. Goes through initialize / tools/list /
+                tools/call and lets Atryum proxy to the upstream + mediate
+                approval.
+
+  3. demo     — runs a small scripted scenario over the harness path so you
+                can click through the UI and approve/deny things.
+
+Examples
+--------
+
+  # Submit one tool call as a fake "amp" harness and wait for approval:
+  python fake_agent.py harness --tool Bash --input '{"cmd":"ls"}'
+
+  # Submit one and auto-report a failure once approved:
+  python fake_agent.py harness --tool Bash --input '{"cmd":"boom"}' \\
+      --simulate-result fail
+
+  # Drive a scripted demo so you can play with /ui/:
+  python fake_agent.py demo
+
+  # Talk MCP JSON-RPC to the default safe server (calc-mcp):
+  python fake_agent.py mcp --list-tools
+  python fake_agent.py mcp --tool add --arguments '{"a":2,"b":3}'
+
+  # Pretend to be a specific harness:
+  python fake_agent.py mcp --client-name cursor --client-version 0.45.7 --list-tools
+
+  # Aggregate /mcp/ endpoint (every server's tools merged):
+  python fake_agent.py mcp '' --list-tools
+
+Config (env or flags):
+  ATRYUM_URL        base url, default http://localhost:8080
+  ATRYUM_MCP_SERVER default MCP server name, default "calc-mcp"
+  ATRYUM_SOURCE     pins the agent identity (harness --source / mcp clientInfo.name);
+                    when unset, a random identity is picked from a small set of
+                    realistic harness names (amp, cursor, claude-code, …)
+  ATRYUM_POLL_MS    poll interval ms while awaiting approval, default 1000
+  THREAD_ID         thread id surfaced in harness submissions
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import sys
+import time
+import uuid
+from typing import Any
+from urllib import error as urlerror
+from urllib import request as urlrequest
+
+DEFAULT_URL = os.environ.get("ATRYUM_URL", "http://localhost:8080")
+DEFAULT_POLL_MS = int(os.environ.get("ATRYUM_POLL_MS", "1000"))
+DEFAULT_THREAD_ID = os.environ.get("THREAD_ID", "")
+
+# Default MCP server to talk to. calc-mcp is a safe local sandbox; the real
+# upstreams (shortcut, github, etc.) are world-impacting so we don't want a
+# bare `mcp` invocation to land there by accident.
+DEFAULT_MCP_SERVER = os.environ.get("ATRYUM_MCP_SERVER", "calc-mcp")
+
+# Real-world agent/harness identities. Used as:
+#   - harness mode: --source (drives the Agent column via inv.client_name)
+#   - mcp mode:     clientInfo.name in the initialize handshake
+# Pick one at random per run so the UI shows a mix of agents instead of a
+# single monoculture "fake-agent" stream.
+#
+# The first block is what each harness *actually* sends in
+# `initialize.clientInfo` — captured by pointing each one at a stdio
+# MCP sniffer (see Atryum SC-16270 ticket). Keep the exact strings;
+# AgentIcon.tsx's `detectAgentKind` regex normalizes them to icons.
+#
+# The second block is best-guess for harnesses we haven't sniffed. Strings
+# may not match what these tools actually send — fine for populating a
+# demo, but don't read anything into them.
+AGENT_IDENTITIES: list[tuple[str, str]] = [
+    # Empirically verified.
+    ("amp-mcp-client", "0.0.0-dev"),
+    ("codex-mcp-client", "0.128.0"),
+    ("Claude Code", "2.1.123"),
+    ("cursor-vscode", "0.45.7"),
+    ("opencode", "1.14.31"),
+    # Best-guess; not yet verified by a real sniff.
+    ("cline", "3.1.0"),
+    ("windsurf", "1.2.4"),
+    ("continue", "0.9.250"),
+    ("zed", "0.156.0"),
+    ("aider", "0.85.0"),
+    ("goose", "1.0.20"),
+]
+
+
+def _env_or_random_identity() -> tuple[str, str]:
+    """Return (name, version). Honors ATRYUM_SOURCE if set, else picks randomly."""
+    override = os.environ.get("ATRYUM_SOURCE", "").strip()
+    if override:
+        return override, "0.0.1"
+    return random.choice(AGENT_IDENTITIES)
+
+
+# ─── tiny HTTP helper (stdlib only, no requests dep) ────────────────────────
+
+
+def _request(
+    method: str,
+    url: str,
+    body: Any | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> tuple[int, dict[str, Any] | str]:
+    data = None
+    hdrs = dict(headers or {})
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        hdrs.setdefault("Content-Type", "application/json")
+    req = urlrequest.Request(url, data=data, method=method, headers=hdrs)
+    try:
+        with urlrequest.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            status = resp.status
+    except urlerror.HTTPError as e:
+        raw = e.read().decode("utf-8", errors="replace")
+        status = e.code
+    try:
+        return status, json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return status, raw
+
+
+def _print_json(label: str, payload: Any) -> None:
+    print(f"── {label} " + "─" * max(2, 60 - len(label)))
+    if isinstance(payload, (dict, list)):
+        print(json.dumps(payload, indent=2))
+    else:
+        print(payload)
+
+
+# ─── harness mode (external invocations) ────────────────────────────────────
+
+
+PENDING_STATES = {"received", "pending_approval", "executing"}
+APPROVED_STATES = {"approved"}
+REJECTED_STATES = {"denied", "expired", "cancelled"}
+
+
+def harness_submit(
+    base: str,
+    source: str,
+    tool: str,
+    input_obj: dict[str, Any],
+    description: str | None,
+    request_id: str,
+    thread_id: str,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "source": source,
+        "tool": tool,
+        "input": input_obj,
+        "request_id": request_id,
+    }
+    if description:
+        body["description"] = description
+    if thread_id:
+        body["thread_id"] = thread_id
+    status, payload = _request("POST", f"{base}/api/v1/external/invocations", body)
+    if status >= 300:
+        raise SystemExit(f"submit failed ({status}): {payload}")
+    assert isinstance(payload, dict)
+    return payload
+
+
+def harness_poll(base: str, invocation_id: str, poll_ms: int) -> dict[str, Any]:
+    url = f"{base}/api/v1/external/invocations/{invocation_id}"
+    while True:
+        status, payload = _request("GET", url)
+        if status >= 300:
+            raise SystemExit(f"poll failed ({status}): {payload}")
+        assert isinstance(payload, dict)
+        cur = payload.get("status")
+        if cur not in PENDING_STATES:
+            return payload
+        print(f"  …status={cur}, waiting {poll_ms}ms")
+        time.sleep(poll_ms / 1000)
+
+
+def harness_patch(
+    base: str,
+    invocation_id: str,
+    execution_status: str,
+    result: Any = None,
+    error: Any = None,
+    message: str | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {"execution_status": execution_status}
+    if result is not None:
+        body["result"] = result
+    if error is not None:
+        body["error"] = error
+    if message:
+        body["message"] = message
+    status, payload = _request(
+        "PATCH", f"{base}/api/v1/external/invocations/{invocation_id}", body
+    )
+    if status >= 300:
+        raise SystemExit(f"patch failed ({status}): {payload}")
+    assert isinstance(payload, dict)
+    return payload
+
+
+def run_harness_once(
+    base: str,
+    source: str,
+    tool: str,
+    input_obj: dict[str, Any],
+    description: str | None,
+    thread_id: str,
+    poll_ms: int,
+    simulate: str,
+) -> None:
+    request_id = f"fake-{uuid.uuid4()}"
+    print(f"submitting tool={tool} source={source} request_id={request_id}")
+    submitted = harness_submit(
+        base, source, tool, input_obj, description, request_id, thread_id
+    )
+    _print_json("submit response", submitted)
+    inv_id = submitted["invocation_id"]
+    decided = submitted
+    if submitted.get("status") in PENDING_STATES:
+        print(f"awaiting approval at {base}/ui/  (invocation {inv_id})")
+        decided = harness_poll(base, inv_id, poll_ms)
+        _print_json("post-approval", decided)
+
+    final = decided.get("status")
+    if final not in APPROVED_STATES:
+        print(f"not approved (status={final}); nothing to execute.")
+        return
+
+    print("→ running PATCH execution_status=running")
+    harness_patch(base, inv_id, "running")
+
+    # Pretend to do work.
+    time.sleep(0.4)
+
+    if simulate == "ok":
+        out = {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"(fake-agent) ran '{tool}' with {input_obj!r} — pretend success",
+                }
+            ]
+        }
+        final_resp = harness_patch(base, inv_id, "completed", result=out)
+    elif simulate == "fail":
+        err = {"message": f"(fake-agent) pretend failure executing '{tool}'"}
+        final_resp = harness_patch(
+            base, inv_id, "failed", error=err, message="pretend failure"
+        )
+    elif simulate == "cancel":
+        final_resp = harness_patch(
+            base, inv_id, "cancelled", message="pretend cancellation"
+        )
+    else:
+        raise SystemExit(f"unknown --simulate-result value: {simulate}")
+    _print_json("final invocation", final_resp)
+
+
+# ─── demo: scripted multi-call scenario over harness path ───────────────────
+
+
+HARNESS_DEMO_CALLS: list[dict[str, Any]] = [
+    {
+        "tool": "Bash",
+        "input": {"cmd": "ls -la /tmp"},
+        "description": "list /tmp",
+        "simulate": "ok",
+    },
+    {
+        "tool": "edit_file",
+        "input": {"path": "/etc/hosts", "content": "127.0.0.1 evil.example"},
+        "description": "edit /etc/hosts (you should DENY this one)",
+        "simulate": "ok",
+    },
+    {
+        "tool": "Read",
+        "input": {"path": "/src/AGENTS.md"},
+        "description": "read AGENTS.md",
+        "simulate": "ok",
+    },
+    {
+        "tool": "Bash",
+        "input": {"cmd": "exit 1"},
+        "description": "command that 'fails'",
+        "simulate": "fail",
+    },
+]
+
+# Safe, side-effect-free calc-mcp tools so the MCP demo can spam invocations
+# against a real upstream and populate the UI with varied agent_client_name
+# values (clientInfo.name is only recorded for MCP-proxied calls, not for
+# external/harness submissions).
+MCP_DEMO_CALLS: list[dict[str, Any]] = [
+    {"tool": "math", "arguments": {"action": "eval", "expression": "2+2"}},
+    {"tool": "math", "arguments": {"action": "eval", "expression": "10*7"}},
+    {"tool": "random", "arguments": {"type": "uuid"}},
+    {"tool": "random", "arguments": {"type": "ulid"}},
+    {"tool": "hash", "arguments": {"algorithm": "sha256", "input": "hello"}},
+    {"tool": "base64", "arguments": {"action": "encode", "input": "atryum"}},
+    {"tool": "datetime", "arguments": {"action": "now"}},
+    {"tool": "semver", "arguments": {"action": "valid", "version": "1.2.3"}},
+]
+
+
+def run_demo(base: str, source: str | None, thread_id: str, poll_ms: int) -> None:
+    print(f"demo: {len(HARNESS_DEMO_CALLS)} harness calls + {len(MCP_DEMO_CALLS)} MCP calls -> {base}")
+    if source is None:
+        print("demo: randomizing agent identity per call (pass --source to pin one)")
+    print(f"open {base}/ui/ and approve/deny harness ones as they come in.\n")
+
+    # MCP calls first — they're auto-approved and record clientInfo, so the
+    # UI fills with varied agents immediately while you're still clicking
+    # through harness approvals.
+    print("── MCP phase (calc-mcp, varied clientInfo) ──")
+    for i, call in enumerate(MCP_DEMO_CALLS, 1):
+        name, version = (
+            (source, "0.0.1") if source is not None else random.choice(AGENT_IDENTITIES)
+        )
+        print(f"\n── mcp {i}/{len(MCP_DEMO_CALLS)}: {call['tool']} as {name}/{version} ──")
+        try:
+            run_mcp(
+                base=base,
+                server=DEFAULT_MCP_SERVER,
+                tool=call["tool"],
+                arguments=call["arguments"],
+                list_tools=False,
+                bearer=None,
+                client_name=name,
+                client_version=version,
+            )
+        except SystemExit as e:
+            print(f"  (mcp call failed: {e})")
+
+    # Harness calls.
+    print("\n── harness phase (external invocations, varied --source) ──")
+    for i, call in enumerate(HARNESS_DEMO_CALLS, 1):
+        agent = source if source is not None else random.choice(AGENT_IDENTITIES)[0]
+        print(f"\n══ harness {i}/{len(HARNESS_DEMO_CALLS)}: {call['tool']} as {agent} ══")
+        run_harness_once(
+            base=base,
+            source=agent,
+            tool=call["tool"],
+            input_obj=call["input"],
+            description=call["description"],
+            thread_id=thread_id,
+            poll_ms=poll_ms,
+            simulate=call["simulate"],
+        )
+    print("\ndemo complete.")
+
+
+# ─── mcp client mode (JSON-RPC over /mcp/{server}) ──────────────────────────
+
+
+def mcp_call(
+    base: str,
+    server: str | None,
+    method: str,
+    params: dict[str, Any] | None,
+    req_id: int,
+    protocol_version: str = "2025-06-18",
+    extra_headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    path = "/mcp/" + (server or "")
+    body: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    headers = {"MCP-Protocol-Version": protocol_version}
+    if extra_headers:
+        headers.update(extra_headers)
+    status, payload = _request("POST", base + path, body, headers=headers)
+    if status >= 300:
+        raise SystemExit(f"mcp {method} failed ({status}): {payload}")
+    if not isinstance(payload, dict):
+        raise SystemExit(f"mcp {method} returned non-json: {payload!r}")
+    return payload
+
+
+def run_mcp(
+    base: str,
+    server: str | None,
+    tool: str | None,
+    arguments: dict[str, Any] | None,
+    list_tools: bool,
+    bearer: str | None,
+    client_name: str,
+    client_version: str,
+) -> None:
+    headers: dict[str, str] = {}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+
+    print(f"mcp: server={server or '(aggregate)'} client={client_name}/{client_version}")
+
+    # 1. initialize
+    init = mcp_call(
+        base,
+        server,
+        "initialize",
+        {
+            "protocolVersion": "2025-06-18",
+            "clientInfo": {"name": client_name, "version": client_version},
+            "capabilities": {},
+        },
+        req_id=1,
+        extra_headers=headers,
+    )
+    _print_json("initialize", init)
+
+    # 2. notifications/initialized (no response expected, server returns 202)
+    mcp_call(
+        base,
+        server,
+        "notifications/initialized",
+        {},
+        req_id=2,
+        extra_headers=headers,
+    )
+
+    # 3. tools/list (optional)
+    if list_tools or tool is None:
+        tools = mcp_call(base, server, "tools/list", {}, req_id=3, extra_headers=headers)
+        _print_json("tools/list", tools)
+        if tool is None:
+            return
+
+    # 4. tools/call
+    call = mcp_call(
+        base,
+        server,
+        "tools/call",
+        {"name": tool, "arguments": arguments or {}},
+        req_id=4,
+        extra_headers=headers,
+    )
+    _print_json("tools/call", call)
+
+
+# ─── argparse ───────────────────────────────────────────────────────────────
+
+
+def _parse_json_arg(value: str, label: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"--{label} must be valid JSON: {e}")
+    if not isinstance(parsed, dict):
+        raise SystemExit(f"--{label} must be a JSON object")
+    return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="fake_agent.py",
+        description="Pretend to be an agent talking to Atryum.",
+    )
+    p.add_argument("--base", default=DEFAULT_URL, help=f"Atryum base URL (default {DEFAULT_URL})")
+    sub = p.add_subparsers(dest="mode", required=True)
+
+    default_name, default_version = _env_or_random_identity()
+
+    # harness
+    ph = sub.add_parser("harness", help="pretend to be a coding harness like amp")
+    ph.add_argument(
+        "--source",
+        default=default_name,
+        help=f"agent label shown as 'upstream' in atryum UI (default this run: {default_name})",
+    )
+    ph.add_argument("--tool", required=True)
+    ph.add_argument("--input", default="{}", help="JSON object of tool input")
+    ph.add_argument("--description", default=None)
+    ph.add_argument("--thread-id", default=DEFAULT_THREAD_ID)
+    ph.add_argument("--poll-ms", type=int, default=DEFAULT_POLL_MS)
+    ph.add_argument(
+        "--simulate-result",
+        choices=["ok", "fail", "cancel"],
+        default="ok",
+        help="how to PATCH the execution result after approval",
+    )
+
+    # demo
+    pd = sub.add_parser("demo", help="scripted multi-call demo over harness path")
+    pd.add_argument(
+        "--source",
+        default=None,
+        help="pin all demo calls to one agent label; default: pick a new random agent per call",
+    )
+    pd.add_argument("--thread-id", default=DEFAULT_THREAD_ID)
+    pd.add_argument("--poll-ms", type=int, default=DEFAULT_POLL_MS)
+
+    # mcp
+    pm = sub.add_parser("mcp", help="pretend to be an MCP client (JSON-RPC)")
+    pm.add_argument(
+        "server",
+        nargs="?",
+        default=DEFAULT_MCP_SERVER,
+        help=(
+            "MCP server name to talk to "
+            f"(default {DEFAULT_MCP_SERVER!r}; pass empty string '' for aggregate /mcp/)"
+        ),
+    )
+    pm.add_argument("--tool", default=None, help="tool name for tools/call")
+    pm.add_argument(
+        "--arguments", default="{}", help="JSON object of tool arguments"
+    )
+    pm.add_argument(
+        "--list-tools",
+        action="store_true",
+        help="call tools/list (default if --tool omitted)",
+    )
+    pm.add_argument(
+        "--bearer",
+        default=None,
+        help="bearer token for the Authorization header (optional)",
+    )
+    pm.add_argument(
+        "--client-name",
+        default=default_name,
+        help=f"clientInfo.name sent in initialize (default this run: {default_name})",
+    )
+    pm.add_argument(
+        "--client-version",
+        default=default_version,
+        help=f"clientInfo.version sent in initialize (default this run: {default_version})",
+    )
+
+    args = p.parse_args(argv)
+
+    if args.mode == "harness":
+        run_harness_once(
+            base=args.base,
+            source=args.source,
+            tool=args.tool,
+            input_obj=_parse_json_arg(args.input, "input"),
+            description=args.description,
+            thread_id=args.thread_id,
+            poll_ms=args.poll_ms,
+            simulate=args.simulate_result,
+        )
+    elif args.mode == "demo":
+        run_demo(
+            base=args.base,
+            source=args.source,  # may be None → demo will randomize per call
+            thread_id=args.thread_id,
+            poll_ms=args.poll_ms,
+        )
+    elif args.mode == "mcp":
+        # Empty string explicitly opts into the aggregate /mcp/ route.
+        server = args.server if args.server != "" else None
+        run_mcp(
+            base=args.base,
+            server=server,
+            tool=args.tool,
+            arguments=_parse_json_arg(args.arguments, "arguments"),
+            list_tools=args.list_tools,
+            bearer=args.bearer,
+            client_name=args.client_name,
+            client_version=args.client_version,
+        )
+    else:
+        p.error(f"unknown mode {args.mode!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
🤖 written. Goes with validmind/frontend#2601
> Captures the `clientInfo.name` / `clientInfo.version` an MCP harness reports during the JSON-RPC `initialize` handshake (Amp, Codex, Claude Code, opencode, Cursor, etc.) and stores it per-invocation so the Atryum UI can show what kind of agent made each tool call. Also extends the same metadata to the direct-API path so harnesses that submit via /api/v1/external/invocations (amp-plugin, custom scripts) populate the same Agent column.
> 
> migration 014: adds `client_name` / `client_version` columns to `invocations`. Per-row capture is the single source of truth — the in-memory session cache below handles the "clientInfo is sent on `initialize` only, not on each tools/call" reality of MCP.
> 
> - `handleMCPProxy("initialize")` parses `params.clientInfo` and stores it into an in-memory `clientInfoCache` keyed by `Mcp-Session-Id` (per the MCP streamable HTTP transport spec), falling back to remote IP + User-Agent for clients that don't send the header. The cache is bounded at 1024 entries (oldest evicted).
> - `handleMCPProxy("tools/call")` reads the cache and threads `ClientName` / `ClientVersion` into `CreateInvocationRequest`.
> 
> - New optional `client_name` / `client_version` JSON fields on `ExternalSubmitRequest`. When set, they override `source` for `inv.ClientName` (`source` still drives approval-rule matching, so existing auto_approve/auto_deny on "amp" etc. is unaffected).
> - `externalInvocations` handler also reads `X-Atryum-Client-Name` and `X-Atryum-Client-Version` request headers as a fallback for raw callers that can't (or won't) put the identity in the body.
> - `examples/amp-plugin/atryum.ts` now sends `client_name` (defaults to the existing `SOURCE` env var) and `client_version` (from `ATRYUM_CLIENT_VERSION` / `AMP_VERSION` when available) on every submit.
> 
> - `invocation.Service.Invoke` and `.Submit` persist `ClientName`/`ClientVersion` per row.
> - `toResponse` reads the per-row columns straight onto the API response. No separate `agent_clients` table or read-time lookup — per-row is authoritative.
> - External `Submit()` no longer overloads `inv.Upstream` with the harness name; the harness identity becomes `inv.ClientName` so it surfaces in the Agent column. Approval-rule matching against the original `source` value is preserved.
> 
> - New `ClientName` field on `InvocationListFilter`, wired through the sqlite filter builder and both `/api/v1/admin/invocations` and the `/stream` endpoint (`?client_name=…`). The frontend UI exposes this as the new "Agent" filter input.
> 
> - Logged via `debugf` in `externalInvocations` for visibility while we figure out what shapes show up in the wild. TODO left in place to plumb it to a real column if a useful signal emerges — premature to add storage now.
> 
> - Cherry-picked from origin/nibz/sc-16270 (Spencer's faker). Three modes: `harness` submits via /api/v1/external/invocations, `mcp` speaks JSON-RPC to /mcp/{server}, `demo` runs a scripted scenario. Useful for populating the UI with realistic-looking invocations from amp / cursor / claude-code / etc. without standing up real harnesses.
> 
> The original `origin/nibz/sc-16270` introduced an `agent_clients` table for authoritative per-`agent_id` identity with a read-time fallback in `toResponse`. Dropped here: `clientInfo` is genuinely session-scoped metadata, so an in-memory cache is the right shape and durable persistence happens at the per-row level. On atryum restart, in-flight sessions lose their cache entry and the client re-sends `clientInfo` on its next `initialize`. Rows written before the restart are unaffected — they captured `client_name` at write time.
> 
> - `agent_id_test.go` covers per-row clientInfo capture from the request payload.
> - `internal/store` tests assert the new migration runs and the `invocations` table carries the new columns.
