### PR TITLE
Allow mapping an anonymous mcp agent to an Agent Record

### DIFF
--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -159,7 +159,9 @@ func TestMCPAcceptsValidTokenAndPlumbsAgentID(t *testing.T) {
 			Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`),
 		},
 	}
-	h := newAuthedHandler(t, svc, rig)
+	hdl := NewHandler(svc, stubServerService{}, nil, nil, nil, &stubAgentSyncSettingsRepo{settings: store.AgentSyncSettings{AnonymousAgentRecordCUID: "anon-agent"}}, nil, nil)
+	hdl.SetAuthValidator(rig.v)
+	h := hdl.Routes()
 
 	tok := rig.sign(t, defaultClaims())
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"demo_tool","arguments":{"a":1}}}`))
@@ -176,6 +178,60 @@ func TestMCPAcceptsValidTokenAndPlumbsAgentID(t *testing.T) {
 	id := auth.AgentIDFromContext(svc.invokedCtx)
 	if id != "agent-007" {
 		t.Fatalf("expected agent_id agent-007 on invoke ctx, got %q", id)
+	}
+}
+
+func TestMCPAnonymousDefaultAgentApplied(t *testing.T) {
+	now := time.Now().UTC()
+	svc := &stubService{
+		invoke: invocation.InvocationResponse{
+			InvocationID: "inv_1", ServerName: "demo", ToolName: "demo_tool",
+			Status: invocation.StatusSucceeded, SubmittedAt: now, CompletedAt: &now,
+			Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`),
+		},
+	}
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, &stubAgentSyncSettingsRepo{settings: store.AgentSyncSettings{AnonymousAgentRecordCUID: " agent-record-x "}}, nil, nil).Routes()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"demo_tool","arguments":{"a":1}}}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if svc.invokedReq == nil {
+		t.Fatal("expected service.Invoke to be called")
+	}
+	if got := auth.AgentIDFromContext(svc.invokedCtx); got != "agent-record-x" {
+		t.Fatalf("expected anonymous default agent-record-x, got %q", got)
+	}
+}
+
+func TestMCPAnonymousDefaultUnsetPreservesAnonymousToolsCall(t *testing.T) {
+	now := time.Now().UTC()
+	svc := &stubService{
+		invoke: invocation.InvocationResponse{
+			InvocationID: "inv_1", ServerName: "demo", ToolName: "demo_tool",
+			Status: invocation.StatusSucceeded, SubmittedAt: now, CompletedAt: &now,
+			Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`),
+		},
+	}
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, &stubAgentSyncSettingsRepo{}, nil, nil).Routes()
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"demo_tool","arguments":{"a":1}}}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if svc.invokedReq == nil {
+		t.Fatal("expected service.Invoke to be called")
+	}
+	if got := auth.AgentIDFromContext(svc.invokedCtx); got != "" {
+		t.Fatalf("expected anonymous invoke ctx, got %q", got)
 	}
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -80,6 +80,7 @@ type agentsRepo interface {
 	List(ctx context.Context) ([]store.AgentRecord, error)
 	ListEnabled(ctx context.Context) ([]store.AgentRecord, error)
 	Get(ctx context.Context, id string) (store.AgentRecord, error)
+	GetByAgentID(ctx context.Context, agentID string) (store.AgentRecord, error)
 	GetByVMCUID(ctx context.Context, vmCUID string) (store.AgentRecord, error)
 	UpdateEnabled(ctx context.Context, id string, enabled bool) error
 	UpdateAgentIDs(ctx context.Context, id string, agentIDs string) error
@@ -497,6 +498,7 @@ func (h *Handler) spaFileServer() http.Handler {
 }
 
 func (h *Handler) invokeUpstream(w http.ResponseWriter, r *http.Request) {
+	r = r.WithContext(h.withAnonymousDefault(r))
 	server := strings.TrimPrefix(r.URL.Path, "/mcp/")
 	server = strings.Trim(server, "/")
 
@@ -571,6 +573,7 @@ func (h *Handler) invocations(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) agentRules(w http.ResponseWriter, r *http.Request) {
+	ctx := h.withAnonymousDefault(r)
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -580,7 +583,7 @@ func (h *Handler) agentRules(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	agentID := auth.AgentIDFromContext(r.Context())
+	agentID := auth.AgentIDFromContext(ctx)
 	if agentID == "" {
 		agentID = strings.TrimSpace(r.URL.Query().Get("agent_id"))
 	}
@@ -593,12 +596,32 @@ func (h *Handler) agentRules(w http.ResponseWriter, r *http.Request) {
 	}
 	tool := strings.TrimSpace(r.URL.Query().Get("tool"))
 
-	resp, err := h.buildAgentRulesResponse(r.Context(), agentID, server, tool)
+	resp, err := h.buildAgentRulesResponse(ctx, agentID, server, tool)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) withAnonymousDefault(r *http.Request) context.Context {
+	ctx := r.Context()
+	if _, ok := auth.IdentityFromContext(ctx); ok {
+		return ctx
+	}
+	if h.agentSyncSettingsRepo == nil {
+		return ctx
+	}
+	s, err := h.agentSyncSettingsRepo.Get(ctx)
+	if err != nil {
+		log.Printf("[auth] anonymous default settings lookup failed: %v", err)
+		return ctx
+	}
+	agentIdentity := strings.TrimSpace(s.AnonymousAgentRecordCUID)
+	if agentIdentity == "" {
+		return ctx
+	}
+	return auth.WithIdentity(ctx, auth.Identity{AgentID: agentIdentity})
 }
 
 func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, tool string) (AgentRulesResponse, error) {
@@ -617,9 +640,15 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 	if err != nil {
 		return AgentRulesResponse{}, err
 	}
+	agentCUID := ""
+	if h.agentsRepo != nil && agentID != "" {
+		if rec, err := h.agentsRepo.GetByAgentID(ctx, agentID); err == nil {
+			agentCUID = rec.ID
+		}
+	}
 
 	for _, rule := range rules {
-		if !rule.Enabled || !apiMatchAgentIDPattern(rule.AgentIDPattern, agentID) {
+		if !rule.Enabled || !apiMatchAgentIDPattern(rule.AgentIDPattern, agentID) || !apiMatchAgentCUIDs(rule.AgentCUIDs, agentCUID) {
 			continue
 		}
 		resp.Items = append(resp.Items, AgentRule{
@@ -642,6 +671,18 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 		}
 	}
 	return resp, nil
+}
+
+func apiMatchAgentCUIDs(cuids []string, agentCUID string) bool {
+	if len(cuids) == 0 {
+		return true
+	}
+	for _, cuid := range cuids {
+		if cuid == agentCUID {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) handleInvocation(w http.ResponseWriter, r *http.Request, server string) {
@@ -1899,20 +1940,22 @@ func (h *Handler) adminModelConfigs(w http.ResponseWriter, r *http.Request) {
 // and PUT /admin/settings. SyncError is non-empty when the post-save agent
 // sync failed; settings are persisted regardless.
 type AgentSyncSettingsResponse struct {
-	OrgCUID                string `json:"org_cuid"`
-	AgentRecordTypeSlug    string `json:"agent_record_type_slug"`
-	ConstitutionFieldKey   string `json:"constitution_field_key"`
-	SummaryModelConfigCUID string `json:"summary_model_config_cuid"`
-	UpdatedAt              string `json:"updated_at,omitempty"`
-	SyncError              string `json:"sync_error,omitempty"`
+	OrgCUID                  string `json:"org_cuid"`
+	AgentRecordTypeSlug      string `json:"agent_record_type_slug"`
+	ConstitutionFieldKey     string `json:"constitution_field_key"`
+	SummaryModelConfigCUID   string `json:"summary_model_config_cuid"`
+	AnonymousAgentRecordCUID string `json:"anonymous_agent_record_cuid"`
+	UpdatedAt                string `json:"updated_at,omitempty"`
+	SyncError                string `json:"sync_error,omitempty"`
 }
 
 // AgentSyncSettingsInput is the JSON body accepted by PUT /admin/settings.
 type AgentSyncSettingsInput struct {
-	OrgCUID                string `json:"org_cuid"`
-	AgentRecordTypeSlug    string `json:"agent_record_type_slug"`
-	ConstitutionFieldKey   string `json:"constitution_field_key"`
-	SummaryModelConfigCUID string `json:"summary_model_config_cuid"`
+	OrgCUID                  string `json:"org_cuid"`
+	AgentRecordTypeSlug      string `json:"agent_record_type_slug"`
+	ConstitutionFieldKey     string `json:"constitution_field_key"`
+	SummaryModelConfigCUID   string `json:"summary_model_config_cuid"`
+	AnonymousAgentRecordCUID string `json:"anonymous_agent_record_cuid"`
 }
 
 func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
@@ -1928,10 +1971,11 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		resp := AgentSyncSettingsResponse{
-			OrgCUID:                s.OrgCUID,
-			AgentRecordTypeSlug:    s.AgentRecordTypeSlug,
-			ConstitutionFieldKey:   s.ConstitutionFieldKey,
-			SummaryModelConfigCUID: s.SummaryModelConfigCUID,
+			OrgCUID:                  s.OrgCUID,
+			AgentRecordTypeSlug:      s.AgentRecordTypeSlug,
+			ConstitutionFieldKey:     s.ConstitutionFieldKey,
+			SummaryModelConfigCUID:   s.SummaryModelConfigCUID,
+			AnonymousAgentRecordCUID: s.AnonymousAgentRecordCUID,
 		}
 		if !s.UpdatedAt.IsZero() {
 			resp.UpdatedAt = s.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z")
@@ -1958,10 +2002,11 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		if err := h.agentSyncSettingsRepo.Save(r.Context(), store.AgentSyncSettings{
-			OrgCUID:                input.OrgCUID,
-			AgentRecordTypeSlug:    input.AgentRecordTypeSlug,
-			ConstitutionFieldKey:   input.ConstitutionFieldKey,
-			SummaryModelConfigCUID: input.SummaryModelConfigCUID,
+			OrgCUID:                  input.OrgCUID,
+			AgentRecordTypeSlug:      input.AgentRecordTypeSlug,
+			ConstitutionFieldKey:     input.ConstitutionFieldKey,
+			SummaryModelConfigCUID:   input.SummaryModelConfigCUID,
+			AnonymousAgentRecordCUID: strings.TrimSpace(input.AnonymousAgentRecordCUID),
 		}); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to save settings: "+err.Error())
 			return
@@ -1983,11 +2028,12 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 		}
 		log.Printf("[adminSettings] GET after save: org_cuid=%q record_type=%q", s.OrgCUID, s.AgentRecordTypeSlug)
 		resp := AgentSyncSettingsResponse{
-			OrgCUID:                s.OrgCUID,
-			AgentRecordTypeSlug:    s.AgentRecordTypeSlug,
-			ConstitutionFieldKey:   s.ConstitutionFieldKey,
-			SummaryModelConfigCUID: s.SummaryModelConfigCUID,
-			SyncError:              syncErr,
+			OrgCUID:                  s.OrgCUID,
+			AgentRecordTypeSlug:      s.AgentRecordTypeSlug,
+			ConstitutionFieldKey:     s.ConstitutionFieldKey,
+			SummaryModelConfigCUID:   s.SummaryModelConfigCUID,
+			AnonymousAgentRecordCUID: s.AnonymousAgentRecordCUID,
+			SyncError:                syncErr,
 		}
 		if !s.UpdatedAt.IsZero() {
 			resp.UpdatedAt = s.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z")

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -178,6 +178,19 @@ func (s *stubAgentsRepo) ListEnabled(context.Context) ([]store.AgentRecord, erro
 func (s *stubAgentsRepo) Get(context.Context, string) (store.AgentRecord, error) {
 	return store.AgentRecord{}, nil
 }
+func (s *stubAgentsRepo) GetByAgentID(_ context.Context, agentID string) (store.AgentRecord, error) {
+	for _, r := range s.records {
+		if r.ID == agentID {
+			return r, nil
+		}
+		for _, id := range parseAgentIDs(r.AgentIDs) {
+			if id == agentID {
+				return r, nil
+			}
+		}
+	}
+	return store.AgentRecord{}, fmt.Errorf("sql: no rows in result set")
+}
 func (s *stubAgentsRepo) GetByVMCUID(_ context.Context, vmCUID string) (store.AgentRecord, error) {
 	if s.byVMCUIDErr != nil {
 		if err, ok := s.byVMCUIDErr[vmCUID]; ok {

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -157,7 +157,7 @@ func (c *Client) FetchAgents(ctx context.Context, orgCUID, agentRecordTypeSlug s
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return AgentsResponse{}, fmt.Errorf("agents endpoint returned %s", resp.Status)
+		return AgentsResponse{}, fmt.Errorf("agents endpoint returned %s", responseStatus(resp))
 	}
 
 	var payload AgentsResponse
@@ -183,7 +183,7 @@ func (c *Client) FetchModelConfigs(ctx context.Context) (ModelConfigsResponse, e
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return ModelConfigsResponse{}, fmt.Errorf("model-configs endpoint returned %s", resp.Status)
+		return ModelConfigsResponse{}, fmt.Errorf("model-configs endpoint returned %s", responseStatus(resp))
 	}
 
 	var payload ModelConfigsResponse
@@ -249,7 +249,7 @@ func (c *Client) FetchOrganizations(ctx context.Context) (VMOrgsResponse, error)
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return VMOrgsResponse{}, fmt.Errorf("organizations endpoint returned %s", resp.Status)
+		return VMOrgsResponse{}, fmt.Errorf("organizations endpoint returned %s", responseStatus(resp))
 	}
 
 	var payload VMOrgsResponse
@@ -288,7 +288,7 @@ func (c *Client) FetchPrimaryRecordTypes(ctx context.Context, orgCUID string) (V
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return VMRecordTypesResponse{}, fmt.Errorf("primary-record-types endpoint returned %s", resp.Status)
+		return VMRecordTypesResponse{}, fmt.Errorf("primary-record-types endpoint returned %s", responseStatus(resp))
 	}
 
 	var payload VMRecordTypesResponse
@@ -331,7 +331,7 @@ func (c *Client) FetchCustomFields(ctx context.Context, orgCUID, primaryRecordTy
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return VMCustomFieldsResponse{}, fmt.Errorf("custom-fields endpoint returned %s", resp.Status)
+		return VMCustomFieldsResponse{}, fmt.Errorf("custom-fields endpoint returned %s", responseStatus(resp))
 	}
 
 	var payload VMCustomFieldsResponse
@@ -391,7 +391,7 @@ func (c *Client) EvaluateToolCall(ctx context.Context, req EvaluateRequest) (Eva
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return EvaluateResponse{}, fmt.Errorf("evaluate endpoint returned %s", resp.Status)
+		return EvaluateResponse{}, fmt.Errorf("evaluate endpoint returned %s", responseStatus(resp))
 	}
 
 	var payload EvaluateResponse
@@ -445,7 +445,7 @@ func (c *Client) SummarizeInvocation(ctx context.Context, req SummarizeInvocatio
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return SummarizeInvocationResponse{}, fmt.Errorf("summarize-invocation endpoint returned %s", resp.Status)
+		return SummarizeInvocationResponse{}, fmt.Errorf("summarize-invocation endpoint returned %s", responseStatus(resp))
 	}
 
 	var payload SummarizeInvocationResponse
@@ -470,7 +470,7 @@ func (c *Client) CheckConnection(ctx context.Context) (ConnectionResponse, error
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return ConnectionResponse{}, fmt.Errorf("backend connection endpoint returned %s", resp.Status)
+		return ConnectionResponse{}, fmt.Errorf("backend connection endpoint returned %s", responseStatus(resp))
 	}
 
 	var payload ConnectionResponse
@@ -481,4 +481,12 @@ func (c *Client) CheckConnection(ctx context.Context) (ConnectionResponse, error
 		return ConnectionResponse{}, fmt.Errorf("backend connection endpoint returned ok=false")
 	}
 	return payload, nil
+}
+
+func responseStatus(resp *http.Response) string {
+	status := resp.Status
+	if location := resp.Header.Get("Location"); location != "" {
+		status += " (Location: " + location + ")"
+	}
+	return status
 }

--- a/internal/store/agent_sync_settings.go
+++ b/internal/store/agent_sync_settings.go
@@ -10,19 +10,20 @@ import (
 	sq "github.com/Masterminds/squirrel"
 )
 
-// AgentSyncSettings holds the three configurable values that control agent
+// AgentSyncSettings holds the configurable values that control agent
 // synchronisation from the ValidMind backend. All fields are empty strings
 // when the user has not yet configured sync (i.e. no row exists yet).
 type AgentSyncSettings struct {
-	OrgCUID                string
-	AgentRecordTypeSlug    string
-	ConstitutionFieldKey   string
-	SummaryModelConfigCUID string
-	UpdatedAt              time.Time
+	OrgCUID                  string
+	AgentRecordTypeSlug      string
+	ConstitutionFieldKey     string
+	SummaryModelConfigCUID   string
+	AnonymousAgentRecordCUID string
+	UpdatedAt                time.Time
 }
 
 var agentSyncSettingsColumns = []string{
-	"org_cuid", "agent_record_type_slug", "constitution_field_key", "summary_model_config_cuid", "updated_at",
+	"org_cuid", "agent_record_type_slug", "constitution_field_key", "summary_model_config_cuid", "anonymous_agent_record_cuid", "updated_at",
 }
 
 // AgentSyncSettingsRepo provides read/write access to the singleton
@@ -63,7 +64,7 @@ func (r *AgentSyncSettingsRepo) Get(ctx context.Context) (AgentSyncSettings, err
 	return s, err
 }
 
-// Save persists all three fields using an upsert so the row is created on
+// Save persists all fields using an upsert so the row is created on
 // first save and updated on subsequent saves regardless of whether a row
 // already exists.
 func (r *AgentSyncSettingsRepo) Save(ctx context.Context, s AgentSyncSettings) error {
@@ -72,19 +73,20 @@ func (r *AgentSyncSettingsRepo) Save(ctx context.Context, s AgentSyncSettings) e
 	var args []any
 	if r.dialect == DialectPostgres {
 		// PostgreSQL upsert
-		query = `INSERT INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, updated_at)
-VALUES (1, $1, $2, $3, $4, $5)
+		query = `INSERT INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, anonymous_agent_record_cuid, updated_at)
+VALUES (1, $1, $2, $3, $4, $5, $6)
 ON CONFLICT (id) DO UPDATE SET
   org_cuid                  = EXCLUDED.org_cuid,
   agent_record_type_slug    = EXCLUDED.agent_record_type_slug,
   constitution_field_key    = EXCLUDED.constitution_field_key,
   summary_model_config_cuid = EXCLUDED.summary_model_config_cuid,
+  anonymous_agent_record_cuid = EXCLUDED.anonymous_agent_record_cuid,
   updated_at                = EXCLUDED.updated_at`
-		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, now}
+		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, s.AnonymousAgentRecordCUID, now}
 	} else {
 		// SQLite: INSERT OR REPLACE replaces the row when the primary key conflicts.
-		query = `INSERT OR REPLACE INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, updated_at) VALUES (1, ?, ?, ?, ?, ?)`
-		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, now}
+		query = `INSERT OR REPLACE INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, anonymous_agent_record_cuid, updated_at) VALUES (1, ?, ?, ?, ?, ?, ?)`
+		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, s.AnonymousAgentRecordCUID, now}
 	}
 	result, err := r.db.ExecContext(ctx, query, args...)
 	if err != nil {
@@ -103,6 +105,7 @@ func scanAgentSyncSettings(row interface{ Scan(dest ...any) error }) (AgentSyncS
 		&s.AgentRecordTypeSlug,
 		&s.ConstitutionFieldKey,
 		&s.SummaryModelConfigCUID,
+		&s.AnonymousAgentRecordCUID,
 		&s.UpdatedAt,
 	); err != nil {
 		return AgentSyncSettings{}, err

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -153,17 +153,19 @@ func (r *AgentsRepo) GetByVMCUID(ctx context.Context, vmCUID string) (AgentRecor
 	return scanAgent(r.db.QueryRowContext(ctx, query, args...))
 }
 
-// GetByAgentID returns the agent record whose agent_ids JSON array contains the
-// given agentID string. Returns sql.ErrNoRows when no match is found.
+// GetByAgentID returns the agent record whose local id matches agentID or whose
+// agent_ids JSON array contains the given agentID string. Returns sql.ErrNoRows
+// when no match is found.
 func (r *AgentsRepo) GetByAgentID(ctx context.Context, agentID string) (AgentRecord, error) {
 	cols := strings.Join(agentColumns, ", ")
 	var query string
 	if r.dialect == DialectPostgres {
 		// PostgreSQL: use the @> containment operator on JSONB.
-		query = `SELECT ` + cols + ` FROM agents WHERE agent_ids @> to_jsonb($1::text)::jsonb LIMIT 1`
+		query = `SELECT ` + cols + ` FROM agents WHERE id = $1 OR agent_ids @> to_jsonb($1::text)::jsonb LIMIT 1`
 	} else {
 		// SQLite: use json_each to expand the array and match the value.
-		query = `SELECT ` + cols + ` FROM agents WHERE EXISTS (SELECT 1 FROM json_each(agent_ids) WHERE value = ?) LIMIT 1`
+		query = `SELECT ` + cols + ` FROM agents WHERE id = ? OR EXISTS (SELECT 1 FROM json_each(agent_ids) WHERE value = ?) LIMIT 1`
+		return scanAgent(r.db.QueryRowContext(ctx, query, agentID, agentID))
 	}
 	return scanAgent(r.db.QueryRowContext(ctx, query, agentID))
 }

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 14 {
+	if len(migrations) != 15 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -67,6 +67,7 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{12, "012_invocation_summary"},
 		{13, "013_summary_model_config"},
 		{14, "014_invocation_client_info.sql"},
+		{15, "015_anonymous_agent_record_cuid"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -77,10 +78,10 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 13 {
+	if len(pending) != 14 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
+	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	for i, want := range wantVersions {
 		if pending[i].Version != want {
 			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)

--- a/internal/store/migrations/015_anonymous_agent_record_cuid.go
+++ b/internal/store/migrations/015_anonymous_agent_record_cuid.go
@@ -1,0 +1,14 @@
+package migrations
+
+func migration015() Definition {
+	return Definition{
+		Version: 15,
+		Name:    "015_anonymous_agent_record_cuid",
+		Steps: []Step{
+			Raw(
+				"add anonymous_agent_record_cuid to agent_sync_settings",
+				`ALTER TABLE agent_sync_settings ADD COLUMN anonymous_agent_record_cuid TEXT NOT NULL DEFAULT ''`,
+			),
+		},
+	}
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -48,5 +48,6 @@ func All() []Definition {
 		migration012(),
 		migration013(),
 		migration014(),
+		migration015(),
 	}
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -36,13 +36,13 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 		t.Fatalf("InitDB: %v", err)
 	}
 
-	// Verify schema_migrations table has 3 entries
+	// Verify schema_migrations table has all registered entries.
 	var count int
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 14 {
-		t.Fatalf("expected 14 migrations, got %d", count)
+	if count != 15 {
+		t.Fatalf("expected 15 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 14 {
-		t.Fatalf("expected 14 migrations after double init, got %d", count)
+	if count != 15 {
+		t.Fatalf("expected 15 migrations after double init, got %d", count)
 	}
 }
 
@@ -752,16 +752,17 @@ func TestAgentSyncSettingsRepo_UpsertOnEmptyTable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get on empty table: %v", err)
 	}
-	if s.OrgCUID != "" {
-		t.Fatalf("expected empty OrgCUID, got %q", s.OrgCUID)
+	if s.OrgCUID != "" || s.AnonymousAgentRecordCUID != "" {
+		t.Fatalf("expected empty settings, got OrgCUID=%q AnonymousAgentRecordCUID=%q", s.OrgCUID, s.AnonymousAgentRecordCUID)
 	}
 
 	// Save should create the row
 	err = repo.Save(ctx, AgentSyncSettings{
-		OrgCUID:                "org-abc",
-		AgentRecordTypeSlug:    "ai-agents",
-		ConstitutionFieldKey:   "constitution",
-		SummaryModelConfigCUID: "model-abc",
+		OrgCUID:                  "org-abc",
+		AgentRecordTypeSlug:      "ai-agents",
+		ConstitutionFieldKey:     "constitution",
+		SummaryModelConfigCUID:   "model-abc",
+		AnonymousAgentRecordCUID: "agent-record-1",
 	})
 	if err != nil {
 		t.Fatalf("Save: %v", err)
@@ -780,5 +781,38 @@ func TestAgentSyncSettingsRepo_UpsertOnEmptyTable(t *testing.T) {
 	}
 	if s.SummaryModelConfigCUID != "model-abc" {
 		t.Fatalf("expected SummaryModelConfigCUID=model-abc, got %q", s.SummaryModelConfigCUID)
+	}
+	if s.AnonymousAgentRecordCUID != "agent-record-1" {
+		t.Fatalf("expected AnonymousAgentRecordCUID=agent-record-1, got %q", s.AnonymousAgentRecordCUID)
+	}
+}
+
+func TestAgentsRepo_GetByAgentIDMatchesRecordID(t *testing.T) {
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+	if err := InitDB(db); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+
+	repo := NewAgentsRepo(db)
+	ctx := context.Background()
+	if err := repo.Upsert(ctx, AgentRecord{
+		ID:                 "agent-record-1",
+		VMOrganizationCUID: "org-1",
+		VMOrganizationName: "Org 1",
+		VMCUID:             "vm-agent-1",
+		VMName:             "Agent One",
+		AgentIDs:           "[]",
+		Enabled:            true,
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, err := repo.GetByAgentID(ctx, "agent-record-1")
+	if err != nil {
+		t.Fatalf("GetByAgentID by record id: %v", err)
+	}
+	if got.ID != "agent-record-1" || got.VMCUID != "vm-agent-1" {
+		t.Fatalf("unexpected agent record: %+v", got)
 	}
 }


### PR DESCRIPTION
This means you can do mcp things with atryum without the oidc process - important for quickstart demo!

Backend changes:
- Store anonymous_agent_record_cuid in agent sync settings.
- Stamp anonymous MCP and agent-rules requests with the selected record CUID when no auth identity exists.
- Resolve agent records by either runtime agent_id or record CUID so constitution and agent-scoped rules apply.
- Add store/API/auth tests for the fallback behavior.
- Include redirect Location details in backend API error statuses to make http:// base URL mistakes easier to diagnose."