### PR TITLE
External invocations: self-declared agent_id + demo-friendly Keycloak…

### DIFF
--- a/examples/amp-plugin/README.md
+++ b/examples/amp-plugin/README.md
@@ -71,6 +71,29 @@ with Approve / Deny buttons.
 | `ATRYUM_URL`      | `http://localhost:8080`| base URL of the atryum server                               |
 | `ATRYUM_SOURCE`   | `amp`                  | label shown as the "upstream" column in the atryum UI       |
 | `ATRYUM_POLL_MS`  | `2000`                 | how often the plugin polls atryum while awaiting approval   |
+| `ATRYUM_AGENT_ID` | _(empty)_              | self-declared agent identifier; matched against Agent Record `agent_ids` (see below) |
+
+## Tagging invocations to an Agent Record
+
+By default the plugin sends no agent identity, so invocations show up in
+the UI unattached to any Agent Record. To get the agent column populated
+and to make agent-scoped approval rules apply:
+
+1. In the Atryum UI, open an Agent Record (or create one) and add a string
+   to its **Agent IDs** field — e.g. `amp-local`, `amp-alice`, or any
+   stable identifier you choose.
+2. Export the same string in your shell:
+
+   ```sh
+   export ATRYUM_AGENT_ID=amp-local
+   ```
+
+3. Re-run amp. Future invocations carry `agent_id: "amp-local"`; Atryum
+   looks it up via `agents.agent_ids @> ["amp-local"]` and tags the row.
+
+This is a **self-declared** identity — anyone with network access to the
+Atryum API can claim any agent id. For verified identity, run Atryum
+behind OAuth and authenticate the plugin instead.
 
 ## API used
 

--- a/examples/amp-plugin/atryum.ts
+++ b/examples/amp-plugin/atryum.ts
@@ -7,10 +7,16 @@
 // tool — amp does. Atryum is the approval mediator and audit log.
 //
 // Configure via env:
-//   ATRYUM_URL    base URL of the atryum server, default http://localhost:8080
-//   ATRYUM_SOURCE label that shows up in the atryum UI as the "upstream"
-//                 column, default "amp"
-//   ATRYUM_POLL_MS poll interval in ms while waiting for approval, default 2000
+//   ATRYUM_URL       base URL of the atryum server, default http://localhost:8080
+//   ATRYUM_SOURCE    label that shows up in the atryum UI as the "upstream"
+//                    column, default "amp"
+//   ATRYUM_POLL_MS   poll interval in ms while waiting for approval, default 2000
+//   ATRYUM_AGENT_ID  stable agent identifier sent to atryum as the
+//                    invocation's `agent_id`. When this string is listed in
+//                    an Agent Record's `agent_ids` array in the atryum UI,
+//                    invocations from this plugin will be tagged to that
+//                    Agent Record (so agent-scoped approval rules apply).
+//                    Default: empty (no agent tagging).
 
 import type { PluginAPI } from "@ampcode/plugin";
 
@@ -26,6 +32,11 @@ const THREAD_ID = process.env.THREAD_ID || "";
 const CLIENT_NAME = process.env.ATRYUM_CLIENT_NAME || SOURCE;
 const CLIENT_VERSION =
   process.env.ATRYUM_CLIENT_VERSION || process.env.AMP_VERSION || "";
+// Self-declared agent identity. Atryum resolves the Agent Record via the
+// agents.agent_ids JSON array, so any string the user has added to an
+// Agent Record (e.g. "amp-local", "amp-alice", a service account id, etc.)
+// will work. Not authenticated — for verified identity use OAuth.
+const AGENT_ID = process.env.ATRYUM_AGENT_ID || "";
 
 type InvocationStatus =
   | "received"
@@ -74,6 +85,7 @@ async function submit(
       thread_id: THREAD_ID || undefined,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,
+      agent_id: AGENT_ID || undefined,
     }),
   });
   if (!res.ok) {

--- a/examples/shared-agent-hook/atryum-hook.mjs
+++ b/examples/shared-agent-hook/atryum-hook.mjs
@@ -21,6 +21,12 @@ const HOST = (process.env.ATRYUM_HOOK_HOST || "claude").toLowerCase();
 const STATE_DIR =
   process.env.ATRYUM_STATE_DIR ||
   path.join(os.homedir(), ".atryum", "agent-hook-state");
+// Self-declared agent identity sent to Atryum as the invocation `agent_id`.
+// When this string is listed in an Agent Record's `agent_ids` array in the
+// Atryum UI, invocations from this hook get tagged to that Agent Record
+// (so agent-scoped approval rules apply). Not authenticated — for verified
+// identity use OAuth. Default: empty (no agent tagging).
+const AGENT_ID = process.env.ATRYUM_AGENT_ID || "";
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -128,6 +134,7 @@ async function submit(event) {
       input,
       request_id: id,
       thread_id: event.session_id || event.sessionId || undefined,
+      agent_id: AGENT_ID || undefined,
     }),
   });
   if (!res.ok) {

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -219,6 +219,60 @@ func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 	}
 }
 
