### PR TITLE
[codex] Support no-config ValidMind API credential startup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,7 @@
 set shell := ["bash", "-cu"]
 
 config := "./atryum.toml"
+frontend_dir := "../frontend"
 
 # List justfile targets
 default:
@@ -33,6 +34,35 @@ fmt:
 
 # Go fmt and test
 check: fmt test
+
+# Build local atryum binary with the currently embedded web assets
+build:
+	CGO_ENABLED=0 go build -o ./atryum ./cmd/atryum
+
+# Build local production-like atryum binary with the sibling frontend embedded
+build-prod:
+	#!/usr/bin/env bash
+	set -euo pipefail
+	repo_dir="$(pwd)"
+	frontend_dir="{{frontend_dir}}"
+	tmp_dir="$(mktemp -d)"
+	cleanup() {
+	  rm -rf "$tmp_dir"
+	}
+	trap cleanup EXIT
+
+	(cd "$frontend_dir" && npm run build:atryum)
+	mkdir -p "$tmp_dir/atryum"
+	rsync -a --delete \
+	  --exclude .git \
+	  --exclude /atryum \
+	  --exclude /atryum.db \
+	  "$repo_dir/" "$tmp_dir/atryum/"
+	rm -rf "$tmp_dir/atryum/internal/api/web"
+	mkdir -p "$tmp_dir/atryum/internal/api/web"
+	cp -R "$frontend_dir/build-atryum/." "$tmp_dir/atryum/internal/api/web/"
+	mv "$tmp_dir/atryum/internal/api/web/atryum.html" "$tmp_dir/atryum/internal/api/web/index.html"
+	(cd "$tmp_dir/atryum" && CGO_ENABLED=0 go build -o "$repo_dir/atryum" ./cmd/atryum)
 
 # Run atryum process locally
 run:

