### PR TITLE
Set atryum.org custom domain for GitHub Pages

### DIFF
--- a/website/CNAME
+++ b/website/CNAME
@@ -1,0 +1,1 @@
+atryum.org


### PR DESCRIPTION
# Set atryum.org custom domain for GitHub Pages

Adds `website/CNAME` (`atryum.org`) so the GitHub Actions Pages deploy
keeps the custom domain. This was missed from PR #37.

## Manual steps after merge

1. Settings → Pages → Source: GitHub Actions (if not already set).
2. Add apex DNS A/AAAA records for atryum.org pointing at GitHub Pages IPs.
3. Tick Enforce HTTPS once the cert provisions.
