### PR TITLE
[codex] Handle upstream MCP session negotiation

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3030,6 +3030,10 @@ func normalizeProtocolVersion(value string) string {
 	switch strings.TrimSpace(value) {
 	case mcp.MCPProtocolVersion2025:
 		return mcp.MCPProtocolVersion2025
+	case mcp.MCPProtocolVersion2025_06_18:
+		return mcp.MCPProtocolVersion2025_06_18
+	case mcp.MCPProtocolVersion2025_03_26:
+		return mcp.MCPProtocolVersion2025_03_26
 	case mcp.MCPProtocolVersion2024:
 		return mcp.MCPProtocolVersion2024
 	default:

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"net/http"
@@ -601,12 +602,17 @@ func (h *Handler) handleMCPSSE(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "streaming not supported")
 		return
 	}
+	protocolVersion := normalizeProtocolVersion(r.Header.Get("MCP-Protocol-Version"))
+	if protocolVersion == "" {
+		protocolVersion = mcp.DefaultMCPProtocolVersion
+	}
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
+	setMCPProtocolVersionHeader(w, protocolVersion)
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, ": atryum mcp ready\n\n")
+	writeSSEComment(w, "atryum mcp ready")
 	flusher.Flush()
 
 	ticker := time.NewTicker(15 * time.Second)
@@ -616,10 +622,17 @@ func (h *Handler) handleMCPSSE(w http.ResponseWriter, r *http.Request) {
 		case <-r.Context().Done():
 			return
 		case <-ticker.C:
-			fmt.Fprintf(w, ": ping\n\n")
+			writeSSEComment(w, "ping")
 			flusher.Flush()
 		}
 	}
+}
+
+func writeSSEComment(w io.Writer, comment string) {
+	for _, line := range strings.Split(comment, "\n") {
+		fmt.Fprintf(w, ": %s\n", line)
+	}
+	fmt.Fprint(w, "\n")
 }
 
 func isJSONRPCRequest(r *http.Request) bool {
@@ -806,7 +819,7 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 		req.JSONRPC = "2.0"
 	}
 	requestID := compactRequestID(req.ID)