--- a/README.md
+++ b/README.md
@@ -108,9 +108,8 @@ connection_timeout_seconds = 5
 ```
 
 The same values can be supplied with environment variables, which override
-TOML: `ATRYUM_BACKEND_BASE_URL`, `ATRYUM_MACHINE_KEY`,
-`ATRYUM_MACHINE_SECRET`, and
-`ATRYUM_BACKEND_CONNECTION_TIMEOUT_SECONDS`.
+TOML: `VM_BASE_URL`, `VM_MACHINE_KEY`, `VM_MACHINE_SECRET`, and
+`VM_CONNECTION_TIMEOUT_SECONDS`.
 
 When `backend.base_url` is empty, the check is skipped for local standalone
 runs. When it is set, startup fails if credentials are missing or the backend

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -16,17 +16,31 @@ log_level = "info"
 
 [backend]
 # Optional ValidMind backend connection check. When base_url is set, Atryum
-# verifies these machine-user credentials at startup by calling:
+# verifies credentials at startup by calling:
 # GET /internal/v1/atryum/connection
 #
+# Machine-user credentials are preferred when configured. If machine_key and
+# machine_secret are both empty, Atryum uses normal user API credentials instead.
+# User API credentials are bound to a single organization, so the Settings UI
+# will use that organization automatically.
+#
+# base_url defaults to https://app.prod.validmind.ai/ when omitted or when no
+# TOML file is present. Set base_url = "" only when you want to disable the
+# ValidMind backend integration entirely.
+#
 # Environment variables override these TOML values:
-# ATRYUM_BACKEND_BASE_URL
-# ATRYUM_MACHINE_KEY
-# ATRYUM_MACHINE_SECRET
-# ATRYUM_BACKEND_CONNECTION_TIMEOUT_SECONDS
-base_url = ""
+# VM_BASE_URL
+# VM_MACHINE_KEY
+# VM_MACHINE_SECRET
+# VM_API_KEY
+# VM_API_SECRET
+# VM_CONNECTION_TIMEOUT_SECONDS
+# VM_EVALUATE_TIMEOUT_SECONDS
+base_url = "https://app.prod.validmind.ai/"
 machine_key = ""
 machine_secret = ""
+api_key = ""
+api_secret = ""
 connection_timeout_seconds = 5
 
 [defaults]

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -43,7 +43,11 @@ func main() {
 		if err != nil {
 			log.Fatalf("backend connection check: %v", err)
 		}
-		log.Printf("backend connection verified for service=%s machine_user_cuid=%s", resp.ServiceName, resp.MachineUserCUID)
+		if backendClient.AuthMode() == "api_key" {
+			log.Printf("backend connection verified with API credentials for org=%s (%s)", resp.OrgCUID, resp.OrgName)
+		} else {
+			log.Printf("backend connection verified for service=%s machine_user_cuid=%s", resp.ServiceName, resp.MachineUserCUID)
+		}
 	} else {
 		log.Printf("backend connection check skipped (backend.base_url not configured)")
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1933,8 +1933,10 @@ type VMOrgItem struct {
 }
 
 type VMOrgListResponse struct {
-	Items []VMOrgItem `json:"items"`
-	Total int         `json:"total"`
+	Items     []VMOrgItem `json:"items"`
+	Total     int         `json:"total"`
+	AuthMode  string      `json:"auth_mode,omitempty"`
+	SingleOrg bool        `json:"single_org,omitempty"`
 }
 
 type VMRecordTypeItem struct {
@@ -1977,7 +1979,7 @@ func (h *Handler) adminVMOrganizations(w http.ResponseWriter, r *http.Request) {
 	for _, o := range resp.Items {
 		items = append(items, VMOrgItem{CUID: o.CUID, Name: o.Name})
 	}
-	writeJSON(w, http.StatusOK, VMOrgListResponse{Items: items, Total: len(items)})
+	writeJSON(w, http.StatusOK, VMOrgListResponse{Items: items, Total: len(items), AuthMode: resp.AuthMode, SingleOrg: resp.SingleOrg})
 }
 
 func (h *Handler) adminVMRecordTypes(w http.ResponseWriter, r *http.Request) {

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -23,8 +23,11 @@ const customFieldsPath = "/internal/v1/atryum/custom-fields"
 
 type ConnectionResponse struct {
 	OK              bool   `json:"ok"`
+	AuthMode        string `json:"auth_mode"`
 	MachineUserCUID string `json:"machine_user_cuid"`
 	ServiceName     string `json:"service_name"`
+	OrgCUID         string `json:"org_cuid"`
+	OrgName         string `json:"org_name"`
 }
 
 // Agent represents an inventory model record returned by the backend.
@@ -54,10 +57,11 @@ type ModelConfigsResponse struct {
 }
 
 type Client struct {
-	baseURL       string
-	machineKey    string
-	machineSecret string
-	httpClient    *http.Client
+	baseURL    string
+	authMode   string
+	authKey    string
+	authSecret string
+	httpClient *http.Client
 	// evaluateClient uses a longer timeout suitable for LLM completion calls.
 	evaluateClient *http.Client
 }
@@ -67,8 +71,28 @@ func NewClient(cfg config.BackendConfig) (*Client, error) {
 	if baseURL == "" {
 		return nil, nil
 	}
-	if strings.TrimSpace(cfg.MachineKey) == "" || strings.TrimSpace(cfg.MachineSecret) == "" {
-		return nil, fmt.Errorf("backend machine credentials are required when backend.base_url is configured")
+	machineKey := strings.TrimSpace(cfg.MachineKey)
+	machineSecret := strings.TrimSpace(cfg.MachineSecret)
+	apiKey := strings.TrimSpace(cfg.APIKey)
+	apiSecret := strings.TrimSpace(cfg.APISecret)
+	authMode := ""
+	authKey := ""
+	authSecret := ""
+	switch {
+	case machineKey != "" && machineSecret != "":
+		authMode = "machine_user"
+		authKey = machineKey
+		authSecret = machineSecret
+	case machineKey != "" || machineSecret != "":
+		return nil, fmt.Errorf("backend machine credentials require both machine_key and machine_secret")
+	case apiKey != "" && apiSecret != "":
+		authMode = "api_key"
+		authKey = apiKey
+		authSecret = apiSecret
+	case apiKey != "" || apiSecret != "":
+		return nil, fmt.Errorf("backend API credentials require both api_key and api_secret")
+	default:
+		return nil, fmt.Errorf("backend credentials are required when backend.base_url is configured")
 	}
 	if _, err := url.ParseRequestURI(baseURL); err != nil {
 		return nil, fmt.Errorf("backend base_url is invalid: %w", err)
@@ -76,11 +100,29 @@ func NewClient(cfg config.BackendConfig) (*Client, error) {
 
 	return &Client{
 		baseURL:        strings.TrimRight(baseURL, "/"),
-		machineKey:     strings.TrimSpace(cfg.MachineKey),
-		machineSecret:  strings.TrimSpace(cfg.MachineSecret),
+		authMode:       authMode,
+		authKey:        authKey,
+		authSecret:     authSecret,
 		httpClient:     &http.Client{Timeout: time.Duration(cfg.ConnectionTimeoutSecs) * time.Second},
 		evaluateClient: &http.Client{Timeout: time.Duration(cfg.EvaluateTimeoutSecs) * time.Second},
 	}, nil
+}
+
+func (c *Client) AuthMode() string {
+	if c == nil {
+		return ""
+	}
+	return c.authMode
+}
+
+func (c *Client) setAuthHeaders(req *http.Request) {
+	if c.authMode == "api_key" {
+		req.Header.Set("X-API-KEY", c.authKey)
+		req.Header.Set("X-API-SECRET", c.authSecret)
+		return
+	}
+	req.Header.Set("X-MACHINE-KEY", c.authKey)
+	req.Header.Set("X-MACHINE-SECRET", c.authSecret)
 }
 
 // FetchAgents retrieves active inventory model agents from the backend for the
@@ -92,7 +134,9 @@ func (c *Client) FetchAgents(ctx context.Context, orgCUID, agentRecordTypeSlug s
 		return AgentsResponse{}, fmt.Errorf("build agents URL: %w", err)
 	}
 	q := u.Query()
-	q.Set("org_cuid", orgCUID)
+	if orgCUID != "" {
+		q.Set("org_cuid", orgCUID)
+	}
 	q.Set("primary_record_type_slug", agentRecordTypeSlug)
 	u.RawQuery = q.Encode()
 
@@ -100,9 +144,10 @@ func (c *Client) FetchAgents(ctx context.Context, orgCUID, agentRecordTypeSlug s
 	if err != nil {
 		return AgentsResponse{}, fmt.Errorf("build agents request: %w", err)
 	}
-	req.Header.Set("X-MACHINE-KEY", c.machineKey)
-	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
-	req.Header.Set("X-Org-CUID", orgCUID)
+	c.setAuthHeaders(req)
+	if orgCUID != "" {
+		req.Header.Set("X-Org-CUID", orgCUID)
+	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)
@@ -128,8 +173,7 @@ func (c *Client) FetchModelConfigs(ctx context.Context) (ModelConfigsResponse, e
 	if err != nil {
 		return ModelConfigsResponse{}, fmt.Errorf("build model-configs request: %w", err)
 	}
-	req.Header.Set("X-MACHINE-KEY", c.machineKey)
-	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	c.setAuthHeaders(req)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)
@@ -157,8 +201,10 @@ type VMOrg struct {
 
 // VMOrgsResponse is the response envelope for the organizations endpoint.
 type VMOrgsResponse struct {
-	Items []VMOrg `json:"items"`
-	Total int     `json:"total"`
+	Items     []VMOrg `json:"items"`
+	Total     int     `json:"total"`
+	AuthMode  string  `json:"auth_mode,omitempty"`
+	SingleOrg bool    `json:"single_org,omitempty"`
 }
 
 // VMRecordType represents a primary record type returned by the backend discovery API.
@@ -193,8 +239,7 @@ func (c *Client) FetchOrganizations(ctx context.Context) (VMOrgsResponse, error)
 	if err != nil {
 		return VMOrgsResponse{}, fmt.Errorf("build organizations request: %w", err)
 	}
-	req.Header.Set("X-MACHINE-KEY", c.machineKey)
-	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	c.setAuthHeaders(req)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)
@@ -221,16 +266,19 @@ func (c *Client) FetchPrimaryRecordTypes(ctx context.Context, orgCUID string) (V
 		return VMRecordTypesResponse{}, fmt.Errorf("build primary-record-types URL: %w", err)
 	}
 	q := u.Query()
-	q.Set("org_cuid", orgCUID)
+	if orgCUID != "" {
+		q.Set("org_cuid", orgCUID)
+	}
 	u.RawQuery = q.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return VMRecordTypesResponse{}, fmt.Errorf("build primary-record-types request: %w", err)
 	}
-	req.Header.Set("X-MACHINE-KEY", c.machineKey)
-	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
-	req.Header.Set("X-Org-CUID", orgCUID)
+	c.setAuthHeaders(req)
+	if orgCUID != "" {
+		req.Header.Set("X-Org-CUID", orgCUID)
+	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)
@@ -258,7 +306,9 @@ func (c *Client) FetchCustomFields(ctx context.Context, orgCUID, primaryRecordTy
 		return VMCustomFieldsResponse{}, fmt.Errorf("build custom-fields URL: %w", err)
 	}
 	q := u.Query()
-	q.Set("org_cuid", orgCUID)
+	if orgCUID != "" {
+		q.Set("org_cuid", orgCUID)
+	}
 	if primaryRecordTypeSlug != "" {
 		q.Set("primary_record_type_slug", primaryRecordTypeSlug)
 	}
@@ -268,9 +318,10 @@ func (c *Client) FetchCustomFields(ctx context.Context, orgCUID, primaryRecordTy
 	if err != nil {
 		return VMCustomFieldsResponse{}, fmt.Errorf("build custom-fields request: %w", err)
 	}
-	req.Header.Set("X-MACHINE-KEY", c.machineKey)
-	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
-	req.Header.Set("X-Org-CUID", orgCUID)
+	c.setAuthHeaders(req)
+	if orgCUID != "" {
+		req.Header.Set("X-Org-CUID", orgCUID)
+	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)
@@ -326,8 +377,7 @@ func (c *Client) EvaluateToolCall(ctx context.Context, req EvaluateRequest) (Eva
 	if err != nil {
 		return EvaluateResponse{}, fmt.Errorf("build evaluate request: %w", err)
 	}
-	httpReq.Header.Set("X-MACHINE-KEY", c.machineKey)
-	httpReq.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	c.setAuthHeaders(httpReq)
 	if req.OrgCUID != "" {
 		httpReq.Header.Set("X-Org-CUID", req.OrgCUID)
 	}
@@ -380,8 +430,7 @@ func (c *Client) SummarizeInvocation(ctx context.Context, req SummarizeInvocatio
 	if err != nil {
 		return SummarizeInvocationResponse{}, fmt.Errorf("build summarize-invocation request: %w", err)
 	}
-	httpReq.Header.Set("X-MACHINE-KEY", c.machineKey)
-	httpReq.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	c.setAuthHeaders(httpReq)
 	if req.OrgCUID != "" {
 		httpReq.Header.Set("X-Org-CUID", req.OrgCUID)
 	}
@@ -411,8 +460,7 @@ func (c *Client) CheckConnection(ctx context.Context) (ConnectionResponse, error
 	if err != nil {
 		return ConnectionResponse{}, fmt.Errorf("build backend connection request: %w", err)
 	}
-	req.Header.Set("X-MACHINE-KEY", c.machineKey)
-	req.Header.Set("X-MACHINE-SECRET", c.machineSecret)
+	c.setAuthHeaders(req)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/backend/client_test.go
+++ b/internal/backend/client_test.go
@@ -27,6 +27,22 @@ func TestNewClientRequiresCredentialsWhenBackendConfigured(t *testing.T) {
 	}
 }
 
+func TestNewClientPrefersMachineCredentialsOverAPIKeyCredentials(t *testing.T) {
+	client, err := NewClient(config.BackendConfig{
+		BaseURL:       "http://backend.test",
+		MachineKey:    "machine-key",
+		MachineSecret: "machine-secret",
+		APIKey:        "api-key",
+		APISecret:     "api-secret",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if client.AuthMode() != "machine_user" {
+		t.Fatalf("AuthMode = %q", client.AuthMode())
+	}
+}
+
 func TestCheckConnectionSendsMachineCredentials(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != connectionPath {
@@ -57,6 +73,40 @@ func TestCheckConnectionSendsMachineCredentials(t *testing.T) {
 		t.Fatalf("CheckConnection: %v", err)
 	}
 	if !resp.OK || resp.MachineUserCUID != "cmu123" || resp.ServiceName != "atryum" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+}
+
+func TestCheckConnectionSendsAPIKeyCredentialsWhenMachineCredentialsAbsent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-API-KEY"); got != "api-key" {
+			t.Errorf("X-API-KEY = %q", got)
+		}
+		if got := r.Header.Get("X-API-SECRET"); got != "api-secret" {
+			t.Errorf("X-API-SECRET = %q", got)
+		}
+		if got := r.Header.Get("X-MACHINE-KEY"); got != "" {
+			t.Errorf("X-MACHINE-KEY = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"auth_mode":"api_key","org_cuid":"org123","org_name":"Demo Org"}`))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(config.BackendConfig{
+		BaseURL:   server.URL,
+		APIKey:    "api-key",
+		APISecret: "api-secret",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	resp, err := client.CheckConnection(context.Background())
+	if err != nil {
+		t.Fatalf("CheckConnection: %v", err)
+	}
+	if resp.AuthMode != "api_key" || resp.OrgCUID != "org123" {
 		t.Fatalf("unexpected response: %+v", resp)
 	}
 }

--- a/internal/config/backend_test.go
+++ b/internal/config/backend_test.go
@@ -3,10 +3,12 @@ package config
 import "testing"
 
 func TestBackendConfigApplyEnvOverridesToml(t *testing.T) {
-	t.Setenv("ATRYUM_BACKEND_BASE_URL", "https://backend.example")
-	t.Setenv("ATRYUM_MACHINE_KEY", "env-key")
-	t.Setenv("ATRYUM_MACHINE_SECRET", "env-secret")
-	t.Setenv("ATRYUM_BACKEND_CONNECTION_TIMEOUT_SECONDS", "9")
+	t.Setenv("VM_BASE_URL", "https://backend.example")
+	t.Setenv("VM_MACHINE_KEY", "env-key")
+	t.Setenv("VM_MACHINE_SECRET", "env-secret")
+	t.Setenv("VM_API_KEY", "env-api-key")
+	t.Setenv("VM_API_SECRET", "env-api-secret")
+	t.Setenv("VM_CONNECTION_TIMEOUT_SECONDS", "9")
 
 	cfg := BackendConfig{
 		BaseURL:               "https://toml.example",
@@ -25,6 +27,12 @@ func TestBackendConfigApplyEnvOverridesToml(t *testing.T) {
 	}
 	if cfg.MachineSecret != "env-secret" {
 		t.Fatalf("MachineSecret = %q", cfg.MachineSecret)
+	}
+	if cfg.APIKey != "env-api-key" {
+		t.Fatalf("APIKey = %q", cfg.APIKey)
+	}
+	if cfg.APISecret != "env-api-secret" {
+		t.Fatalf("APISecret = %q", cfg.APISecret)
 	}
 	if cfg.ConnectionTimeoutSecs != 9 {
 		t.Fatalf("ConnectionTimeoutSecs = %d", cfg.ConnectionTimeoutSecs)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,8 @@ import (
 	"atryum/internal/auth"
 )
 
+const DefaultBackendBaseURL = "https://app.prod.validmind.ai/"
+
 type Config struct {
 	Server    ServerConfig     `toml:"server"`
 	Backend   BackendConfig    `toml:"backend"`
@@ -32,6 +34,8 @@ type BackendConfig struct {
 	BaseURL               string `toml:"base_url"`
 	MachineKey            string `toml:"machine_key"`
 	MachineSecret         string `toml:"machine_secret"`
+	APIKey                string `toml:"api_key"`
+	APISecret             string `toml:"api_secret"`
 	ConnectionTimeoutSecs int    `toml:"connection_timeout_seconds"`
 	// EvaluateTimeoutSecs is the HTTP timeout for /evaluate calls, which invoke
 	// an LLM and can take much longer than a normal API round-trip. Defaults to
@@ -92,6 +96,7 @@ func Load(path string) (Config, error) {
 			LogLevel:     "info",
 		},
 		Backend: BackendConfig{
+			BaseURL:               DefaultBackendBaseURL,
 			ConnectionTimeoutSecs: 5,
 		},
 		Defaults: DefaultsConfig{
@@ -99,21 +104,30 @@ func Load(path string) (Config, error) {
 		},
 	}
 	_, err := toml.DecodeFile(path, &cfg)
+	if err != nil && !os.IsNotExist(err) {
+		return cfg, err
+	}
 	cfg.Backend.ApplyEnv()
-	return cfg, err
+	return cfg, nil
 }
 
 func (c *BackendConfig) ApplyEnv() {
-	if value := os.Getenv("ATRYUM_BACKEND_BASE_URL"); value != "" {
+	if value := os.Getenv("VM_BASE_URL"); value != "" {
 		c.BaseURL = value
 	}
-	if value := os.Getenv("ATRYUM_MACHINE_KEY"); value != "" {
+	if value := os.Getenv("VM_MACHINE_KEY"); value != "" {
 		c.MachineKey = value
 	}
-	if value := os.Getenv("ATRYUM_MACHINE_SECRET"); value != "" {
+	if value := os.Getenv("VM_MACHINE_SECRET"); value != "" {
 		c.MachineSecret = value
 	}
-	if value := os.Getenv("ATRYUM_BACKEND_CONNECTION_TIMEOUT_SECONDS"); value != "" {
+	if value := os.Getenv("VM_API_KEY"); value != "" {
+		c.APIKey = value
+	}
+	if value := os.Getenv("VM_API_SECRET"); value != "" {
+		c.APISecret = value
+	}
+	if value := os.Getenv("VM_CONNECTION_TIMEOUT_SECONDS"); value != "" {
 		if parsed, err := strconv.Atoi(value); err == nil {
 			c.ConnectionTimeoutSecs = parsed
 		}
@@ -121,7 +135,7 @@ func (c *BackendConfig) ApplyEnv() {
 	if c.ConnectionTimeoutSecs <= 0 {
 		c.ConnectionTimeoutSecs = 5
 	}
-	if value := os.Getenv("ATRYUM_BACKEND_EVALUATE_TIMEOUT_SECONDS"); value != "" {
+	if value := os.Getenv("VM_EVALUATE_TIMEOUT_SECONDS"); value != "" {
 		if parsed, err := strconv.Atoi(value); err == nil {
 			c.EvaluateTimeoutSecs = parsed
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,3 +48,28 @@ connection_timeout_seconds = 7
 		t.Fatalf("Backend.ConnectionTimeoutSecs = %d", cfg.Backend.ConnectionTimeoutSecs)
 	}
 }
+
+func TestLoadMissingConfigUsesDefaultsAndEnv(t *testing.T) {
+	t.Setenv("VM_API_KEY", "env-api-key")
+	t.Setenv("VM_API_SECRET", "env-api-secret")
+
+	cfg, err := Load(filepath.Join(t.TempDir(), "missing.toml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Server.ListenAddr != ":8080" {
+		t.Fatalf("ListenAddr = %q", cfg.Server.ListenAddr)
+	}
+	if cfg.Server.DatabasePath != "./atryum.db" {
+		t.Fatalf("DatabasePath = %q", cfg.Server.DatabasePath)
+	}
+	if cfg.Backend.BaseURL != DefaultBackendBaseURL {
+		t.Fatalf("Backend.BaseURL = %q", cfg.Backend.BaseURL)
+	}
+	if cfg.Backend.APIKey != "env-api-key" {
+		t.Fatalf("Backend.APIKey = %q", cfg.Backend.APIKey)
+	}
+	if cfg.Backend.APISecret != "env-api-secret" {
+		t.Fatalf("Backend.APISecret = %q", cfg.Backend.APISecret)
+	}
+}


### PR DESCRIPTION
## Summary

- Support ValidMind user API credentials in Atryum while still preferring machine-user credentials when present.
- Allow startup without an `atryum.toml` by using code defaults, including the prod ValidMind base URL.
- Rename ValidMind-related env vars to `VM_*` and add local build recipes for quick and production-like binaries.

## Impact

`VM_API_KEY=... VM_API_SECRET=... ./atryum` can run with no config file, use local SQLite, serve the embedded UI, and connect to the prod ValidMind backend using org-bound API credentials.

## Validation

- `go test ./...`
- `just build && ./atryum -h`
- `just build-prod && ./atryum -h`
