### PR TITLE
[SC-16493] Add /models/<vm_cuid>/invocations reporting endpoint

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -80,6 +80,7 @@ type agentsRepo interface {
 	List(ctx context.Context) ([]store.AgentRecord, error)
 	ListEnabled(ctx context.Context) ([]store.AgentRecord, error)
 	Get(ctx context.Context, id string) (store.AgentRecord, error)
+	GetByVMCUID(ctx context.Context, vmCUID string) (store.AgentRecord, error)
 	UpdateEnabled(ctx context.Context, id string, enabled bool) error
 	UpdateAgentIDs(ctx context.Context, id string, agentIDs string) error
 	DeleteAll(ctx context.Context) error
@@ -450,6 +451,7 @@ func (h *Handler) Routes() http.Handler {
 	apiKeyMW := auth.APIKeyMiddleware(h.apiKeyAuth)
 	mux.Handle("/agent_ids", apiKeyMW(http.HandlerFunc(h.agentIDs)))
 	mux.Handle("/invocations/", apiKeyMW(http.HandlerFunc(h.invocationsByAgentID)))
+	mux.Handle("/models/", apiKeyMW(http.HandlerFunc(h.invocationsByVMCUID)))
 	mux.HandleFunc("/ui", h.uiIndex)
 	mux.Handle("/ui/", http.StripPrefix("/ui/", h.spaFileServer()))
 	mux.HandleFunc("/", h.root)
@@ -879,6 +881,77 @@ func (h *Handler) invocationsByAgentID(w http.ResponseWriter, r *http.Request) {
 	resp, err := h.svc.List(r.Context(), filter)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// invocationsByVMCUID returns a paginated list of invocations for all runtime
+// agent IDs mapped to the given ValidMind inventory model CUID. The vm_cuid is
+// taken from the path segment after "/models/" (e.g. "/models/mdl_abc/invocations").
+// Protected by the API key middleware.
+func (h *Handler) invocationsByVMCUID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	// Path is /models/{vm_cuid}/invocations
+	trimmed := strings.TrimPrefix(r.URL.Path, "/models/")
+	vmCUID := strings.TrimSuffix(trimmed, "/invocations")
+	vmCUID = strings.Trim(vmCUID, "/")
+	if vmCUID == "" {
+		writeError(w, http.StatusBadRequest, "vm_cuid is required")
+		return
+	}
+	if h.agentsRepo == nil {
+		writeError(w, http.StatusServiceUnavailable, "agents repository not configured")
+		return
+	}
+	record, err := h.agentsRepo.GetByVMCUID(r.Context(), vmCUID)
+	if err != nil {
+		if err.Error() == "sql: no rows in result set" || strings.Contains(err.Error(), "no rows") {
+			writeError(w, http.StatusNotFound, "no agent record found for vm_cuid")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to look up agent record")
+		return
+	}
+	agentIDs := parseAgentIDs(record.AgentIDs)
+	if len(agentIDs) == 0 {
+		// Agent record exists but has no runtime IDs assigned yet — return empty list.
+		limit := readUintQuery(r, "limit", 50)
+		writeJSON(w, http.StatusOK, invocation.InvocationListResponse{
+			Items:  []invocation.InvocationResponse{},
+			Total:  0,
+			Offset: readUintQuery(r, "offset", 0),
+			Limit:  limit,
+		})
+		return
+	}
+	filter := invocation.InvocationListFilter{
+		Offset:   readUintQuery(r, "offset", 0),
+		Limit:    readUintQuery(r, "limit", 50),
+		AgentIDs: agentIDs,
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("start_date")); raw != "" {
+		t, err := parseDateParam(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid start_date: "+err.Error())
+			return
+		}
+		filter.StartDate = &t
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("end_date")); raw != "" {
+		t, err := parseDateParam(raw)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid end_date: "+err.Error())
+			return
+		}
+		filter.EndDate = &t
+	}
+	resp, err := h.svc.List(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list invocations")
 		return
 	}
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -858,9 +858,9 @@ func (h *Handler) invocationsByAgentID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	filter := invocation.InvocationListFilter{
-		Offset:  readUintQuery(r, "offset", 0),
-		Limit:   readUintQuery(r, "limit", 50),
-		AgentID: agentID,
+		Offset:   readUintQuery(r, "offset", 0),
+		Limit:    readUintQuery(r, "limit", 50),
+		AgentIDs: []string{agentID},
 	}
 	if raw := strings.TrimSpace(r.URL.Query().Get("start_date")); raw != "" {
 		t, err := parseDateParam(raw)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -156,8 +157,10 @@ func (s *stubAgentSyncSettingsRepo) Save(_ context.Context, settings store.Agent
 }
 
 type stubAgentsRepo struct {
-	records []store.AgentRecord
-	err     error
+	records     []store.AgentRecord
+	err         error
+	byVMCUID    map[string]store.AgentRecord
+	byVMCUIDErr map[string]error
 }
 
 func (s *stubAgentsRepo) List(context.Context) ([]store.AgentRecord, error) {
@@ -174,6 +177,19 @@ func (s *stubAgentsRepo) ListEnabled(context.Context) ([]store.AgentRecord, erro
 }
 func (s *stubAgentsRepo) Get(context.Context, string) (store.AgentRecord, error) {
 	return store.AgentRecord{}, nil
+}
+func (s *stubAgentsRepo) GetByVMCUID(_ context.Context, vmCUID string) (store.AgentRecord, error) {
+	if s.byVMCUIDErr != nil {
+		if err, ok := s.byVMCUIDErr[vmCUID]; ok {
+			return store.AgentRecord{}, err
+		}
+	}
+	if s.byVMCUID != nil {
+		if rec, ok := s.byVMCUID[vmCUID]; ok {
+			return rec, nil
+		}
+	}
+	return store.AgentRecord{}, fmt.Errorf("sql: no rows in result set")
 }
 func (s *stubAgentsRepo) UpdateEnabled(context.Context, string, bool) error { return nil }
 func (s *stubAgentsRepo) UpdateAgentIDs(context.Context, string, string) error {
@@ -671,6 +687,84 @@ func TestAdminInvocationsResponsesIncludeServerToolAndInput(t *testing.T) {
 		}
 		if !strings.Contains(w.Body.String(), `"input":{"issue":123,"verbose":true}`) {
 			t.Fatalf("expected input in detail response, got %s", w.Body.String())
+		}
+	})
+}
+
+// TestInvocationsByVMCUID tests the invocationsByVMCUID handler directly,
+// bypassing the API key middleware (same pattern as TestAgentIDsUsesAgentsTable).
+func TestInvocationsByVMCUID(t *testing.T) {
+	inv := invocation.InvocationResponse{
+		InvocationID: "inv_vm_1",
+		ServerName:   "amp",
+		ToolName:     "Read",
+		Status:       invocation.StatusSucceeded,
+	}
+	svc := &stubService{invoke: inv}
+
+	t.Run("returns invocations for known vm_cuid", func(t *testing.T) {
+		agents := &stubAgentsRepo{
+			byVMCUID: map[string]store.AgentRecord{
+				"mdl_abc": {ID: "agent_1", AgentIDs: `["worker-1"]`, Enabled: true},
+			},
+		}
+		h := NewHandler(svc, stubServerService{}, nil, nil, agents, nil, nil, nil)
+		req := httptest.NewRequest(http.MethodGet, "/models/mdl_abc/invocations", nil)
+		w := httptest.NewRecorder()
+		h.invocationsByVMCUID(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+		}
+		var resp invocation.InvocationListResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.Items) != 1 || resp.Items[0].InvocationID != "inv_vm_1" {
+			t.Fatalf("unexpected items: %+v", resp.Items)
+		}
+	})
+
+	t.Run("returns 404 for unknown vm_cuid", func(t *testing.T) {
+		agents := &stubAgentsRepo{} // byVMCUID is nil — stub returns no rows error
+		h := NewHandler(svc, stubServerService{}, nil, nil, agents, nil, nil, nil)
+		req := httptest.NewRequest(http.MethodGet, "/models/mdl_unknown/invocations", nil)
+		w := httptest.NewRecorder()
+		h.invocationsByVMCUID(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("returns empty list when agent has no agent_ids", func(t *testing.T) {
+		agents := &stubAgentsRepo{
+			byVMCUID: map[string]store.AgentRecord{
+				"mdl_noids": {ID: "agent_2", AgentIDs: `[]`, Enabled: true},
+			},
+		}
+		h := NewHandler(svc, stubServerService{}, nil, nil, agents, nil, nil, nil)
+		req := httptest.NewRequest(http.MethodGet, "/models/mdl_noids/invocations", nil)
+		w := httptest.NewRecorder()
+		h.invocationsByVMCUID(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+		}
+		var resp invocation.InvocationListResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.Items) != 0 || resp.Total != 0 {
+			t.Fatalf("expected empty list, got %+v", resp)
+		}
+	})
+
+	t.Run("returns 400 when vm_cuid missing from path", func(t *testing.T) {
+		agents := &stubAgentsRepo{}
+		h := NewHandler(svc, stubServerService{}, nil, nil, agents, nil, nil, nil)
+		req := httptest.NewRequest(http.MethodGet, "/models//invocations", nil)
+		w := httptest.NewRecorder()
+		h.invocationsByVMCUID(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
 		}
 	})
 }

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -108,7 +108,7 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	if got.AgentID == nil || *got.AgentID != "agent-007" {
 		t.Fatalf("expected invocation.agent_id=agent-007, got %v", got.AgentID)
 	}
-	list, err := svc.List(context.Background(), invocation.InvocationListFilter{AgentID: "agent-007", Limit: 10})
+	list, err := svc.List(context.Background(), invocation.InvocationListFilter{AgentIDs: []string{"agent-007"}, Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -30,15 +30,15 @@ type Approval struct {
 }
 
 type Invocation struct {
-	InvocationID   string     `json:"invocation_id"`
-	RequestID      *string    `json:"request_id,omitempty"`
-	IdempotencyKey *string    `json:"idempotency_key,omitempty"`
-	Tool           string     `json:"tool"`
-	Upstream       string     `json:"upstream"`
-	Status         Status     `json:"status"`
-	Approval       *Approval  `json:"approval"`
-	MatchedRuleID  *string    `json:"matched_rule_id,omitempty"`
-	AgentID        *string    `json:"agent_id,omitempty"`
+	InvocationID   string    `json:"invocation_id"`
+	RequestID      *string   `json:"request_id,omitempty"`
+	IdempotencyKey *string   `json:"idempotency_key,omitempty"`
+	Tool           string    `json:"tool"`
+	Upstream       string    `json:"upstream"`
+	Status         Status    `json:"status"`
+	Approval       *Approval `json:"approval"`
+	MatchedRuleID  *string   `json:"matched_rule_id,omitempty"`
+	AgentID        *string   `json:"agent_id,omitempty"`
 	// ClientName / ClientVersion mirror the MCP `initialize.clientInfo`
 	// the harness reported on the connection that issued this invocation.
 	// Captured even when auth is disabled (no agent_id) so the UI can still
@@ -67,8 +67,7 @@ type InvocationListFilter struct {
 	Server     string
 	Tool       string
 	Status     string
-	AgentID    string
-	AgentIDs   []string // when set, filters to invocations whose agent_id is in this list
+	AgentIDs   []string // filters to invocations whose agent_id is in this list
 	ClientName string
 	StartDate  *time.Time
 	EndDate    *time.Time
@@ -131,13 +130,13 @@ type ExternalExecutionUpdate struct {
 }
 
 type InvocationResponse struct {
-	InvocationID  string          `json:"invocation_id"`
-	ServerName    string          `json:"server_name"`
-	ToolName      string          `json:"tool_name"`
-	Status        Status          `json:"status"`
-	Approval      *Approval       `json:"approval"`
-	MatchedRuleID *string         `json:"matched_rule_id,omitempty"`
-	AgentID       *string         `json:"agent_id,omitempty"`
+	InvocationID  string    `json:"invocation_id"`
+	ServerName    string    `json:"server_name"`
+	ToolName      string    `json:"tool_name"`
+	Status        Status    `json:"status"`
+	Approval      *Approval `json:"approval"`
+	MatchedRuleID *string   `json:"matched_rule_id,omitempty"`
+	AgentID       *string   `json:"agent_id,omitempty"`
 	// AgentClientName / AgentClientVersion identify the MCP client software
 	// (e.g. "amp", "cursor", "claude-code") captured from the most recent
 	// `initialize` handshake associated with this AgentID. They describe the

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -68,6 +68,7 @@ type InvocationListFilter struct {
 	Tool       string
 	Status     string
 	AgentID    string
+	AgentIDs   []string // when set, filters to invocations whose agent_id is in this list
 	ClientName string
 	StartDate  *time.Time
 	EndDate    *time.Time

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -139,6 +139,20 @@ func (r *AgentsRepo) UpdateEnabled(ctx context.Context, id string, enabled bool)
 	return err
 }
 
+// GetByVMCUID returns the agent record for the given ValidMind inventory model
+// CUID. Returns sql.ErrNoRows when no match is found.
+func (r *AgentsRepo) GetByVMCUID(ctx context.Context, vmCUID string) (AgentRecord, error) {
+	query, args, err := r.sb.Select(agentColumns...).
+		From("agents").
+		Where(sq.Eq{"vm_cuid": vmCUID}).
+		Limit(1).
+		ToSql()
+	if err != nil {
+		return AgentRecord{}, err
+	}
+	return scanAgent(r.db.QueryRowContext(ctx, query, args...))
+}
+
 // GetByAgentID returns the agent record whose agent_ids JSON array contains the
 // given agentID string. Returns sql.ErrNoRows when no match is found.
 func (r *AgentsRepo) GetByAgentID(ctx context.Context, agentID string) (AgentRecord, error) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -660,6 +660,9 @@ func applyInvocationFilter(builder sq.SelectBuilder, countBuilder sq.SelectBuild
 	if filter.AgentID != "" {
 		builder = builder.Where(sq.Eq{"agent_id": filter.AgentID})
 		countBuilder = countBuilder.Where(sq.Eq{"agent_id": filter.AgentID})
+	} else if len(filter.AgentIDs) > 0 {
+		builder = builder.Where(sq.Eq{"agent_id": filter.AgentIDs})
+		countBuilder = countBuilder.Where(sq.Eq{"agent_id": filter.AgentIDs})
 	}
 	if filter.ClientName != "" {
 		builder = builder.Where(sq.Eq{"client_name": filter.ClientName})

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -256,28 +256,28 @@ func (r *ServerRepo) UpsertServer(ctx context.Context, upstream mcp.Upstream) er
 	now := time.Now().UTC()
 
 	updateMap := map[string]interface{}{
-		"mode":                 string(upstream.Mode),
-		"base_url":             emptyToNil(upstream.BaseURL),
-		"auth_token":           emptyToNil(upstream.AuthToken),
-		"timeout_seconds":      int(upstream.Timeout / time.Second),
-		"command":              emptyToNil(upstream.Command),
-		"args_json":            argsJSON,
-		"env_json":             envJSON,
-		"enabled":              boolToInt(upstream.Enabled),
-		"auth_type":            string(upstream.Status.AuthType),
-		"connection_status":    string(upstream.Status.ConnectionStatus),
-		"auth_status":          string(upstream.Status.AuthStatus),
-		"reauth_needed":        boolToInt(upstream.Status.ReauthNeeded),
-		"last_checked_at":      upstream.Status.LastCheckedAt,
-		"last_check_ok":        boolToInt(upstream.Status.LastCheckOK),
-		"last_error_summary":   emptyToNil(derefString(upstream.Status.LastErrorSummary)),
-		"action_required":      emptyToNil(derefString(upstream.Status.ActionRequired)),
-		"oauth_provider_id":    emptyToNil(upstream.OAuthProviderID),
-		"oauth_provider_label": emptyToNil(upstream.OAuthProviderLabel),
-		"oauth_authorize_url":  emptyToNil(upstream.OAuthAuthorizeURL),
-		"oauth_token_url":      emptyToNil(upstream.OAuthTokenURL),
-		"oauth_client_id":      emptyToNil(upstream.OAuthClientID),
-		"oauth_client_secret":  emptyToNil(upstream.OAuthClientSecret),
+		"mode":                      string(upstream.Mode),
+		"base_url":                  emptyToNil(upstream.BaseURL),
+		"auth_token":                emptyToNil(upstream.AuthToken),
+		"timeout_seconds":           int(upstream.Timeout / time.Second),
+		"command":                   emptyToNil(upstream.Command),
+		"args_json":                 argsJSON,
+		"env_json":                  envJSON,
+		"enabled":                   boolToInt(upstream.Enabled),
+		"auth_type":                 string(upstream.Status.AuthType),
+		"connection_status":         string(upstream.Status.ConnectionStatus),
+		"auth_status":               string(upstream.Status.AuthStatus),
+		"reauth_needed":             boolToInt(upstream.Status.ReauthNeeded),
+		"last_checked_at":           upstream.Status.LastCheckedAt,
+		"last_check_ok":             boolToInt(upstream.Status.LastCheckOK),
+		"last_error_summary":        emptyToNil(derefString(upstream.Status.LastErrorSummary)),
+		"action_required":           emptyToNil(derefString(upstream.Status.ActionRequired)),
+		"oauth_provider_id":         emptyToNil(upstream.OAuthProviderID),
+		"oauth_provider_label":      emptyToNil(upstream.OAuthProviderLabel),
+		"oauth_authorize_url":       emptyToNil(upstream.OAuthAuthorizeURL),
+		"oauth_token_url":           emptyToNil(upstream.OAuthTokenURL),
+		"oauth_client_id":           emptyToNil(upstream.OAuthClientID),
+		"oauth_client_secret":       emptyToNil(upstream.OAuthClientSecret),
 		"oauth_scopes":              emptyToNil(upstream.OAuthScopes),
 		"oauth_client_registration": emptyToNil(string(upstream.OAuthClientRegistration)),
 		"updated_at":                now,
@@ -657,10 +657,7 @@ func applyInvocationFilter(builder sq.SelectBuilder, countBuilder sq.SelectBuild
 		builder = builder.Where(sq.Eq{"status": filter.Status})
 		countBuilder = countBuilder.Where(sq.Eq{"status": filter.Status})
 	}
-	if filter.AgentID != "" {
-		builder = builder.Where(sq.Eq{"agent_id": filter.AgentID})
-		countBuilder = countBuilder.Where(sq.Eq{"agent_id": filter.AgentID})
-	} else if len(filter.AgentIDs) > 0 {
+	if len(filter.AgentIDs) > 0 {
 		builder = builder.Where(sq.Eq{"agent_id": filter.AgentIDs})
 		countBuilder = countBuilder.Where(sq.Eq{"agent_id": filter.AgentIDs})
 	}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -281,7 +281,7 @@ func TestInvocationRepo_AgentIDPersistedAndFilterable(t *testing.T) {
 	}
 
 	// Filter by agent_id returns only the matching row.
-	invs, total, err := repo.List(ctx, invocation.InvocationListFilter{AgentID: "agent-007", Limit: 10})
+	invs, total, err := repo.List(ctx, invocation.InvocationListFilter{AgentIDs: []string{"agent-007"}, Limit: 10})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}


### PR DESCRIPTION
# Pull Request Description

## What and why?

Adds a new API-key-protected endpoint `GET /models/<vm_cuid>/invocations` that allows the ValidMind backend to retrieve paginated invocation logs for a given ValidMind inventory model CUID.

The endpoint resolves the `vm_cuid` to the associated Atryum `agent_ids` via the agents store, then queries invocations with `WHERE agent_id IN (...)` across all linked runtime agents. This bridges the ValidMind model identity space to Atryum's runtime agent identity space without requiring a schema migration on the invocations table.

**Before:** No way to query invocations by ValidMind model identity.  
**After:** The ValidMind backend (and any API-key holder) can retrieve invocations for a model by CUID.

## How to test

1. Ensure an agent exists in Atryum with a `vm_cuid` set.
2. Call the endpoint with a valid API key:
   ```
   curl -H "X-API-Key: <key>" "http://localhost:8080/models/<vm_cuid>/invocations?offset=0&limit=20"
   ```
3. Verify a paginated response containing invocations for the linked agent(s) is returned.
4. With an unknown `vm_cuid`, verify a 404 is returned.
5. With a `vm_cuid` that has no linked agent IDs, verify an empty invocations list is returned.

## What needs special review?

- `invocationsByVMCUID` handler path parsing — the `vm_cuid` is extracted from the URL segment after `/models/` and before `/invocations`. Confirm the trimming logic handles edge cases.
- `applyInvocationFilter` in `sqlite.go` — the `AgentIDs` `IN` clause uses `sq.Eq{"agent_id": []string{...}}`, which squirrel translates to `IN (...)`. Verify this is correct for 0-length and 1-length slices.

## Dependencies, breaking changes, and deployment notes

- No database schema changes. The `vm_cuid` lookup is done at query time via the existing `agents` table.
- No breaking changes to existing endpoints.
- Requires the calling service (ValidMind backend) to have a valid Atryum API key configured.

## Release notes

Internal infrastructure change; no user-facing release notes required.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

Made with [Cursor](https://cursor.com)