### PR TITLE
[codex] Call backend Atryum unstable API

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ After first-run bootstrap, edit MCP servers through the UI/API; TOML `[[upstream
 
 `server.database_url` selects the storage provider by URL scheme. `postgres://` and `postgresql://` use PostgreSQL via pgx stdlib; `sqlite://`, `file:`, an empty URL, or a bare path use SQLite. Normal tests do not require PostgreSQL; run the optional store integration test with `ATRYUM_POSTGRES_TESTS=1 go test ./internal/store`.
 
-When `backend.base_url` is empty, the ValidMind backend connection check is skipped for local standalone runs. When it is set, startup fails if credentials are missing or `GET /internal/v1/atryum/connection` is rejected. Environment variables override TOML: `VM_BASE_URL`, `VM_MACHINE_KEY`, `VM_MACHINE_SECRET`, and `VM_CONNECTION_TIMEOUT_SECONDS`.
+When `backend.base_url` is empty, the ValidMind backend connection check is skipped for local standalone runs. When it is set, startup fails if credentials are missing or `GET /api/atryum/unstable/connection` is rejected. Environment variables override TOML: `VM_BASE_URL`, `VM_MACHINE_KEY`, `VM_MACHINE_SECRET`, and `VM_CONNECTION_TIMEOUT_SECONDS`.
 
 ## Running
 

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -17,7 +17,7 @@ log_level = "info"
 [backend]
 # Optional ValidMind backend connection check. When base_url is set, Atryum
 # verifies credentials at startup by calling:
-# GET /internal/v1/atryum/connection
+# GET /api/atryum/unstable/connection
 #
 # Machine-user credentials are preferred when configured. If machine_key and
 # machine_secret are both empty, Atryum uses normal user API credentials instead.

--- a/docs/testing/ai-evaluation.md
+++ b/docs/testing/ai-evaluation.md
@@ -178,7 +178,7 @@ Send a tool call through Atryum using a bearer token issued for the agent identi
 
 1. Atryum receives the invocation and matches it to the AI Evaluation rule.
 2. It resolves the agent's Inventory Model CUID and org CUID from the stored record.
-3. It calls `POST /internal/v1/atryum/evaluate` on the ValidMind backend with the agent details, constitution field key, and tool call context.
+3. It calls `POST /api/atryum/unstable/evaluate` on the ValidMind backend with the agent details, constitution field key, and tool call context.
 4. The backend fetches the constitution chain from the Inventory Model's custom fields, builds a prompt with precedence rules, and asks the configured LLM for a verdict.
 5. Atryum receives `{ verdict, reason }` and routes the invocation accordingly:
 

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -12,14 +12,15 @@ import (
 	"atryum/internal/config"
 )
 
-const connectionPath = "/internal/v1/atryum/connection"
-const agentsPath = "/internal/v1/atryum/agents"
-const modelConfigsPath = "/internal/v1/atryum/model-configs"
-const evaluatePath = "/internal/v1/atryum/evaluate"
-const summarizeInvocationPath = "/internal/v1/atryum/summarize-invocation"
-const organizationsPath = "/internal/v1/atryum/organizations"
-const primaryRecordTypesPath = "/internal/v1/atryum/primary-record-types"
-const customFieldsPath = "/internal/v1/atryum/custom-fields"
+const atryumAPIPath = "/api/atryum/unstable"
+const connectionPath = atryumAPIPath + "/connection"
+const agentsPath = atryumAPIPath + "/agents"
+const modelConfigsPath = atryumAPIPath + "/model-configs"
+const evaluatePath = atryumAPIPath + "/evaluate"
+const summarizeInvocationPath = atryumAPIPath + "/summarize-invocation"
+const organizationsPath = atryumAPIPath + "/organizations"
+const primaryRecordTypesPath = atryumAPIPath + "/primary-record-types"
+const customFieldsPath = atryumAPIPath + "/custom-fields"
 
 type ConnectionResponse struct {
 	OK              bool   `json:"ok"`


### PR DESCRIPTION
## Summary
- update Atryum backend client constants from `/internal/v1/atryum` to `/api/atryum/unstable`
- update README, example config, and AI evaluation testing docs to reference the new backend path

## Validation
- `go test ./internal/backend ./internal/config ./internal/api`

## Notes
- This should be merged with the backend route move PR so Atryum and backend agree on the new exposed ingress path.