### PR TITLE
[codex] Support no-auth agent id hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Three pieces of identity travel with every invocation:
 
 Auth is OIDC-based and supports multiple authorization servers concurrently (Keycloak, Auth0, etc.) — see `[[auth]]` blocks. API-key-protected legacy endpoints (`/agent_ids`, `/invocations/{agent_id}`) exist for tooling that hasn't moved to bearer tokens yet.
 
+For local no-auth MCP runs, when no `[[auth]]` blocks are configured, callers may provide a best-effort agent identity with `?agent_id=` on `/mcp/{server}` and `/api/v1/agent/rules`. For example: `http://localhost:8080/mcp/shortcut?agent_id=hunners-codex`. This ID is ignored as soon as inbound auth is configured.
+
+The Settings UI can also select a default ValidMind agent record. AI Evaluation uses that record when an incoming runtime agent ID is missing or does not map to a synced agent, allowing local no-auth runs to evaluate against a known constitution without adding TOML.
+
 ## HTTP surface
 
 Public (auth-protected when `[[auth]]` is configured):

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -329,6 +329,14 @@ func (a *agentsLookupAdapter) GetByAgentID(ctx context.Context, agentID string) 
 	return invocation.AgentRecord{ID: rec.ID, VMCUID: rec.VMCUID, VMOrganizationCUID: rec.VMOrganizationCUID}, nil
 }
 
+func (a *agentsLookupAdapter) GetByVMCUID(ctx context.Context, vmCUID string) (invocation.AgentRecord, error) {
+	rec, err := a.repo.GetByVMCUID(ctx, vmCUID)
+	if err != nil {
+		return invocation.AgentRecord{}, err
+	}
+	return invocation.AgentRecord{ID: rec.ID, VMCUID: rec.VMCUID, VMOrganizationCUID: rec.VMOrganizationCUID}, nil
+}
+
 // syncSettingsAdapter bridges store.AgentSyncSettingsRepo → invocation.SyncSettingsProvider.
 // ConstitutionFieldKey is read from the DB on every call so that changes saved
 // via the Settings UI take effect immediately without a restart.