+// External (non-MCP) callers like the amp-plugin example don't run behind
+// the auth middleware today, so there is no identity in context. They can
+// instead self-declare via the new `agent_id` field on ExternalSubmitRequest,
+// which Submit must promote onto the invocation row so the Agent column /
+// agents.agent_ids resolution / agent-scoped rule matching all light up.
+// A verified OAuth identity in context still wins when both are present.
+func TestExternalSubmitUsesSelfDeclaredAgentIDWhenNoAuthIdentity(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	svc := invocation.NewService(
+		store.NewInvocationRepo(db), store.NewEventRepo(db), nil,
+		nil, policy.AlwaysApproveProvider{},
+		5*time.Second, nil, nil, nil, nil,
+	)
+
+	// No auth identity in context — self-declared agent_id should be used.
+	resp, err := svc.Submit(context.Background(), invocation.ExternalSubmitRequest{
+		Source:  "amp",
+		Tool:    "bash",
+		Input:   map[string]any{"cmd": "ls"},
+		AgentID: "amp-local",
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if resp.AgentID == nil || *resp.AgentID != "amp-local" {
+		t.Fatalf("expected agent_id=amp-local from body, got %v", resp.AgentID)
+	}
+
+	// Verified OAuth identity in context wins over the body, so a hostile
+	// caller can't claim someone else's agent_id when auth is enforced.
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{
+		AgentID: "verified-007", Issuer: "https://idp.test",
+	})
+	resp2, err := svc.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source:  "amp",
+		Tool:    "bash",
+		Input:   map[string]any{"cmd": "ls"},
+		AgentID: "spoofed-id",
+	})
+	if err != nil {
+		t.Fatalf("Submit with auth: %v", err)
+	}
+	if resp2.AgentID == nil || *resp2.AgentID != "verified-007" {
+		t.Fatalf("expected verified agent_id to win over body; got %v", resp2.AgentID)
+	}
+}
+
 func eventsAsJSON(items []invocation.EventResponse) string {
 	b, _ := json.Marshal(items)
 	return string(b)

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -116,6 +116,13 @@ type ExternalSubmitRequest struct {
 	// doubles as the approval-rule matching key.
 	ClientName    string `json:"client_name,omitempty"`
 	ClientVersion string `json:"client_version,omitempty"`
+	// AgentID is a self-declared runtime agent identifier (e.g. an amp
+	// session id, or a stable harness identity). When no OAuth identity is
+	// attached to the request (the external endpoint is anonymous), this
+	// field is used to tag the invocation and to resolve the Agent Record
+	// via the agents.agent_ids array. A verified OAuth identity in the
+	// request context always wins. Optional.
+	AgentID string `json:"agent_id,omitempty"`
 }
 
 // ExternalExecutionUpdate is sent by the external executor to report on a

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -719,7 +719,15 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 		return InvocationResponse{}, err
 	}
 	// Evaluate rules against (source, tool, user) — same logic as Invoke.
+	// Verified OAuth identity (when the external route runs behind auth
+	// middleware) wins. Otherwise fall back to the self-declared agent_id
+	// in the body — useful for plugin-style callers that aren't doing
+	// OAuth but still want their invocations tagged & matched to an
+	// Agent Record via agents.agent_ids.
 	agentID := auth.AgentIDFromContext(ctx)
+	if agentID == "" {
+		agentID = strings.TrimSpace(req.AgentID)
+	}
 	agentRec := s.resolveAgentRecord(ctx, agentID)
 
 	now := time.Now().UTC()

--- a/keycloak/setup-realm.sh
+++ b/keycloak/setup-realm.sh
@@ -36,6 +36,16 @@ SCOPE_NAME="${SCOPE_NAME:-atryum:mcp}"
 AUDIENCE="${AUDIENCE:-atryum}"
 REDIRECT_URI="${REDIRECT_URI:-http://localhost:8080/*}"
 