-	protocolVersion := negotiateProtocolVersion(r.Header.Get("MCP-Protocol-Version"), req.Params)
+	protocolVersion := negotiateProtocolVersion(req.Method, r.Header.Get("MCP-Protocol-Version"), req.Params)
 	h.debugf("server-side mcp request server=%s method=%s id=%s", server, req.Method, requestID)
 	defer func() {
 		h.debugf("server-side mcp complete server=%s method=%s id=%s duration_ms=%d", server, req.Method, requestID, time.Since(started).Milliseconds())
@@ -3011,17 +3024,29 @@ func (h *Handler) forwardProxyEnvelope(ctx context.Context, server string, envel
 	return result, true
 }
 
-func negotiateProtocolVersion(header string, params json.RawMessage) string {
-	if v := normalizeProtocolVersion(header); v != "" {
-		return v
-	}
+func negotiateProtocolVersion(method, header string, params json.RawMessage) string {
 	var payload struct {
 		ProtocolVersion string `json:"protocolVersion"`
 	}
-	if err := json.Unmarshal(params, &payload); err == nil {
-		if v := normalizeProtocolVersion(payload.ProtocolVersion); v != "" {
-			return v
+	if strings.TrimSpace(method) == "initialize" {
+		if err := json.Unmarshal(params, &payload); err == nil {
+			if v := normalizeProtocolVersion(payload.ProtocolVersion); v != "" {
+				return v
+			}
 		}
+	}
+	if v := normalizeProtocolVersion(header); v != "" {
+		return v
+	}
+	if strings.TrimSpace(method) != "initialize" {
+		if err := json.Unmarshal(params, &payload); err == nil {
+			if v := normalizeProtocolVersion(payload.ProtocolVersion); v != "" {
+				return v
+			}
+		}
+	}
+	if strings.TrimSpace(method) == "initialize" {
+		return mcp.MCPProtocolVersion2025_06_18
 	}
 	return mcp.DefaultMCPProtocolVersion
 }

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -261,7 +261,7 @@ func (s *stubAgentsRepo) DeleteAll(context.Context) error {
 
 func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil)
-	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05"}}`))
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("MCP-Protocol-Version", "2025-11-25")
 	w := httptest.NewRecorder()
@@ -271,7 +271,7 @@ func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	if got := w.Header().Get("MCP-Protocol-Version"); got != "2025-11-25" {
+	if got := w.Header().Get("MCP-Protocol-Version"); got != "2025-06-18" {
 		t.Fatalf("expected negotiated header, got %q", got)
 	}
 	var resp map[string]any
@@ -279,8 +279,8 @@ func TestMCPInitializeNegotiatesProtocolVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	result := resp["result"].(map[string]any)
-	if result["protocolVersion"] != "2025-11-25" {
-		t.Fatalf("expected protocol version 2025-11-25, got %#v", result["protocolVersion"])
+	if result["protocolVersion"] != "2025-06-18" {
+		t.Fatalf("expected protocol version 2025-06-18, got %#v", result["protocolVersion"])
 	}
 	instructions, ok := result["instructions"].(string)
 	if !ok || !strings.Contains(instructions, "atryum.rules.get") {
@@ -480,6 +480,7 @@ func TestMCPGetOpenSSEStream(t *testing.T) {
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, "/mcp/demo", nil).WithContext(ctx)
+	req.Header.Set("MCP-Protocol-Version", "2025-06-18")
 	w := httptest.NewRecorder()
 	done := make(chan struct{})
 	go func() {
@@ -494,6 +495,12 @@ func TestMCPGetOpenSSEStream(t *testing.T) {
 	}
 	if ct := w.Header().Get("Content-Type"); !strings.Contains(ct, "text/event-stream") {
 		t.Fatalf("expected text/event-stream, got %s", ct)
+	}
+	if got := w.Header().Get("MCP-Protocol-Version"); got != "2025-06-18" {
+		t.Fatalf("expected protocol header, got %q", got)
+	}
+	if !strings.Contains(w.Body.String(), ": atryum mcp ready\n\n") {
+		t.Fatalf("expected initial SSE ready comment, got %q", w.Body.String())
 	}
 }
 

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -30,9 +30,11 @@ const (
 )
 
 const (
-	MCPProtocolVersion2024    = "2024-11-05"
-	MCPProtocolVersion2025    = "2025-11-25"
-	DefaultMCPProtocolVersion = MCPProtocolVersion2025
+	MCPProtocolVersion2024       = "2024-11-05"
+	MCPProtocolVersion2025_03_26 = "2025-03-26"
+	MCPProtocolVersion2025_06_18 = "2025-06-18"
+	MCPProtocolVersion2025       = "2025-11-25"
+	DefaultMCPProtocolVersion    = MCPProtocolVersion2025
 )
 
 type ServerConnectionStatus string
@@ -224,10 +226,13 @@ type Client struct {
 	// (since spec rev 2025-03-26) lets a server require an `Mcp-Session-Id`
 	// header on every non-initialize request. We initialize lazily, cache
 	// the id, and clear it on 404 (server-side expiry) so the next call
-	// re-inits. Stateless upstreams (those that never return the header)
-	// stay as empty strings.
-	sessionMu sync.Mutex
-	sessions  map[string]string
+	// re-inits. The protocol version is kept with the session because
+	// fallback may initialize older servers with 2025-03-26 while Atryum's
+	// default remains newer. Stateless upstreams (those that never return
+	// the header) stay as empty strings.
+	sessionMu        sync.Mutex
+	sessions         map[string]string
+	sessionProtocols map[string]string
 }
 
 type InvokeResult struct {
@@ -284,7 +289,7 @@ func (r *Resolver) WithCredentials(credentials CredentialStore) *Resolver {
 
 func NewHTTPClient() *Client {
 	debug := strings.EqualFold(os.Getenv("ATRYUM_MCP_DEBUG"), "1") || strings.EqualFold(os.Getenv("ATRYUM_MCP_DEBUG"), "true")
-	return &Client{httpClient: &http.Client{}, debug: debug, sessions: make(map[string]string)}
+	return &Client{httpClient: &http.Client{}, debug: debug, sessions: make(map[string]string), sessionProtocols: make(map[string]string)}
 }
 
 func (r *Resolver) Resolve(name string) (Upstream, error) {
@@ -529,6 +534,21 @@ func (c *Client) invokeHTTP(ctx context.Context, upstream Upstream, tool string,
 		return InvokeResult{}, err
 	}
 	if len(rpcResp.Error) > 0 && string(rpcResp.Error) != "null" {
+		if isMissingSessionRPCError(rpcResp.Error) {
+			if retryErr := c.reinitializeRequiredHTTPSession(ctx, upstream); retryErr != nil {
+				return InvokeResult{}, retryErr
+			}
+			result, err = c.doHTTPEnvelope(ctx, upstream, body, DefaultMCPProtocolVersion)
+			if err != nil {
+				return InvokeResult{}, err
+			}
+			rpcResp = rpcResponse{}
+			if err := json.Unmarshal(result.Body, &rpcResp); err != nil {
+				return InvokeResult{}, err
+			}
+		}
+	}
+	if len(rpcResp.Error) > 0 && string(rpcResp.Error) != "null" {
 		return InvokeResult{StatusCode: result.StatusCode, Body: rpcResp.Error, Failed: true}, nil
 	}
 	bodyBytes := rpcResp.Result
@@ -555,6 +575,21 @@ func (c *Client) listToolsHTTP(ctx context.Context, upstream Upstream) ([]Tool, 
 	var rpcResp rpcResponse
 	if err := json.Unmarshal(result.Body, &rpcResp); err != nil {
 		return nil, err
+	}
+	if len(rpcResp.Error) > 0 && string(rpcResp.Error) != "null" {
+		if isMissingSessionRPCError(rpcResp.Error) {
+			if retryErr := c.reinitializeRequiredHTTPSession(ctx, upstream); retryErr != nil {
+				return nil, retryErr
+			}
+			result, err = c.doHTTPEnvelope(ctx, upstream, body, DefaultMCPProtocolVersion)
+			if err != nil {
+				return nil, err
+			}
+			rpcResp = rpcResponse{}
+			if err := json.Unmarshal(result.Body, &rpcResp); err != nil {
+				return nil, err
+			}
+		}
 	}
 	if len(rpcResp.Error) > 0 && string(rpcResp.Error) != "null" {
 		return nil, fmt.Errorf("upstream tools/list error: %s", string(rpcResp.Error))
@@ -601,7 +636,13 @@ func (c *Client) doHTTPEnvelopeRaw(ctx context.Context, upstream Upstream, body 
 
 func (c *Client) doHTTPEnvelope(ctx context.Context, upstream Upstream, body []byte, protocolVersion string) (ForwardResult, error) {
 	sessionID := c.getSession(upstream.Name)
-	resp, err := c.doHTTPEnvelopeRaw(ctx, upstream, body, protocolVersion, sessionID)
+	effectiveProtocol := protocolVersion
+	if sessionID != "" {
+		if sessionProtocol := c.getSessionProtocol(upstream.Name); sessionProtocol != "" {
+			effectiveProtocol = sessionProtocol
+		}
+	}
+	resp, err := c.doHTTPEnvelopeRaw(ctx, upstream, body, effectiveProtocol, sessionID)
 	if err != nil {
 		return ForwardResult{}, err
 	}
@@ -609,7 +650,7 @@ func (c *Client) doHTTPEnvelope(ctx context.Context, upstream Upstream, body []b
 	// Capture/clear session id based on response. 404 with an existing
 	// session means the server forgot us; drop it so the next call inits.
 	if newSession := strings.TrimSpace(resp.Header.Get("Mcp-Session-Id")); newSession != "" {
-		c.setSession(upstream.Name, newSession)
+		c.setSession(upstream.Name, newSession, effectiveProtocol)
 	} else if resp.StatusCode == http.StatusNotFound && sessionID != "" {
 		c.clearSession(upstream.Name)
 	}
@@ -635,16 +676,33 @@ func (c *Client) getSession(name string) string {
 	return c.sessions[name]
 }
 
-func (c *Client) setSession(name, id string) {
+func (c *Client) getSessionProtocol(name string) string {
+	c.sessionMu.Lock()
+	defer c.sessionMu.Unlock()
+	return c.sessionProtocols[name]
+}
+
+func (c *Client) setSession(name, id, protocolVersion string) {
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
 	c.sessions[name] = id
+	c.sessionProtocols[name] = protocolVersion
 }
 
 func (c *Client) clearSession(name string) {
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
 	delete(c.sessions, name)
+	delete(c.sessionProtocols, name)
+}
+
+func httpProtocolCandidates() []string {
+	return []string{
+		DefaultMCPProtocolVersion,
+		MCPProtocolVersion2025_06_18,
+		MCPProtocolVersion2025_03_26,
+		MCPProtocolVersion2024,
+	}
 }
 
 // ensureHTTPSession initializes the upstream session if not yet established,
@@ -652,36 +710,84 @@ func (c *Client) clearSession(name string) {
 // Mcp-Session-Id). Required by spec-compliant servers (e.g. Shortcut) which
 // reject non-initialize requests that arrive without a session id.
 func (c *Client) ensureHTTPSession(ctx context.Context, upstream Upstream) error {
+	return c.ensureHTTPSessionMode(ctx, upstream, false)
+}
+
+func (c *Client) reinitializeRequiredHTTPSession(ctx context.Context, upstream Upstream) error {
+	c.clearSession(upstream.Name)
+	return c.ensureHTTPSessionMode(ctx, upstream, true)
+}
+
+func (c *Client) ensureHTTPSessionMode(ctx context.Context, upstream Upstream, requireSession bool) error {
 	if c.getSession(upstream.Name) != "" {
 		return nil
 	}
+	var lastErr error
+	for _, protocolVersion := range httpProtocolCandidates() {
+		hadSession, err := c.initializeHTTPSession(ctx, upstream, protocolVersion)
+		if err != nil {
+			lastErr = err
+			if isProtocolNegotiationError(err) {
+				continue
+			}
+			return err
+		}
+		if !requireSession || hadSession {
+			return nil
+		}
+		lastErr = fmt.Errorf("upstream initialize using MCP %s did not return Mcp-Session-Id", protocolVersion)
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("upstream initialize failed")
+}
+
+func (c *Client) initializeHTTPSession(ctx context.Context, upstream Upstream, protocolVersion string) (bool, error) {
 	initBody, err := json.Marshal(Envelope{
 		JSONRPC: "2.0",
 		ID:      json.RawMessage([]byte("1")),
 		Method:  "initialize",
 		Params: mustRawJSON(map[string]any{
-			"protocolVersion": DefaultMCPProtocolVersion,
+			"protocolVersion": protocolVersion,
 			"clientInfo":      map[string]any{"name": "atryum", "version": "0.1.0"},
 			"capabilities":    map[string]any{},
 		}),
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	// doHTTPEnvelope reads the Mcp-Session-Id response header and stores it.
-	if _, err := c.doHTTPEnvelope(ctx, upstream, initBody, DefaultMCPProtocolVersion); err != nil {
-		return err
+	result, err := c.doHTTPEnvelope(ctx, upstream, initBody, protocolVersion)
+	if err != nil {
+		return false, err
+	}
+	if result.StatusCode >= http.StatusBadRequest {
+		c.clearSession(upstream.Name)
+		return false, fmt.Errorf("upstream initialize using MCP %s failed: http %d: %s", protocolVersion, result.StatusCode, extractErrorDetail(result.Body))
+	}
+	if len(bytes.TrimSpace(result.Body)) > 0 {
+		var rpcResp rpcResponse
+		if err := json.Unmarshal(result.Body, &rpcResp); err != nil {
+			c.clearSession(upstream.Name)
+			return false, fmt.Errorf("upstream initialize using MCP %s returned invalid JSON-RPC: %w", protocolVersion, err)
+		}
+		if len(rpcResp.Error) > 0 && string(rpcResp.Error) != "null" {
+			c.clearSession(upstream.Name)
+			return false, fmt.Errorf("upstream initialize using MCP %s error: %s", protocolVersion, rpcErrorDetail(rpcResp.Error))
+		}
 	}
 	// Spec requires the client to send notifications/initialized after a
 	// successful initialize. Stateless servers ignore it; stateful ones need
 	// it to mark the session usable.
-	if c.getSession(upstream.Name) != "" {
+	hadSession := c.getSession(upstream.Name) != ""
+	if hadSession {
 		notifyBody, err := json.Marshal(Envelope{JSONRPC: "2.0", Method: "notifications/initialized", Params: mustRawJSON(map[string]any{})})
 		if err == nil {
-			_, _ = c.doHTTPEnvelope(ctx, upstream, notifyBody, DefaultMCPProtocolVersion)
+			_, _ = c.doHTTPEnvelope(ctx, upstream, notifyBody, protocolVersion)
 		}
 	}
-	return nil
+	return hadSession, nil
 }
 
 func (c *Client) invokeStdio(ctx context.Context, upstream Upstream, tool string, input map[string]any) (InvokeResult, error) {
@@ -1062,6 +1168,36 @@ func extractErrorDetail(body []byte) string {
 		trimmed = trimmed[:200] + "..."
 	}
 	return trimmed
+}
+
+func rpcErrorDetail(body json.RawMessage) string {
+	if len(body) == 0 || string(body) == "null" {
+		return ""
+	}
+	var rpcErr struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &rpcErr); err == nil && strings.TrimSpace(rpcErr.Message) != "" {
+		if rpcErr.Code != 0 {
+			return fmt.Sprintf(`{"code":%d,"message":%q}`, rpcErr.Code, rpcErr.Message)
+		}
+		return rpcErr.Message
+	}
+	return strings.TrimSpace(string(body))
+}
+
+func isProtocolNegotiationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "protocol")
+}
+
+func isMissingSessionRPCError(body json.RawMessage) bool {
+	lower := strings.ToLower(rpcErrorDetail(body))
+	return strings.Contains(lower, "session") && strings.Contains(lower, "no session")
 }
 
 func classifyAuthFailure(message string) (ServerAuthStatus, bool) {

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -231,6 +231,7 @@ type Client struct {
 	// default remains newer. Stateless upstreams (those that never return
 	// the header) stay as empty strings.
 	sessionMu        sync.Mutex
+	sessionInitLocks map[string]*sync.Mutex
 	sessions         map[string]string
 	sessionProtocols map[string]string
 }
@@ -246,6 +247,8 @@ type ForwardResult struct {
 	Body            []byte
 	ContentType     string
 	ProtocolVersion string
+	SessionExpired  bool
+	SessionID       string
 }
 
 type ConnectionTestResult struct {
@@ -289,7 +292,7 @@ func (r *Resolver) WithCredentials(credentials CredentialStore) *Resolver {
 
 func NewHTTPClient() *Client {
 	debug := strings.EqualFold(os.Getenv("ATRYUM_MCP_DEBUG"), "1") || strings.EqualFold(os.Getenv("ATRYUM_MCP_DEBUG"), "true")
-	return &Client{httpClient: &http.Client{}, debug: debug, sessions: make(map[string]string), sessionProtocols: make(map[string]string)}
+	return &Client{httpClient: &http.Client{}, debug: debug, sessionInitLocks: make(map[string]*sync.Mutex), sessions: make(map[string]string), sessionProtocols: make(map[string]string)}
 }
 
 func (r *Resolver) Resolve(name string) (Upstream, error) {
@@ -525,7 +528,7 @@ func (c *Client) invokeHTTP(ctx context.Context, upstream Upstream, tool string,
 	if err != nil {
 		return InvokeResult{}, err
 	}
-	result, err := c.doHTTPEnvelope(ctx, upstream, body, DefaultMCPProtocolVersion)
+	result, err := c.doHTTPEnvelopeWithSessionRetry(ctx, upstream, body, DefaultMCPProtocolVersion)
 	if err != nil {
 		return InvokeResult{}, err
 	}
@@ -535,10 +538,10 @@ func (c *Client) invokeHTTP(ctx context.Context, upstream Upstream, tool string,
 	}
 	if len(rpcResp.Error) > 0 && string(rpcResp.Error) != "null" {
 		if isMissingSessionRPCError(rpcResp.Error) {
-			if retryErr := c.reinitializeRequiredHTTPSession(ctx, upstream); retryErr != nil {
+			if retryErr := c.reinitializeRequiredHTTPSession(ctx, upstream, result.SessionID); retryErr != nil {
 				return InvokeResult{}, retryErr
 			}
-			result, err = c.doHTTPEnvelope(ctx, upstream, body, DefaultMCPProtocolVersion)
+			result, err = c.doHTTPEnvelopeWithSessionRetry(ctx, upstream, body, DefaultMCPProtocolVersion)
 			if err != nil {
 				return InvokeResult{}, err
 			}
@@ -568,7 +571,7 @@ func (c *Client) listToolsHTTP(ctx context.Context, upstream Upstream) ([]Tool, 
 	if err != nil {
 		return nil, err
 	}
-	result, err := c.doHTTPEnvelope(ctx, upstream, body, DefaultMCPProtocolVersion)
+	result, err := c.doHTTPEnvelopeWithSessionRetry(ctx, upstream, body, DefaultMCPProtocolVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -578,10 +581,10 @@ func (c *Client) listToolsHTTP(ctx context.Context, upstream Upstream) ([]Tool, 
 	}
 	if len(rpcResp.Error) > 0 && string(rpcResp.Error) != "null" {
 		if isMissingSessionRPCError(rpcResp.Error) {
-			if retryErr := c.reinitializeRequiredHTTPSession(ctx, upstream); retryErr != nil {
+			if retryErr := c.reinitializeRequiredHTTPSession(ctx, upstream, result.SessionID); retryErr != nil {
 				return nil, retryErr
 			}
-			result, err = c.doHTTPEnvelope(ctx, upstream, body, DefaultMCPProtocolVersion)
+			result, err = c.doHTTPEnvelopeWithSessionRetry(ctx, upstream, body, DefaultMCPProtocolVersion)
 			if err != nil {
 				return nil, err
 			}
@@ -609,7 +612,7 @@ func (c *Client) forwardEnvelopeHTTP(ctx context.Context, upstream Upstream, env
 	if err != nil {
 		return ForwardResult{}, err
 	}
-	return c.doHTTPEnvelope(ctx, upstream, body, protocolVersion)
+	return c.doHTTPEnvelopeWithSessionRetry(ctx, upstream, body, protocolVersion)
 }
 
 func (c *Client) doHTTPEnvelopeRaw(ctx context.Context, upstream Upstream, body []byte, protocolVersion, sessionID string) (*http.Response, error) {
@@ -647,33 +650,61 @@ func (c *Client) doHTTPEnvelope(ctx context.Context, upstream Upstream, body []b
 		return ForwardResult{}, err
 	}
 	defer resp.Body.Close()
+	sessionExpired := false
 	// Capture/clear session id based on response. 404 with an existing
 	// session means the server forgot us; drop it so the next call inits.
 	if newSession := strings.TrimSpace(resp.Header.Get("Mcp-Session-Id")); newSession != "" {
 		c.setSession(upstream.Name, newSession, effectiveProtocol)
 	} else if resp.StatusCode == http.StatusNotFound && sessionID != "" {
-		c.clearSession(upstream.Name)
+		c.clearSessionIfCurrent(upstream.Name, sessionID)
+		sessionExpired = true
 	}
 	contentType := resp.Header.Get("Content-Type")
+	if sessionExpired {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return ForwardResult{StatusCode: resp.StatusCode, Body: bodyBytes, ContentType: contentType, ProtocolVersion: resp.Header.Get("MCP-Protocol-Version"), SessionExpired: true, SessionID: sessionID}, nil
+	}
 	if strings.Contains(contentType, "text/event-stream") {
 		data, sseErr := extractFirstSSEData(resp.Body)
 		if sseErr != nil {
 			return ForwardResult{}, sseErr
 		}
-		return ForwardResult{StatusCode: resp.StatusCode, Body: data, ContentType: "application/json", ProtocolVersion: resp.Header.Get("MCP-Protocol-Version")}, nil
+		return ForwardResult{StatusCode: resp.StatusCode, Body: data, ContentType: "application/json", ProtocolVersion: resp.Header.Get("MCP-Protocol-Version"), SessionID: sessionID}, nil
 	}
 	respBody := new(bytes.Buffer)
 	_, err = respBody.ReadFrom(resp.Body)
 	if err != nil {
 		return ForwardResult{}, err
 	}
-	return ForwardResult{StatusCode: resp.StatusCode, Body: respBody.Bytes(), ContentType: contentType, ProtocolVersion: resp.Header.Get("MCP-Protocol-Version")}, nil
+	return ForwardResult{StatusCode: resp.StatusCode, Body: respBody.Bytes(), ContentType: contentType, ProtocolVersion: resp.Header.Get("MCP-Protocol-Version"), SessionID: sessionID}, nil
+}
+
+func (c *Client) doHTTPEnvelopeWithSessionRetry(ctx context.Context, upstream Upstream, body []byte, protocolVersion string) (ForwardResult, error) {
+	result, err := c.doHTTPEnvelope(ctx, upstream, body, protocolVersion)
+	if err != nil || !result.SessionExpired {
+		return result, err
+	}
+	if err := c.reinitializeRequiredHTTPSession(ctx, upstream, result.SessionID); err != nil {
+		return ForwardResult{}, err
+	}
+	return c.doHTTPEnvelope(ctx, upstream, body, protocolVersion)
 }
 
 func (c *Client) getSession(name string) string {
 	c.sessionMu.Lock()
 	defer c.sessionMu.Unlock()
 	return c.sessions[name]
+}
+
+func (c *Client) getSessionInitLock(name string) *sync.Mutex {
+	c.sessionMu.Lock()
+	defer c.sessionMu.Unlock()
+	lock := c.sessionInitLocks[name]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		c.sessionInitLocks[name] = lock
+	}
+	return lock
 }
 
 func (c *Client) getSessionProtocol(name string) string {
@@ -696,6 +727,16 @@ func (c *Client) clearSession(name string) {
 	delete(c.sessionProtocols, name)
 }
 
+func (c *Client) clearSessionIfCurrent(name, id string) {
+	c.sessionMu.Lock()
+	defer c.sessionMu.Unlock()
+	if c.sessions[name] != id {
+		return
+	}
+	delete(c.sessions, name)
+	delete(c.sessionProtocols, name)
+}
+
 func httpProtocolCandidates() []string {
 	return []string{
 		DefaultMCPProtocolVersion,
@@ -713,15 +754,38 @@ func (c *Client) ensureHTTPSession(ctx context.Context, upstream Upstream) error
 	return c.ensureHTTPSessionMode(ctx, upstream, false)
 }
 
-func (c *Client) reinitializeRequiredHTTPSession(ctx context.Context, upstream Upstream) error {
-	c.clearSession(upstream.Name)
-	return c.ensureHTTPSessionMode(ctx, upstream, true)
+func (c *Client) reinitializeRequiredHTTPSession(ctx context.Context, upstream Upstream, failedSessionID string) error {
+	initLock := c.getSessionInitLock(upstream.Name)
+	initLock.Lock()
+	defer initLock.Unlock()
+
+	currentSessionID := c.getSession(upstream.Name)
+	if failedSessionID != "" && currentSessionID != "" && currentSessionID != failedSessionID {
+		return nil
+	}
+	if failedSessionID == "" && currentSessionID != "" {
+		return nil
+	}
+	if failedSessionID != "" {
+		c.clearSessionIfCurrent(upstream.Name, failedSessionID)
+	} else {
+		c.clearSession(upstream.Name)
+	}
+	return c.initializeHTTPSessionCandidates(ctx, upstream, true)
 }
 
 func (c *Client) ensureHTTPSessionMode(ctx context.Context, upstream Upstream, requireSession bool) error {
+	initLock := c.getSessionInitLock(upstream.Name)
+	initLock.Lock()
+	defer initLock.Unlock()
+
 	if c.getSession(upstream.Name) != "" {
 		return nil
 	}
+	return c.initializeHTTPSessionCandidates(ctx, upstream, requireSession)
+}
+
+func (c *Client) initializeHTTPSessionCandidates(ctx context.Context, upstream Upstream, requireSession bool) error {
 	var lastErr error
 	for _, protocolVersion := range httpProtocolCandidates() {
 		hadSession, err := c.initializeHTTPSession(ctx, upstream, protocolVersion)
@@ -744,6 +808,7 @@ func (c *Client) ensureHTTPSessionMode(ctx context.Context, upstream Upstream, r
 }
 
 func (c *Client) initializeHTTPSession(ctx context.Context, upstream Upstream, protocolVersion string) (bool, error) {
+	c.debugf("connection test http initialize server=%s url=%s protocol=%s auth=%s", upstream.Name, upstream.BaseURL, protocolVersion, debugAuthSummary(upstream))
 	initBody, err := json.Marshal(Envelope{
 		JSONRPC: "2.0",
 		ID:      json.RawMessage([]byte("1")),
@@ -755,13 +820,16 @@ func (c *Client) initializeHTTPSession(ctx context.Context, upstream Upstream, p
 		}),
 	})
 	if err != nil {
+		c.debugf("connection test http marshal error server=%s err=%v", upstream.Name, err)
 		return false, err
 	}
 	// doHTTPEnvelope reads the Mcp-Session-Id response header and stores it.
 	result, err := c.doHTTPEnvelope(ctx, upstream, initBody, protocolVersion)
 	if err != nil {
+		c.debugf("connection test http transport error server=%s err=%v", upstream.Name, err)
 		return false, err
 	}
+	c.debugf("connection test http response server=%s status=%d content_type=%q protocol=%q body=%s", upstream.Name, result.StatusCode, result.ContentType, result.ProtocolVersion, truncateForLog(result.Body, 600))
 	if result.StatusCode >= http.StatusBadRequest {
 		c.clearSession(upstream.Name)
 		return false, fmt.Errorf("upstream initialize using MCP %s failed: http %d: %s", protocolVersion, result.StatusCode, extractErrorDetail(result.Body))
@@ -1033,40 +1101,19 @@ func (c *Client) testHTTP(ctx context.Context, upstream Upstream) ConnectionTest
 		c.debugf("connection test http validation server=%s err=%q action=%q oauth_authorize_url=%s oauth_token_url=%s", upstream.Name, message, action, upstream.OAuthAuthorizeURL, upstream.OAuthTokenURL)
 		return ConnectionTestResult{Ok: false, Message: message, ConnectionStatus: ConnectionStatusNeedsAttention, AuthStatus: AuthStatusMissingCredentials, ReauthNeeded: false, LastCheckOK: false, LastErrorSummary: &message, ActionRequired: &action}
 	}
-	c.debugf("connection test http initialize server=%s url=%s protocol=%s auth=%s", upstream.Name, upstream.BaseURL, DefaultMCPProtocolVersion, debugAuthSummary(upstream))
-	initBody, err := json.Marshal(Envelope{JSONRPC: "2.0", ID: json.RawMessage([]byte("1")), Method: "initialize", Params: mustRawJSON(map[string]any{
-		"protocolVersion": DefaultMCPProtocolVersion,
-		"clientInfo":      map[string]any{"name": "atryum", "version": "0.1.0"},
-		"capabilities":    map[string]any{},
-	})})
-	if err != nil {
+	if err := c.ensureHTTPSession(ctx, upstream); err != nil {
 		message := err.Error()
-		c.debugf("connection test http marshal error server=%s err=%v", upstream.Name, err)
-		return ConnectionTestResult{Ok: false, Message: message, ConnectionStatus: ConnectionStatusNeedsAttention, AuthStatus: AuthStatusUnknown, LastCheckOK: false, LastErrorSummary: &message}
-	}
-	result, err := c.doHTTPEnvelope(ctx, upstream, initBody, DefaultMCPProtocolVersion)
-	if err != nil {
-		message := err.Error()
-		c.debugf("connection test http transport error server=%s err=%v", upstream.Name, err)
-		return ConnectionTestResult{Ok: false, Message: message, ConnectionStatus: ConnectionStatusUnreachable, AuthStatus: AuthStatusUnknown, LastCheckOK: false, LastErrorSummary: &message}
-	}
-	c.debugf("connection test http response server=%s status=%d content_type=%q protocol=%q body=%s", upstream.Name, result.StatusCode, result.ContentType, result.ProtocolVersion, truncateForLog(result.Body, 600))
-	if result.StatusCode == http.StatusUnauthorized || result.StatusCode == http.StatusForbidden {
-		message := fmt.Sprintf("http %d", result.StatusCode)
-		if detail := extractErrorDetail(result.Body); detail != "" {
-			message = fmt.Sprintf("http %d: %s", result.StatusCode, detail)
+		switch {
+		case strings.Contains(message, "http 401"), strings.Contains(message, "http 403"):
+			action := "refresh or reconnect credentials"
+			return ConnectionTestResult{Ok: false, Message: message, ConnectionStatus: ConnectionStatusNeedsAttention, AuthStatus: AuthStatusInvalid, ReauthNeeded: true, LastCheckOK: false, LastErrorSummary: &message, ActionRequired: &action}
+		case strings.Contains(message, "http "):
+			return ConnectionTestResult{Ok: false, Message: message, ConnectionStatus: ConnectionStatusDegraded, AuthStatus: AuthStatusUnknown, LastCheckOK: false, LastErrorSummary: &message}
+		default:
+			return ConnectionTestResult{Ok: false, Message: message, ConnectionStatus: ConnectionStatusUnreachable, AuthStatus: AuthStatusUnknown, LastCheckOK: false, LastErrorSummary: &message}
 		}
-		action := "refresh or reconnect credentials"
-		return ConnectionTestResult{Ok: false, Message: message, ConnectionStatus: ConnectionStatusNeedsAttention, AuthStatus: AuthStatusInvalid, ReauthNeeded: true, LastCheckOK: false, LastErrorSummary: &message, ActionRequired: &action}
 	}
-	if result.StatusCode >= http.StatusBadRequest {
-		message := fmt.Sprintf("http %d", result.StatusCode)
-		if detail := extractErrorDetail(result.Body); detail != "" {
-			message = fmt.Sprintf("http %d: %s", result.StatusCode, detail)
-		}
-		return ConnectionTestResult{Ok: false, Message: message, ConnectionStatus: ConnectionStatusDegraded, AuthStatus: AuthStatusUnknown, LastCheckOK: false, LastErrorSummary: &message}
-	}
-	message := fmt.Sprintf("http %d", result.StatusCode)
+	message := "http initialize ok"
 	return ConnectionTestResult{Ok: true, Message: message, ConnectionStatus: ConnectionStatusReady, AuthStatus: AuthStatusReady, ReauthNeeded: false, LastCheckOK: true}
 }
 

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -9,7 +9,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestConnectionDebugLogsHTTPProbeWithoutSecrets(t *testing.T) {
@@ -133,6 +136,77 @@ func TestMissingSessionRPCErrorDetection(t *testing.T) {
 	}
 }
 
+func TestListToolsSerializesConcurrentInitialize(t *testing.T) {
+	var activeInitializes int32
+	var maxActiveInitializes int32
+	var initializeCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req Envelope
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		switch req.Method {
+		case "initialize":
+			active := atomic.AddInt32(&activeInitializes, 1)
+			for {
+				maxActive := atomic.LoadInt32(&maxActiveInitializes)
+				if active <= maxActive || atomic.CompareAndSwapInt32(&maxActiveInitializes, maxActive, active) {
+					break
+				}
+			}
+			count := atomic.AddInt32(&initializeCount, 1)
+			time.Sleep(20 * time.Millisecond)
+			atomic.AddInt32(&activeInitializes, -1)
+			w.Header().Set("Mcp-Session-Id", "sid-concurrent")
+			writeTestRPC(w, req.ID, map[string]any{"protocolVersion": r.Header.Get("MCP-Protocol-Version"), "capabilities": map[string]any{}}, nil)
+			if count > 1 {
+				t.Fatalf("unexpected duplicate initialize %d", count)
+			}
+		case "notifications/initialized":
+			if got := r.Header.Get("Mcp-Session-Id"); got != "sid-concurrent" {
+				t.Fatalf("initialized notification missing session id: %q", got)
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			if got := r.Header.Get("Mcp-Session-Id"); got != "sid-concurrent" {
+				t.Fatalf("tools/list missing session id: %q", got)
+			}
+			writeTestRPC(w, req.ID, map[string]any{"tools": []map[string]any{{"name": "stories.search"}}}, nil)
+		default:
+			t.Fatalf("unexpected method %q", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.httpClient = server.Client()
+	upstream := Upstream{Name: "shortcut", Mode: UpstreamModeHTTP, BaseURL: server.URL}
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := client.ListTools(context.Background(), upstream)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("ListTools returned error: %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(&initializeCount); got != 1 {
+		t.Fatalf("initialize count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&maxActiveInitializes); got != 1 {
+		t.Fatalf("max active initializes = %d, want 1", got)
+	}
+}
+
 func TestListToolsRecoversWhenUpstreamRequiresSessionAfterStatelessInitialize(t *testing.T) {
 	var protocols []string
 	var sawSessionlessList bool
@@ -181,6 +255,138 @@ func TestListToolsRecoversWhenUpstreamRequiresSessionAfterStatelessInitialize(t 
 		t.Fatal("test did not exercise sessionless tools/list failure")
 	}
 	want := []string{MCPProtocolVersion2025, MCPProtocolVersion2025, MCPProtocolVersion2025_06_18, MCPProtocolVersion2025_03_26}
+	if len(protocols) != len(want) {
+		t.Fatalf("expected initialize protocols %#v, got %#v", want, protocols)
+	}
+	for i := range want {
+		if protocols[i] != want[i] {
+			t.Fatalf("expected initialize protocols %#v, got %#v", want, protocols)
+		}
+	}
+}
+
+func TestListToolsRetriesAfterSessionExpired404(t *testing.T) {
+	var initializeCount int32
+	var expiredOnce atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req Envelope
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		switch req.Method {
+		case "initialize":
+			count := atomic.AddInt32(&initializeCount, 1)
+			sessionID := "sid-1"
+			if count == 2 {
+				sessionID = "sid-2"
+			}
+			w.Header().Set("Mcp-Session-Id", sessionID)
+			writeTestRPC(w, req.ID, map[string]any{"protocolVersion": r.Header.Get("MCP-Protocol-Version"), "capabilities": map[string]any{}}, nil)
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			switch r.Header.Get("Mcp-Session-Id") {
+			case "sid-1":
+				if !expiredOnce.CompareAndSwap(false, true) {
+					t.Fatal("expired session used more than once")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":{"message":"session expired"}}`))
+			case "sid-2":
+				writeTestRPC(w, req.ID, map[string]any{"tools": []map[string]any{{"name": "stories.retry"}}}, nil)
+			default:
+				t.Fatalf("unexpected tools/list session id %q", r.Header.Get("Mcp-Session-Id"))
+			}
+		default:
+			t.Fatalf("unexpected method %q", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.httpClient = server.Client()
+	tools, err := client.ListTools(context.Background(), Upstream{Name: "shortcut", Mode: UpstreamModeHTTP, BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("ListTools returned error: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "stories.retry" {
+		t.Fatalf("unexpected tools: %#v", tools)
+	}
+	if got := atomic.LoadInt32(&initializeCount); got != 2 {
+		t.Fatalf("initialize count = %d, want 2", got)
+	}
+	if !expiredOnce.Load() {
+		t.Fatal("test did not exercise expired session 404")
+	}
+}
+
+func TestReinitializeSkipsWhenNewerSessionExists(t *testing.T) {
+	var initializeCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req Envelope
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if req.Method == "initialize" {
+			atomic.AddInt32(&initializeCount, 1)
+		}
+		writeTestRPC(w, req.ID, map[string]any{"protocolVersion": r.Header.Get("MCP-Protocol-Version"), "capabilities": map[string]any{}}, nil)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.httpClient = server.Client()
+	client.setSession("shortcut", "sid-fresh", MCPProtocolVersion2025_03_26)
+
+	err := client.reinitializeRequiredHTTPSession(context.Background(), Upstream{Name: "shortcut", Mode: UpstreamModeHTTP, BaseURL: server.URL}, "sid-stale")
+	if err != nil {
+		t.Fatalf("reinitializeRequiredHTTPSession returned error: %v", err)
+	}
+	if got := atomic.LoadInt32(&initializeCount); got != 0 {
+		t.Fatalf("initialize count = %d, want 0", got)
+	}
+	if got := client.getSession("shortcut"); got != "sid-fresh" {
+		t.Fatalf("session = %q, want sid-fresh", got)
+	}
+}
+
+func TestConnectionUsesProtocolFallback(t *testing.T) {
+	var protocols []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req Envelope
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		switch req.Method {
+		case "initialize":
+			protocol := r.Header.Get("MCP-Protocol-Version")
+			protocols = append(protocols, protocol)
+			if protocol != MCPProtocolVersion2025_03_26 {
+				writeTestRPC(w, req.ID, nil, map[string]any{"code": -32602, "message": "unsupported protocol version"})
+				return
+			}
+			w.Header().Set("Mcp-Session-Id", "sid-test")
+			writeTestRPC(w, req.ID, map[string]any{"protocolVersion": protocol, "capabilities": map[string]any{}}, nil)
+		case "notifications/initialized":
+			if got := r.Header.Get("Mcp-Session-Id"); got != "sid-test" {
+				t.Fatalf("initialized notification missing session id: %q", got)
+			}
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Fatalf("unexpected method %q", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.httpClient = server.Client()
+	result := client.TestConnection(context.Background(), Upstream{Name: "shortcut", Mode: UpstreamModeHTTP, BaseURL: server.URL, Enabled: true})
+	if !result.Ok {
+		t.Fatalf("TestConnection returned not ok: %#v; protocols=%#v", result, protocols)
+	}
+	want := []string{MCPProtocolVersion2025, MCPProtocolVersion2025_06_18, MCPProtocolVersion2025_03_26}
 	if len(protocols) != len(want) {
 		t.Fatalf("expected initialize protocols %#v, got %#v", want, protocols)
 	}

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -27,14 +27,16 @@ func TestConnectionDebugLogsHTTPProbeWithoutSecrets(t *testing.T) {
 	}()
 
 	const targetURL = "https://shortcut.example/mcp"
-	client := &Client{httpClient: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+	client := NewHTTPClient()
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		return &http.Response{
 			StatusCode: http.StatusUnauthorized,
 			Header:     http.Header{"Content-Type": []string{"application/json"}},
 			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"token expired"}}`)),
 			Request:    r,
 		}, nil
-	})}, debug: true, sessions: make(map[string]string)}
+	})}
+	client.debug = true
 	result := client.TestConnection(context.Background(), Upstream{
 		Name:        "shortcut",
 		Mode:        UpstreamModeHTTP,
@@ -55,7 +57,7 @@ func TestConnectionDebugLogsHTTPProbeWithoutSecrets(t *testing.T) {
 		"connection test http initialize server=shortcut",
 		"connection test http response server=shortcut status=401",
 		"connection test result server=shortcut",
-		"message=\"http 401: token expired\"",
+		"message=\"upstream initialize using MCP 2025-11-25 failed: http 401: token expired\"",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected logs to contain %q, got:\n%s", want, got)

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -3,9 +3,11 @@ package mcp
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -63,8 +65,147 @@ func TestConnectionDebugLogsHTTPProbeWithoutSecrets(t *testing.T) {
 	}
 }
 
+func TestListToolsRetriesInitializeWithCompatibleProtocol(t *testing.T) {
+	var protocols []string
+	var sawToolsListSession bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req Envelope
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		switch req.Method {
+		case "initialize":
+			protocol := r.Header.Get("MCP-Protocol-Version")
+			protocols = append(protocols, protocol)
+			if protocol == MCPProtocolVersion2025 {
+				writeTestRPC(w, req.ID, nil, map[string]any{"code": -32602, "message": "unsupported protocol version"})
+				return
+			}
+			if protocol != MCPProtocolVersion2025_03_26 {
+				writeTestRPC(w, req.ID, nil, map[string]any{"code": -32602, "message": "unsupported protocol version"})
+				return
+			}
+			w.Header().Set("Mcp-Session-Id", "sid-1")
+			writeTestRPC(w, req.ID, map[string]any{"protocolVersion": protocol, "capabilities": map[string]any{}}, nil)
+		case "notifications/initialized":
+			if got := r.Header.Get("Mcp-Session-Id"); got != "sid-1" {
+				t.Fatalf("initialized notification missing session id: %q", got)
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			if got := r.Header.Get("Mcp-Session-Id"); got == "sid-1" {
+				sawToolsListSession = true
+			}
+			if got := r.Header.Get("MCP-Protocol-Version"); got != MCPProtocolVersion2025_03_26 {
+				t.Fatalf("tools/list used protocol %q, want %q", got, MCPProtocolVersion2025_03_26)
+			}
+			writeTestRPC(w, req.ID, map[string]any{"tools": []map[string]any{{"name": "stories.search"}}}, nil)
+		default:
+			t.Fatalf("unexpected method %q", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.httpClient = server.Client()
+	tools, err := client.ListTools(context.Background(), Upstream{Name: "shortcut", Mode: UpstreamModeHTTP, BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("ListTools returned error: %v; protocols=%#v", err, protocols)
+	}
+	if len(tools) != 1 || tools[0].Name != "stories.search" {
+		t.Fatalf("unexpected tools: %#v", tools)
+	}
+	if !sawToolsListSession {
+		t.Fatal("tools/list did not include the negotiated session id")
+	}
+	if len(protocols) != 3 {
+		t.Fatalf("expected three initialize attempts, got %d: %#v", len(protocols), protocols)
+	}
+	if protocols[0] != MCPProtocolVersion2025 || protocols[1] != MCPProtocolVersion2025_06_18 || protocols[2] != MCPProtocolVersion2025_03_26 {
+		t.Fatalf("unexpected protocol fallback order: %#v", protocols)
+	}
+}
+
+func TestMissingSessionRPCErrorDetection(t *testing.T) {
+	if !isMissingSessionRPCError(json.RawMessage(`{"code":-32000,"message":"No session ID provided for non-initialization request"}`)) {
+		t.Fatal("expected missing session error to be detected")
+	}
+}
+
+func TestListToolsRecoversWhenUpstreamRequiresSessionAfterStatelessInitialize(t *testing.T) {
+	var protocols []string
+	var sawSessionlessList bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req Envelope
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		switch req.Method {
+		case "initialize":
+			protocol := r.Header.Get("MCP-Protocol-Version")
+			protocols = append(protocols, protocol)
+			if protocol == MCPProtocolVersion2025_03_26 {
+				w.Header().Set("Mcp-Session-Id", "sid-2")
+			}
+			writeTestRPC(w, req.ID, map[string]any{"protocolVersion": protocol, "capabilities": map[string]any{}}, nil)
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			if r.Header.Get("Mcp-Session-Id") == "" {
+				sawSessionlessList = true
+				writeTestRPC(w, req.ID, nil, map[string]any{"code": -32000, "message": "No session ID provided for non-initialization request"})
+				return
+			}
+			if got := r.Header.Get("MCP-Protocol-Version"); got != MCPProtocolVersion2025_03_26 {
+				t.Fatalf("tools/list used protocol %q, want %q", got, MCPProtocolVersion2025_03_26)
+			}
+			writeTestRPC(w, req.ID, map[string]any{"tools": []map[string]any{{"name": "stories.get"}}}, nil)
+		default:
+			t.Fatalf("unexpected method %q", req.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.httpClient = server.Client()
+	tools, err := client.ListTools(context.Background(), Upstream{Name: "shortcut", Mode: UpstreamModeHTTP, BaseURL: server.URL})
+	if err != nil {
+		t.Fatalf("ListTools returned error: %v; protocols=%#v", err, protocols)
+	}
+	if len(tools) != 1 || tools[0].Name != "stories.get" {
+		t.Fatalf("unexpected tools: %#v", tools)
+	}
+	if !sawSessionlessList {
+		t.Fatal("test did not exercise sessionless tools/list failure")
+	}
+	want := []string{MCPProtocolVersion2025, MCPProtocolVersion2025, MCPProtocolVersion2025_06_18, MCPProtocolVersion2025_03_26}
+	if len(protocols) != len(want) {
+		t.Fatalf("expected initialize protocols %#v, got %#v", want, protocols)
+	}
+	for i := range want {
+		if protocols[i] != want[i] {
+			t.Fatalf("expected initialize protocols %#v, got %#v", want, protocols)
+		}
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+func writeTestRPC(w http.ResponseWriter, id json.RawMessage, result any, rpcErr any) {
+	w.Header().Set("Content-Type", "application/json")
+	resp := map[string]any{"jsonrpc": "2.0", "id": id}
+	if rpcErr != nil {
+		resp["error"] = rpcErr
+	} else {
+		resp["result"] = result
+	}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
## Summary

- Add MCP protocol compatibility negotiation for upstream Streamable HTTP servers.
- Cache the protocol version with each upstream MCP session and reuse it on subsequent requests.
- Serialize cold upstream session initialization per upstream to avoid racing session IDs.
- Reinitialize and retry once when an upstream reports a missing or expired MCP session ID.

## Validation

- `go test ./...`