@@ -339,6 +347,11 @@ type syncSettingsAdapter struct {
 func (a *syncSettingsAdapter) ConstitutionFieldKey(ctx context.Context) string {
 	s, _ := a.repo.Get(ctx)
 	return s.ConstitutionFieldKey
+}
+
+func (a *syncSettingsAdapter) DefaultAgentVMCUID(ctx context.Context) string {
+	s, _ := a.repo.Get(ctx)
+	return s.DefaultAgentVMCUID
 }
 
 func (a *syncSettingsAdapter) SummarySettings(ctx context.Context) (string, string) {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -426,6 +426,7 @@ func (h *Handler) Routes() http.Handler {
 		mux.Handle("/.well-known/oauth-protected-resource", h.protectedResourceMetadata())
 	}
 	mcpHandler := auth.MiddlewareWithOptions(h.authValidator, "/.well-known/oauth-protected-resource", auth.MiddlewareOptions{SkipVerify: h.authDebugSkip, DebugLogIdentity: h.debug})(http.HandlerFunc(h.invokeUpstream))
+	mcpHandler = h.noAuthAgentIDHint(mcpHandler)
 	mux.Handle("/mcp/", mcpHandler)
 	mux.HandleFunc("/api/v1/invocations", h.invocations)
 	mux.HandleFunc("/api/v1/admin/invocations", h.adminInvocations)
@@ -445,6 +446,7 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/admin/oauth/callback", h.oauthCallback)
 	mux.HandleFunc("/api/v1/admin/policy", h.adminPolicy)
 	agentRulesHandler := auth.MiddlewareWithOptions(h.authValidator, "/.well-known/oauth-protected-resource", auth.MiddlewareOptions{SkipVerify: h.authDebugSkip, DebugLogIdentity: h.debug})(http.HandlerFunc(h.agentRules))
+	agentRulesHandler = h.noAuthAgentIDHint(agentRulesHandler)
 	mux.Handle("/api/v1/agent/rules", agentRulesHandler)
 	mux.HandleFunc("/api/v1/external/invocations", h.externalInvocations)
 	mux.HandleFunc("/api/v1/external/invocations/", h.externalInvocationDetail)
@@ -456,6 +458,50 @@ func (h *Handler) Routes() http.Handler {
 	mux.Handle("/ui/", http.StripPrefix("/ui/", h.spaFileServer()))
 	mux.HandleFunc("/", h.root)
 	return mux
+}
+
+func (h *Handler) noAuthAgentIDHint(next http.Handler) http.Handler {
+	if h.authValidator != nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		agentID := normalizeNoAuthAgentID(r.URL.Query().Get("agent_id"))
+		if agentID == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		identity := auth.Identity{
+			AgentID: agentID,
+			Issuer:  "atryum:no-auth",
+			Subject: agentID,
+		}
+		next.ServeHTTP(w, r.WithContext(auth.WithIdentity(r.Context(), identity)))
+	})
+}
+
+func normalizeNoAuthAgentID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 256 {
+		return ""
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if r >= 'A' && r <= 'Z' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		switch r {
+		case '.', '_', ':', '-':
+			continue
+		default:
+			return ""
+		}
+	}
+	return value
 }
 
 func (h *Handler) healthz(w http.ResponseWriter, _ *http.Request) {
@@ -581,10 +627,10 @@ func (h *Handler) agentRules(w http.ResponseWriter, r *http.Request) {
 	}
 
 	agentID := auth.AgentIDFromContext(r.Context())
-	if agentID == "" {
-		agentID = strings.TrimSpace(r.URL.Query().Get("agent_id"))
+	if agentID == "" && h.authValidator == nil {
+		agentID = normalizeNoAuthAgentID(r.URL.Query().Get("agent_id"))
 	}
-	if agentID == "" {
+	if agentID == "" && h.authValidator == nil {
 		agentID = strings.TrimSpace(r.URL.Query().Get("request_id"))
 	}
 	server := strings.TrimSpace(r.URL.Query().Get("server"))
@@ -1903,6 +1949,7 @@ type AgentSyncSettingsResponse struct {
 	AgentRecordTypeSlug    string `json:"agent_record_type_slug"`
 	ConstitutionFieldKey   string `json:"constitution_field_key"`
 	SummaryModelConfigCUID string `json:"summary_model_config_cuid"`
+	DefaultAgentVMCUID     string `json:"default_agent_vm_cuid"`
 	UpdatedAt              string `json:"updated_at,omitempty"`
 	SyncError              string `json:"sync_error,omitempty"`
 }
@@ -1913,6 +1960,7 @@ type AgentSyncSettingsInput struct {
 	AgentRecordTypeSlug    string `json:"agent_record_type_slug"`
 	ConstitutionFieldKey   string `json:"constitution_field_key"`
 	SummaryModelConfigCUID string `json:"summary_model_config_cuid"`
+	DefaultAgentVMCUID     string `json:"default_agent_vm_cuid"`
 }
 
 func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
@@ -1932,6 +1980,7 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 			AgentRecordTypeSlug:    s.AgentRecordTypeSlug,
 			ConstitutionFieldKey:   s.ConstitutionFieldKey,
 			SummaryModelConfigCUID: s.SummaryModelConfigCUID,
+			DefaultAgentVMCUID:     s.DefaultAgentVMCUID,
 		}
 		if !s.UpdatedAt.IsZero() {
 			resp.UpdatedAt = s.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z")
@@ -1962,6 +2011,7 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 			AgentRecordTypeSlug:    input.AgentRecordTypeSlug,
 			ConstitutionFieldKey:   input.ConstitutionFieldKey,
 			SummaryModelConfigCUID: input.SummaryModelConfigCUID,
+			DefaultAgentVMCUID:     input.DefaultAgentVMCUID,
 		}); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to save settings: "+err.Error())
 			return
@@ -1987,6 +2037,7 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 			AgentRecordTypeSlug:    s.AgentRecordTypeSlug,
 			ConstitutionFieldKey:   s.ConstitutionFieldKey,
 			SummaryModelConfigCUID: s.SummaryModelConfigCUID,
+			DefaultAgentVMCUID:     s.DefaultAgentVMCUID,
 			SyncError:              syncErr,
 		}
 		if !s.UpdatedAt.IsZero() {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -80,6 +80,7 @@ type agentsRepo interface {
 	List(ctx context.Context) ([]store.AgentRecord, error)
 	ListEnabled(ctx context.Context) ([]store.AgentRecord, error)
 	Get(ctx context.Context, id string) (store.AgentRecord, error)
+	GetByAgentID(ctx context.Context, agentID string) (store.AgentRecord, error)
 	GetByVMCUID(ctx context.Context, vmCUID string) (store.AgentRecord, error)
 	UpdateEnabled(ctx context.Context, id string, enabled bool) error
 	UpdateAgentIDs(ctx context.Context, id string, agentIDs string) error
@@ -663,9 +664,10 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 	if err != nil {
 		return AgentRulesResponse{}, err
 	}
+	agentCUID := h.resolveAgentRecordForRules(ctx, agentID)
 
 	for _, rule := range rules {
-		if !rule.Enabled || !apiMatchAgentIDPattern(rule.AgentIDPattern, agentID) {
+		if !apiRuleMatches(rule, server, tool, agentID, agentCUID, false) {
 			continue
 		}
 		resp.Items = append(resp.Items, AgentRule{
@@ -678,8 +680,7 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 			Order:          rule.Order,
 		})
 		if resp.Action == "" && server != "" && tool != "" &&
-			apiMatchPatterns(rule.ServerPatterns, server) &&
-			apiMatchPatterns(rule.ToolPatterns, tool) {
+			apiRuleMatches(rule, server, tool, agentID, agentCUID, true) {
 			resp.Action = rule.Action
 			if rule.ID != "" {
 				id := rule.ID
@@ -688,6 +689,63 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 		}
 	}
 	return resp, nil
+}
+
+func (h *Handler) resolveAgentRecordForRules(ctx context.Context, agentID string) string {
+	if h.agentsRepo == nil {
+		return ""
+	}
+	if agentID != "" {
+		if rec, err := h.agentsRepo.GetByAgentID(ctx, agentID); err == nil {
+			return rec.ID
+		}
+	}
+	if h.agentSyncSettingsRepo == nil {
+		return ""
+	}
+	settings, err := h.agentSyncSettingsRepo.Get(ctx)
+	if err != nil {
+		return ""
+	}
+	defaultVMCUID := strings.TrimSpace(settings.DefaultAgentVMCUID)
+	if defaultVMCUID == "" {
+		return ""
+	}
+	rec, err := h.agentsRepo.GetByVMCUID(ctx, defaultVMCUID)
+	if err != nil {
+		return ""
+	}
+	return rec.ID
+}
+
+func apiRuleMatches(rule store.Rule, server, tool, agentID, agentCUID string, includeServerTool bool) bool {
+	if !rule.Enabled {
+		return false
+	}
+	if includeServerTool {
+		if !apiMatchPatterns(rule.ServerPatterns, server) {
+			return false
+		}
+		if !apiMatchPatterns(rule.ToolPatterns, tool) {
+			return false
+		}
+	}
+	if !apiMatchAgentIDPattern(rule.AgentIDPattern, agentID) {
+		return false
+	}
+	return apiMatchAgentCUIDs(rule.AgentCUIDs, agentCUID)
+}
+
+func apiMatchAgentCUIDs(cuids []string, agentCUID string) bool {
+	if len(cuids) == 0 {
+		return true
+	}
+	for _, cuid := range cuids {
+		if cuid == agentCUID {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) handleInvocation(w http.ResponseWriter, r *http.Request, server string) {
@@ -1072,12 +1130,13 @@ func (h *Handler) annotateToolsWithPolicy(ctx context.Context, server string, to
 		return out
 	}
 	agentID := auth.AgentIDFromContext(ctx)
+	agentCUID := h.resolveAgentRecordForRules(ctx, agentID)
 	for i, t := range tools {
 		if t.Name == agentRulesToolName {
 			out[i] = t
 			continue
 		}
-		action, matched := effectiveActionForTool(rules, server, t.Name, agentID)
+		action, matched := effectiveActionForTool(rules, server, t.Name, agentID, agentCUID)
 		desc := t.Description
 		if action != "" {
 			prefix := "[atryum policy: " + action + "] "
@@ -1101,20 +1160,11 @@ func (h *Handler) annotateToolsWithPolicy(ctx context.Context, server string, to
 }
 
 // effectiveActionForTool returns the action of the first enabled rule that
-// matches (server, tool, agentID), mirroring invocation.matchRules priority order.
+// matches (server, tool, agentID, agentCUID), mirroring invocation.matchRules priority order.
 // When no rule matches, it returns RuleActionHumanApproval (the default).
-func effectiveActionForTool(rules []store.Rule, server, tool, agentID string) (string, string) {
+func effectiveActionForTool(rules []store.Rule, server, tool, agentID, agentCUID string) (string, string) {
 	for _, r := range rules {
-		if !r.Enabled {
-			continue
-		}
-		if !apiMatchPatterns(r.ServerPatterns, server) {
-			continue
-		}
-		if !apiMatchPatterns(r.ToolPatterns, tool) {
-			continue
-		}
-		if !apiMatchAgentIDPattern(r.AgentIDPattern, agentID) {
+		if !apiRuleMatches(r, server, tool, agentID, agentCUID, true) {
 			continue
 		}
 		return r.Action, r.ID

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"atryum/internal/auth"
 	backendclient "atryum/internal/backend"
 	"atryum/internal/invocation"
 	"atryum/internal/mcp"
@@ -482,6 +483,68 @@ func TestMCPToolsCallInterceptsInvocation(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), `"text":"ok"`) {
 		t.Fatalf("expected tool result, got %s", w.Body.String())
+	}
+}
+
+func TestMCPNoAuthAgentIDQueryHintSetsIdentity(t *testing.T) {
+	now := time.Now().UTC()
+	svc := &stubService{invoke: invocation.InvocationResponse{InvocationID: "inv_123", ServerName: "demo", ToolName: "demo_tool", Status: invocation.StatusSucceeded, SubmittedAt: now, CompletedAt: &now, Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)}}
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo?agent_id=hunners-codex", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"demo_tool","arguments":{}}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if svc.invokedCtx == nil {
+		t.Fatal("expected invocation context")
+	}
+	if got := auth.AgentIDFromContext(svc.invokedCtx); got != "hunners-codex" {
+		t.Fatalf("agent id = %q", got)
+	}
+}
+
+func TestMCPNoAuthAgentIDQueryHintRejectsInvalidCharacters(t *testing.T) {
+	now := time.Now().UTC()
+	svc := &stubService{invoke: invocation.InvocationResponse{InvocationID: "inv_123", ServerName: "demo", ToolName: "demo_tool", Status: invocation.StatusSucceeded, SubmittedAt: now, CompletedAt: &now, Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)}}
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo?agent_id=bad/agent", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"demo_tool","arguments":{}}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if svc.invokedCtx == nil {
+		t.Fatal("expected invocation context")
+	}
+	if got := auth.AgentIDFromContext(svc.invokedCtx); got != "" {
+		t.Fatalf("agent id = %q", got)
+	}
+}
+
+func TestMCPAgentIDQueryHintIgnoredWhenAuthConfigured(t *testing.T) {
+	now := time.Now().UTC()
+	svc := &stubService{invoke: invocation.InvocationResponse{InvocationID: "inv_123", ServerName: "demo", ToolName: "demo_tool", Status: invocation.StatusSucceeded, SubmittedAt: now, CompletedAt: &now, Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)}}
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil)
+	h.SetAuthValidator(&auth.Validator{})
+	h.SetAuthDebugSkipVerify(true)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo?agent_id=hunners-codex", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"demo_tool","arguments":{}}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if svc.invokedCtx == nil {
+		t.Fatal("expected invocation context")
+	}
+	if got := auth.AgentIDFromContext(svc.invokedCtx); got != "" {
+		t.Fatalf("agent id = %q", got)
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -179,6 +179,16 @@ func (s *stubAgentsRepo) ListEnabled(context.Context) ([]store.AgentRecord, erro
 func (s *stubAgentsRepo) Get(context.Context, string) (store.AgentRecord, error) {
 	return store.AgentRecord{}, nil
 }
+func (s *stubAgentsRepo) GetByAgentID(_ context.Context, agentID string) (store.AgentRecord, error) {
+	for _, r := range s.records {
+		for _, id := range parseAgentIDs(r.AgentIDs) {
+			if id == agentID {
+				return r, nil
+			}
+		}
+	}
+	return store.AgentRecord{}, fmt.Errorf("sql: no rows in result set")
+}
 func (s *stubAgentsRepo) GetByVMCUID(_ context.Context, vmCUID string) (store.AgentRecord, error) {
 	if s.byVMCUIDErr != nil {
 		if err, ok := s.byVMCUIDErr[vmCUID]; ok {
@@ -620,6 +630,42 @@ func TestAgentRulesListsApplicableRulesAndDisposition(t *testing.T) {
 	}
 }
 
+func TestAgentRulesUsesDefaultAgentRecordForAgentScopedRules(t *testing.T) {
+	defaultAgent := store.AgentRecord{ID: "agent-default", VMCUID: "vm-default", AgentIDs: "[]"}
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "other-agent", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "*", AgentCUIDs: []string{"agent-other"}, Enabled: true, Order: 0},
+		{ID: "default-agent", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "*", AgentCUIDs: []string{defaultAgent.ID}, Enabled: true, Order: 1},
+		{ID: "fallback-human", Action: invocation.RuleActionHumanApproval, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "*", Enabled: true, Order: 2},
+	}}
+	agents := &stubAgentsRepo{byVMCUID: map[string]store.AgentRecord{defaultAgent.VMCUID: defaultAgent}}
+	settings := &stubAgentSyncSettingsRepo{settings: store.AgentSyncSettings{DefaultAgentVMCUID: defaultAgent.VMCUID}}
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, agents, settings, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/rules?source=amp&tool=Read", nil)
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AgentRulesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Action != invocation.RuleActionAutoApprove {
+		t.Fatalf("expected default-agent auto approve disposition, got %q", resp.Action)
+	}
+	if resp.MatchedRuleID == nil || *resp.MatchedRuleID != "default-agent" {
+		t.Fatalf("expected matched rule default-agent, got %#v", resp.MatchedRuleID)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected default-scoped and fallback rules, got %#v", resp.Items)
+	}
+	if resp.Items[0].ID != "default-agent" || resp.Items[1].ID != "fallback-human" {
+		t.Fatalf("unexpected applicable rules order: %#v", resp.Items)
+	}
+}
+
 func TestMCPToolsListAnnotatesEffectiveAction(t *testing.T) {
 	rules := &stubRulesRepo{rules: []store.Rule{
 		{ID: "read-auto", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "*", Enabled: true, Order: 0},
@@ -674,6 +720,60 @@ func TestMCPToolsListAnnotatesEffectiveAction(t *testing.T) {
 	rulesTool := rpcResp.Result.Tools[byName["atryum.rules.get"]]
 	if rulesTool.Annotations != nil {
 		t.Fatalf("synthetic rules tool should not be annotated, got %#v", rulesTool.Annotations)
+	}
+}
+
+func TestMCPToolsListAnnotationsUseDefaultAgentScopedRules(t *testing.T) {
+	defaultAgent := store.AgentRecord{ID: "agent-default", VMCUID: "vm-default", AgentIDs: "[]"}
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "bash-deny-other", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Bash"}, AgentIDPattern: "*", AgentCUIDs: []string{"agent-other"}, Enabled: true, Order: 0},
+		{ID: "bash-auto-default", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Bash"}, AgentIDPattern: "*", AgentCUIDs: []string{defaultAgent.ID}, Enabled: true, Order: 1},
+		{ID: "bash-human-fallback", Action: invocation.RuleActionHumanApproval, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Bash"}, AgentIDPattern: "*", Enabled: true, Order: 2},
+	}}
+	svc := &stubService{tools: []mcp.Tool{{Name: "Bash", Description: "run a shell command"}}}
+	agents := &stubAgentsRepo{byVMCUID: map[string]store.AgentRecord{defaultAgent.VMCUID: defaultAgent}}
+	settings := &stubAgentSyncSettingsRepo{settings: store.AgentSyncSettings{DefaultAgentVMCUID: defaultAgent.VMCUID}}
+	h := NewHandler(svc, stubServerService{}, nil, rules, agents, settings, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var rpcResp struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				Description string `json:"description"`
+				Annotations *struct {
+					Atryum struct {
+						EffectiveAction string `json:"effective_action"`
+						MatchedRuleID   string `json:"matched_rule_id"`
+					} `json:"atryum"`
+				} `json:"annotations"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &rpcResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rpcResp.Result.Tools) == 0 {
+		t.Fatalf("expected tools, got %#v", rpcResp.Result.Tools)
+	}
+	bashTool := rpcResp.Result.Tools[0]
+	if bashTool.Name != "Bash" {
+		t.Fatalf("expected Bash tool, got %q", bashTool.Name)
+	}
+	if bashTool.Annotations == nil || bashTool.Annotations.Atryum.EffectiveAction != invocation.RuleActionAutoApprove {
+		t.Fatalf("Bash tool annotations: %#v", bashTool.Annotations)
+	}
+	if bashTool.Annotations.Atryum.MatchedRuleID != "bash-auto-default" {
+		t.Fatalf("Bash matched rule: %q", bashTool.Annotations.Atryum.MatchedRuleID)
+	}
+	if !strings.HasPrefix(bashTool.Description, "[atryum policy: auto_approve]") {
+		t.Fatalf("Bash description prefix: %q", bashTool.Description)
 	}
 }
 

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -59,6 +59,7 @@ func newApproval(status, reason string, confidence *float64) *Approval {
 // resolve an agent's VM CUID from its runtime agent ID.
 type AgentLookup interface {
 	GetByAgentID(ctx context.Context, agentID string) (AgentRecord, error)
+	GetByVMCUID(ctx context.Context, vmCUID string) (AgentRecord, error)
 }
 
 // AgentRecord is a lightweight copy of store.AgentRecord used within the
@@ -87,6 +88,7 @@ type SummaryClient interface {
 // the Settings UI are picked up immediately without a restart.
 type SyncSettingsProvider interface {
 	ConstitutionFieldKey(ctx context.Context) string
+	DefaultAgentVMCUID(ctx context.Context) string
 	SummarySettings(ctx context.Context) (orgCUID string, modelConfigCUID string)
 }
 
@@ -287,7 +289,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 					decision = policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (auto_approve)"}
 				case RuleActionAIEvaluation:
 					var conf *float64
-					decision, conf = s.runAIEvaluation(ctx, &r, upstream.Name, req.Tool, req.Input, agentID)
+					decision, conf = s.runAIEvaluation(ctx, &r, upstream.Name, req.Tool, req.Input, agentID, agentRec)
 					if decision.Disposition != dispositionContinue {
 						aiConfidence = conf
 					}
@@ -358,13 +360,28 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 // cannot be found or when agents lookup is not configured — callers treat an
 // empty ID as "match all agents" in rule filtering.
 func (s *Service) resolveAgentRecord(ctx context.Context, agentID string) AgentRecord {
-	if s.agents == nil || agentID == "" {
+	if s.agents == nil {
 		return AgentRecord{}
 	}
-	rec, err := s.agents.GetByAgentID(ctx, agentID)
-	if err != nil {
-		slog.Warn("could not resolve agent record for rule matching; agent-scoped rules will not match",
+	if agentID != "" {
+		rec, err := s.agents.GetByAgentID(ctx, agentID)
+		if err == nil {
+			return rec
+		}
+		slog.Warn("could not resolve agent record for runtime agent id; falling back to default agent record if configured",
 			"agent_id", agentID, "error", err)
+	}
+	defaultVMCUID := ""
+	if s.syncSettings != nil {
+		defaultVMCUID = strings.TrimSpace(s.syncSettings.DefaultAgentVMCUID(ctx))
+	}
+	if defaultVMCUID == "" {
+		return AgentRecord{}
+	}
+	rec, err := s.agents.GetByVMCUID(ctx, defaultVMCUID)
+	if err != nil {
+		slog.Warn("could not resolve default agent record",
+			"default_agent_vm_cuid", defaultVMCUID, "error", err)
 		return AgentRecord{}
 	}
 	return rec
@@ -373,7 +390,7 @@ func (s *Service) resolveAgentRecord(ctx context.Context, agentID string) AgentR
 // runAIEvaluation calls the VM backend's evaluate endpoint and translates the
 // LLM verdict into a policy.Decision. On any error or if the evaluator is not
 // configured, it falls back to DispositionHuman so no invocation is silently lost.
-func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serverName, toolName string, toolArgs map[string]any, agentID string) (policy.Decision, *float64) {
+func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serverName, toolName string, toolArgs map[string]any, agentID string, agentRec AgentRecord) (policy.Decision, *float64) {
 	if s.evaluator == nil {
 		slog.Warn("ai_evaluation rule matched but no evaluator configured; falling back to human_approval",
 			"rule_id", rule.ID, "tool", toolName, "server", serverName)
@@ -384,19 +401,8 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 	// fetched server-side and the request can be cross-validated against the org.
 	agentVMCUID := ""
 	orgCUID := ""
-	if s.agents != nil && agentID != "" {
-		rec, err := s.agents.GetByAgentID(ctx, agentID)
-		if err != nil {
-			slog.Error("ai_evaluation: could not resolve agent record; denying tool call",
-				"rule_id", rule.ID, "agent_id", agentID, "tool", toolName, "error", err)
-			return policy.Decision{
-				Disposition: policy.DispositionNever,
-				Reason:      "ai_evaluation denied: no agent identity (could not resolve agent record)",
-			}, nil
-		}
-		agentVMCUID = rec.VMCUID
-		orgCUID = rec.VMOrganizationCUID
-	}
+	agentVMCUID = agentRec.VMCUID
+	orgCUID = agentRec.VMOrganizationCUID
 
 	constitutionFieldKey := ""
 	if s.syncSettings != nil {
@@ -777,7 +783,7 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 			for _, rule := range matchRules(approvalRules, source, req.Tool, user, agentRec.ID) {
 				r := rule
 				if r.Action == RuleActionAIEvaluation {
-					d, conf := s.runAIEvaluation(ctx, &r, source, req.Tool, req.Input, agentID)
+					d, conf := s.runAIEvaluation(ctx, &r, source, req.Tool, req.Input, agentID, agentRec)
 					if d.Disposition == dispositionContinue {
 						slog.Info("ai_evaluation: LLM deferred to next rule; continuing rule iteration",
 							"rule_id", r.ID, "server", source, "tool", req.Tool)

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"atryum/internal/auth"
 	"atryum/internal/config"
 	"atryum/internal/invocation"
 	"atryum/internal/invocation/policy"
@@ -310,6 +311,75 @@ func TestSubmitPendingApprovalAutomaticallySummarizesInvocation(t *testing.T) {
 	}
 }
 
+func TestSubmitAIEvaluationUsesDefaultAgentRecordForUnmappedAgentID(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	invRepo := store.NewInvocationRepo(db)
+	eventRepo := store.NewEventRepo(db)
+	evaluator := &evaluateClientStub{
+		resp: invocation.EvaluateResponse{Verdict: "approved", Reason: "default constitution allows this"},
+	}
+	defaultAgent := invocation.AgentRecord{
+		ID:                 "agent-local-default",
+		VMCUID:             "agent-vm-default",
+		VMOrganizationCUID: "org-default",
+	}
+	service := invocation.NewService(
+		invRepo,
+		eventRepo,
+		nil,
+		nil,
+		nil,
+		5*time.Second,
+		rulesStoreStub{rules: []invocation.ApprovalRule{{
+			ID:              "rule-ai",
+			Action:          invocation.RuleActionAIEvaluation,
+			ToolPatterns:    []string{"bash"},
+			ModelConfigCUID: "model-ai",
+			AgentCUIDs:      []string{defaultAgent.ID},
+			Enabled:         true,
+		}}},
+		agentLookupStub{byVMCUID: map[string]invocation.AgentRecord{defaultAgent.VMCUID: defaultAgent}},
+		evaluator,
+		summarySettingsStub{
+			constitutionFieldKey: "constitution",
+			defaultAgentVMCUID:   defaultAgent.VMCUID,
+		},
+	)
+
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "hunners-codex"})
+	resp, err := service.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source: "github",
+		Tool:   "bash",
+		Input:  map[string]any{"cmd": "pwd"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusApproved {
+		t.Fatalf("status = %q", resp.Status)
+	}
+	req := evaluator.request()
+	if req.AgentVMCUID != defaultAgent.VMCUID {
+		t.Fatalf("AgentVMCUID = %q", req.AgentVMCUID)
+	}
+	if req.OrgCUID != defaultAgent.VMOrganizationCUID {
+		t.Fatalf("OrgCUID = %q", req.OrgCUID)
+	}
+	if req.ConstitutionFieldKey != "constitution" {
+		t.Fatalf("ConstitutionFieldKey = %q", req.ConstitutionFieldKey)
+	}
+	if req.ModelConfigCUID != "model-ai" {
+		t.Fatalf("ModelConfigCUID = %q", req.ModelConfigCUID)
+	}
+}
+
 func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 	t.Helper()
 	db, err := sql.Open("sqlite", ":memory:")
@@ -348,16 +418,72 @@ func (s *summaryClientStub) request() invocation.SummaryRequest {
 }
 
 type summarySettingsStub struct {
-	orgCUID         string
-	modelConfigCUID string
+	orgCUID              string
+	modelConfigCUID      string
+	constitutionFieldKey string
+	defaultAgentVMCUID   string
 }
 
 func (s summarySettingsStub) ConstitutionFieldKey(context.Context) string {
-	return ""
+	return s.constitutionFieldKey
+}
+
+func (s summarySettingsStub) DefaultAgentVMCUID(context.Context) string {
+	return s.defaultAgentVMCUID
 }
 
 func (s summarySettingsStub) SummarySettings(context.Context) (string, string) {
 	return s.orgCUID, s.modelConfigCUID
+}
+
+type rulesStoreStub struct {
+	rules []invocation.ApprovalRule
+}
+
+func (s rulesStoreStub) ListApprovalRules(context.Context) ([]invocation.ApprovalRule, error) {
+	return s.rules, nil
+}
+
+type agentLookupStub struct {
+	byAgentID map[string]invocation.AgentRecord
+	byVMCUID  map[string]invocation.AgentRecord
+}
+
+func (s agentLookupStub) GetByAgentID(_ context.Context, agentID string) (invocation.AgentRecord, error) {
+	if s.byAgentID != nil {
+		if rec, ok := s.byAgentID[agentID]; ok {
+			return rec, nil
+		}
+	}
+	return invocation.AgentRecord{}, sql.ErrNoRows
+}
+
+func (s agentLookupStub) GetByVMCUID(_ context.Context, vmCUID string) (invocation.AgentRecord, error) {
+	if s.byVMCUID != nil {
+		if rec, ok := s.byVMCUID[vmCUID]; ok {
+			return rec, nil
+		}
+	}
+	return invocation.AgentRecord{}, sql.ErrNoRows
+}
+
+type evaluateClientStub struct {
+	mu   sync.Mutex
+	req  invocation.EvaluateRequest
+	resp invocation.EvaluateResponse
+}
+
+func (s *evaluateClientStub) EvaluateToolCall(_ context.Context, req invocation.EvaluateRequest) (invocation.EvaluateResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.req = req
+	return s.resp, nil
+}
+
+func (s *evaluateClientStub) request() invocation.EvaluateRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.req
 }
 
 func approveNextInvocation(t *testing.T, service *invocation.Service, delay time.Duration) {

--- a/internal/store/agent_sync_settings.go
+++ b/internal/store/agent_sync_settings.go
@@ -18,11 +18,12 @@ type AgentSyncSettings struct {
 	AgentRecordTypeSlug    string
 	ConstitutionFieldKey   string
 	SummaryModelConfigCUID string
+	DefaultAgentVMCUID     string
 	UpdatedAt              time.Time
 }
 
 var agentSyncSettingsColumns = []string{
-	"org_cuid", "agent_record_type_slug", "constitution_field_key", "summary_model_config_cuid", "updated_at",
+	"org_cuid", "agent_record_type_slug", "constitution_field_key", "summary_model_config_cuid", "default_agent_vm_cuid", "updated_at",
 }
 
 // AgentSyncSettingsRepo provides read/write access to the singleton
@@ -72,19 +73,20 @@ func (r *AgentSyncSettingsRepo) Save(ctx context.Context, s AgentSyncSettings) e
 	var args []any
 	if r.dialect == DialectPostgres {
 		// PostgreSQL upsert
-		query = `INSERT INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, updated_at)
-VALUES (1, $1, $2, $3, $4, $5)
+		query = `INSERT INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, default_agent_vm_cuid, updated_at)
+VALUES (1, $1, $2, $3, $4, $5, $6)
 ON CONFLICT (id) DO UPDATE SET
   org_cuid                  = EXCLUDED.org_cuid,
   agent_record_type_slug    = EXCLUDED.agent_record_type_slug,
   constitution_field_key    = EXCLUDED.constitution_field_key,
   summary_model_config_cuid = EXCLUDED.summary_model_config_cuid,
+  default_agent_vm_cuid     = EXCLUDED.default_agent_vm_cuid,
   updated_at                = EXCLUDED.updated_at`
-		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, now}
+		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, s.DefaultAgentVMCUID, now}
 	} else {
 		// SQLite: INSERT OR REPLACE replaces the row when the primary key conflicts.
-		query = `INSERT OR REPLACE INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, updated_at) VALUES (1, ?, ?, ?, ?, ?)`
-		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, now}
+		query = `INSERT OR REPLACE INTO agent_sync_settings (id, org_cuid, agent_record_type_slug, constitution_field_key, summary_model_config_cuid, default_agent_vm_cuid, updated_at) VALUES (1, ?, ?, ?, ?, ?, ?)`
+		args = []any{s.OrgCUID, s.AgentRecordTypeSlug, s.ConstitutionFieldKey, s.SummaryModelConfigCUID, s.DefaultAgentVMCUID, now}
 	}
 	result, err := r.db.ExecContext(ctx, query, args...)
 	if err != nil {
@@ -103,6 +105,7 @@ func scanAgentSyncSettings(row interface{ Scan(dest ...any) error }) (AgentSyncS
 		&s.AgentRecordTypeSlug,
 		&s.ConstitutionFieldKey,
 		&s.SummaryModelConfigCUID,
+		&s.DefaultAgentVMCUID,
 		&s.UpdatedAt,
 	); err != nil {
 		return AgentSyncSettings{}, err

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 14 {
+	if len(migrations) != 15 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -67,6 +67,7 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{12, "012_invocation_summary"},
 		{13, "013_summary_model_config"},
 		{14, "014_invocation_client_info.sql"},
+		{15, "015_default_agent_record"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -77,10 +78,10 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 13 {
+	if len(pending) != 14 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
+	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	for i, want := range wantVersions {
 		if pending[i].Version != want {
 			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)

--- a/internal/store/migrations/015_default_agent_record.go
+++ b/internal/store/migrations/015_default_agent_record.go
@@ -1,0 +1,13 @@
+package migrations
+
+func migration015() Definition {
+	return Definition{
+		Version: 15,
+		Name:    "015_default_agent_record",
+		Steps: []Step{
+			Raw("add default agent record to sync settings", `
+				ALTER TABLE agent_sync_settings ADD COLUMN default_agent_vm_cuid TEXT NOT NULL DEFAULT ''
+			`),
+		},
+	}
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -48,5 +48,6 @@ func All() []Definition {
 		migration012(),
 		migration013(),
 		migration014(),
+		migration015(),
 	}
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -41,8 +41,8 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 14 {
-		t.Fatalf("expected 14 migrations, got %d", count)
+	if count != 15 {
+		t.Fatalf("expected 15 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 14 {
-		t.Fatalf("expected 14 migrations after double init, got %d", count)
+	if count != 15 {
+		t.Fatalf("expected 15 migrations after double init, got %d", count)
 	}
 }
 
@@ -762,6 +762,7 @@ func TestAgentSyncSettingsRepo_UpsertOnEmptyTable(t *testing.T) {
 		AgentRecordTypeSlug:    "ai-agents",
 		ConstitutionFieldKey:   "constitution",
 		SummaryModelConfigCUID: "model-abc",
+		DefaultAgentVMCUID:     "agent-vm-abc",
 	})
 	if err != nil {
 		t.Fatalf("Save: %v", err)
@@ -780,5 +781,8 @@ func TestAgentSyncSettingsRepo_UpsertOnEmptyTable(t *testing.T) {
 	}
 	if s.SummaryModelConfigCUID != "model-abc" {
 		t.Fatalf("expected SummaryModelConfigCUID=model-abc, got %q", s.SummaryModelConfigCUID)
+	}
+	if s.DefaultAgentVMCUID != "agent-vm-abc" {
+		t.Fatalf("expected DefaultAgentVMCUID=agent-vm-abc, got %q", s.DefaultAgentVMCUID)
 	}
 }


### PR DESCRIPTION
## Summary

- Accept `?agent_id=` as a no-auth MCP identity hint only when no inbound `[[auth]]` validator is configured.
- Restrict no-auth `agent_id` hints to conservative ASCII identifier characters.
- Add a DB-backed default ValidMind agent record setting for no-auth and unmapped agent IDs.
- Use the default agent record for AI Evaluation context when the runtime agent ID is missing or not mapped.
- Document local no-auth identity hints and the default agent record setting in the README.

## Impact

Local `./atryum` runs can keep no-auth MCP ergonomics while still providing AI Evaluation with a ValidMind agent record and constitution. Authenticated deployments continue to ignore query-string agent IDs.

## Validation

- `go test ./...`
- `just build-prod && ./atryum -h`