+# Token lifespans (seconds). Demo-friendly defaults: 24h access tokens,
+# 30-day sessions. Stock Keycloak defaults (5min access / 30min idle /
+# 10hr max) are what causes OAuth-based MCP clients (opencode, Claude Code)
+# to "expire fast" in dev. Override via env if you want different values.
+ACCESS_TOKEN_LIFESPAN="${ACCESS_TOKEN_LIFESPAN:-86400}"
+SSO_SESSION_IDLE_TIMEOUT="${SSO_SESSION_IDLE_TIMEOUT:-2592000}"
+SSO_SESSION_MAX_LIFESPAN="${SSO_SESSION_MAX_LIFESPAN:-2592000}"
+CLIENT_SESSION_IDLE_TIMEOUT="${CLIENT_SESSION_IDLE_TIMEOUT:-86400}"
+CLIENT_SESSION_MAX_LIFESPAN="${CLIENT_SESSION_MAX_LIFESPAN:-2592000}"
+
 need() { command -v "$1" >/dev/null 2>&1 || { echo "missing: $1" >&2; exit 1; }; }
 need curl
 need jq
@@ -71,6 +81,27 @@ else
 fi
 
 REALM_ID=$(api GET "/${REALM}" | jq -r .id)
+
+# Step 2b — UI: Realm Settings → Sessions / Tokens
+#   Tune token & session lifespans for demos. Stock Keycloak defaults
+#   (accessTokenLifespan=300s) are why OAuth MCP clients felt like they
+#   "expired" after 5 minutes. With these settings a single auth lasts
+#   ~30 days, with the access token itself good for 24h before refresh.
+log "Tuning realm token/session lifespans (access=${ACCESS_TOKEN_LIFESPAN}s, sso_max=${SSO_SESSION_MAX_LIFESPAN}s)..."
+api PUT "/${REALM}" -d "$(cat <<EOF
+{
+  "realm": "${REALM}",
+  "accessTokenLifespan": ${ACCESS_TOKEN_LIFESPAN},
+  "accessTokenLifespanForImplicitFlow": ${ACCESS_TOKEN_LIFESPAN},
+  "ssoSessionIdleTimeout": ${SSO_SESSION_IDLE_TIMEOUT},
+  "ssoSessionMaxLifespan": ${SSO_SESSION_MAX_LIFESPAN},
+  "ssoSessionIdleTimeoutRememberMe": ${SSO_SESSION_IDLE_TIMEOUT},
+  "ssoSessionMaxLifespanRememberMe": ${SSO_SESSION_MAX_LIFESPAN},
+  "clientSessionIdleTimeout": ${CLIENT_SESSION_IDLE_TIMEOUT},
+  "clientSessionMaxLifespan": ${CLIENT_SESSION_MAX_LIFESPAN}
+}
+EOF
+)" >/dev/null
 
 # Step 3 — UI: Client Scopes → Create client scope
 #   Name: atryum:mcp


### PR DESCRIPTION
… lifespans

ExternalSubmitRequest now accepts an optional `agent_id` field. When the external route runs anonymously (no OAuth identity in context — the default for the amp-plugin and shared-agent-hook examples), Submit promotes the self-declared value onto the invocation row so the Agent column populates and the agents.agent_ids -> Agent Record resolution / agent-scoped approval rules light up the same way they do for verified MCP traffic. A verified OAuth identity in context still wins, so this is purely additive.

- internal/invocation/model.go: AgentID string field on ExternalSubmitRequest
- internal/invocation/service.go: Submit falls back to req.AgentID when auth.AgentIDFromContext(ctx) is empty
- internal/invocation/agent_id_test.go: TestExternalSubmitUsesSelfDeclaredAgentIDWhenNoAuthIdentity covers both the fallback and the auth-wins-over-body invariant
- examples/amp-plugin/atryum.ts: reads ATRYUM_AGENT_ID and sends it as agent_id; omitted when unset (default behavior unchanged)
- examples/shared-agent-hook/atryum-hook.mjs: same treatment
- examples/amp-plugin/README.md: documents the new env var and the "add the string to an Agent Record's Agent IDs" UI workflow

Also bumps the Keycloak realm token/session lifespans in setup-realm.sh so OAuth-based MCP clients (Claude Code, opencode) don't expire mid-demo. Stock Keycloak defaults (300s access / 30min idle / 10h max) are why tokens felt "gone in 5-10 minutes". New defaults are 24h access token / 30d sessions, overridable via ACCESS_TOKEN_LIFESPAN, SSO_SESSION_*, CLIENT_SESSION_* env vars. Applied in a new Step 2b right after realm creation; re-run ./keycloak/setup-realm.sh against an existing realm to reconcile.

Amp-Thread-ID: https://ampcode.com/threads/T-019e80f8-23f2-74a8-9120-ca3aaf2cef16