### PR TITLE
Harness integration testing suite

### DIFF
--- a/.github/workflows/agent-harness-integration-tests.yml
+++ b/.github/workflows/agent-harness-integration-tests.yml
@@ -1,0 +1,124 @@
+name: Agent harness integration tests
+
+on:
+  push:
+    branches: [main, integrations-suite]
+    paths:
+      - "integrations/**"
+      - "internal/**"
+      - "cmd/**"
+      - "examples/**"
+      - "scripts/fake_agent.py"
+      - ".github/workflows/agent-harness-integration-tests.yml"
+  pull_request:
+    paths:
+      - "integrations/**"
+      - "internal/**"
+      - "cmd/**"
+      - "examples/**"
+      - "scripts/fake_agent.py"
+      - ".github/workflows/agent-harness-integration-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agent-harness-integration-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  baseline:
+    name: Baseline (fake-agent)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run integration baseline matrix
+        working-directory: integrations
+        run: |
+          chmod +x scripts/agent_harness_integration_tests.sh
+          ./scripts/agent_harness_integration_tests.sh matrix \
+            --only-passing \
+            --harnesses fake-agent \
+            --targets calculator
+
+  live-harnesses:
+    name: Live harnesses (repository secrets)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: baseline
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      vars.RUN_LIVE_HARNESS_INTEGRATION_TESTS == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - harness: codex
+            auth: no-auth
+            api_key_secret: OPENAI_API_KEY
+            install: npm install -g @openai/codex
+          - harness: claude-code
+            auth: no-auth
+            api_key_secret: ANTHROPIC_API_KEY
+            install: npm install -g @anthropic-ai/claude-code
+          - harness: amp
+            auth: no-auth
+            api_key_secret: AMP_API_KEY
+            install: npm install -g @sourcegraph/amp
+          - harness: grok
+            auth: no-auth
+            api_key_secret: XAI_API_KEY
+            install: ""
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install harness CLI
+        if: matrix.install != ''
+        run: ${{ matrix.install }}
+
+      - name: Run harness case
+        working-directory: integrations
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+        run: |
+          key_name='${{ matrix.api_key_secret }}'
+          if [ -z "${!key_name:-}" ]; then
+            echo "Skipping ${{ matrix.harness }}: ${key_name} secret not configured"
+            exit 0
+          fi
+          chmod +x scripts/agent_harness_integration_tests.sh
+          ./scripts/agent_harness_integration_tests.sh run \
+            --harness "${{ matrix.harness }}" \
+            --auth "${{ matrix.auth }}" \
+            --target calculator

--- a/Justfile
+++ b/Justfile
@@ -150,3 +150,16 @@ release-push tag:
         else
           gh release create "{{tag}}" "${artifacts[@]}" --generate-notes
         fi
+
+# List registered harnesses, auth protocols, and MCP targets
+integration-list:
+	integrations/scripts/agent_harness_integration_tests.sh list
+
+# Run a single integration case (override harness/auth/target via env or args)
+integration-test harness="fake-agent" auth="no-auth" target="calculator":
+	integrations/scripts/agent_harness_integration_tests.sh run \
+	  --harness {{harness}} --auth {{auth}} --target {{target}}
+
+# Run the full integration matrix (skips unavailable harnesses and placeholder auth)
+integration-test-matrix *args:
+	integrations/scripts/agent_harness_integration_tests.sh matrix --only-passing {{args}}

--- a/integrations/.gitignore
+++ b/integrations/.gitignore
@@ -1,0 +1,18 @@
+# Local nix shell — not committed (developers on NixOS may use it locally)
+shell.nix
+
+# Runtime artifacts
+.run/
+*.db
+*.db-journal
+*.log
+*.pid
+
+# Harness config snapshots written during tests
+.harness-config/
+
+# Python venv for mock OIDC
+.venv/
+
+# Test results
+results/

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,79 @@
+# Atryum harness integration tests
+
+End-to-end tests that wire real AI agent harnesses through Atryum to upstream MCP
+servers. Exercises harness MCP quirks, hook integrations from `examples/`, and
+harness→Atryum inbound auth protocols.
+
+Approval uses **rules only** — each test run seeds a catch-all `auto_approve` rule
+via `POST /api/v1/admin/rules` (no `[policy]` provider).
+
+## Quick start
+
+```bash
+# From repo root
+just integration-test
+just integration-test-matrix
+
+# Or directly
+cd integrations
+./scripts/agent_harness_integration_tests.sh list
+./scripts/agent_harness_integration_tests.sh run --harness fake-agent --auth no-auth
+./scripts/agent_harness_integration_tests.sh matrix --only-passing
+```
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `list` | Print harnesses, auth protocols, MCP targets |
+| `run` | Single case: `--harness`, `--auth`, optional `--target` |
+| `matrix` | Full cross-product; filters via `--harnesses`, `--auth`, `--targets`, `--only-passing` |
+
+## LLM credentials vs Atryum auth
+
+Harness LLM billing credentials (never committed):
+
+| Harness | Env var | Notes |
+|---------|---------|-------|
+| Codex, Pi | `OPENAI_API_KEY` | API billing; no Codex subscription OAuth needed |
+| Claude Code | `ANTHROPIC_API_KEY` | API billing |
+| Amp | `AMP_API_KEY` | Or existing `amp login` session |
+| Grok | `XAI_API_KEY` | |
+| Cursor | `CURSOR_API_KEY` | |
+
+Harness→**Atryum** auth is configured separately (`no-auth`, `oauth-client-credentials`, `oauth-dcr`, …).
+
+## Registries
+
+| File | Contents |
+|------|----------|
+| `config/harnesses.yaml` | CLIs, invoke templates, hooks, MCP wiring |
+| `config/auth-protocols.yaml` | Inbound Atryum auth modes |
+| `config/mcp-targets.yaml` | Upstream MCP servers + verification prompts |
+
+Default MCP target: [mcp-server-calculator](https://github.com/githejie/mcp-server-calculator) (pip-installed in `.venv`).
+
+## Mock OIDC
+
+`auth/mock-oidc/` — lightweight alternative to Keycloak for `oauth-client-credentials` and `oauth-dcr` cases.
+
+## CI
+
+`.github/workflows/agent-harness-integration-tests.yml` runs the `fake-agent` baseline on every PR.
+Optional live-harness jobs run when repository secrets (`OPENAI_API_KEY`, etc.) are configured.
+
+## Local Nix (optional, not committed)
+
+`shell.nix` is gitignored for NixOS developers who want isolated toolchains.
+
+## Layout
+
+```
+integrations/
+├── scripts/agent_harness_integration_tests.sh   # entrypoint
+├── lib/                                         # atryum, auth, harness helpers
+├── config/                                      # YAML registries
+├── fixtures/atryum/                             # per-auth TOML templates
+├── auth/mock-oidc/                              # lightweight OIDC
+└── requirements.txt                             # PyYAML, calculator MCP, mock OIDC deps
+```

--- a/integrations/auth/mock-oidc/mock_oidc.py
+++ b/integrations/auth/mock-oidc/mock_oidc.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Lightweight OIDC mock for Atryum integration tests.
+
+Implements enough of Keycloak's atryum realm surface for local harness testing:
+  - OpenID Provider discovery
+  - JWKS
+  - client_credentials token endpoint
+  - Dynamic Client Registration (RFC 7591)
+
+Usage:
+  python3 mock_oidc.py --port 9090 --realm atryum
+
+Environment (written to .env by the server on startup):
+  MOCK_OIDC_ISSUER, MOCK_OIDC_TOKEN_URL, MOCK_OIDC_DCR_URL,
+  MOCK_OIDC_CLIENT_ID, MOCK_OIDC_CLIENT_SECRET
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import secrets
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def _b64url_uint(val: int) -> str:
+    import base64
+
+    raw = val.to_bytes((val.bit_length() + 7) // 8, "big")
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+class MockOIDC:
+    def __init__(self, host: str, port: int, realm: str, env_file: Path | None) -> None:
+        self.host = host
+        self.port = port
+        self.realm = realm
+        self.base = f"http://{host}:{port}"
+        self.issuer = f"{self.base}/realms/{realm}"
+        self.token_url = f"{self.issuer}/protocol/openid-connect/token"
+        self.dcr_url = f"{self.issuer}/clients-registrations/openid-connect"
+        self.jwks_url = f"{self.issuer}/protocol/openid-connect/certs"
+        self.discovery_url = f"{self.issuer}/.well-known/openid-configuration"
+
+        self.static_client_id = "test-client"
+        self.static_client_secret = "test-secret"
+        self.clients: dict[str, dict[str, Any]] = {
+            self.static_client_id: {
+                "client_id": self.static_client_id,
+                "client_secret": self.static_client_secret,
+                "grant_types": ["client_credentials"],
+            }
+        }
+
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self.private_pem = key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        pub = key.public_key().public_numbers()
+        self.kid = "mock-oidc-1"
+        self.jwks = {
+            "keys": [
+                {
+                    "kty": "RSA",
+                    "kid": self.kid,
+                    "use": "sig",
+                    "alg": "RS256",
+                    "n": _b64url_uint(pub.n),
+                    "e": _b64url_uint(pub.e),
+                }
+            ]
+        }
+
+        if env_file is not None:
+            env_file.write_text(
+                "\n".join(
+                    [
+                        f"MOCK_OIDC_ISSUER={self.issuer}",
+                        f"MOCK_OIDC_TOKEN_URL={self.token_url}",
+                        f"MOCK_OIDC_DCR_URL={self.dcr_url}",
+                        f"MOCK_OIDC_JWKS_URL={self.jwks_url}",
+                        f"MOCK_OIDC_CLIENT_ID={self.static_client_id}",
+                        f"MOCK_OIDC_CLIENT_SECRET={self.static_client_secret}",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+    def discovery(self) -> dict[str, Any]:
+        return {
+            "issuer": self.issuer,
+            "authorization_endpoint": f"{self.issuer}/protocol/openid-connect/auth",
+            "token_endpoint": self.token_url,
+            "jwks_uri": self.jwks_url,
+            "registration_endpoint": self.dcr_url,
+            "response_types_supported": ["code", "token"],
+            "grant_types_supported": ["client_credentials", "authorization_code"],
+            "token_endpoint_auth_methods_supported": [
+                "client_secret_post",
+                "client_secret_basic",
+                "none",
+            ],
+            "scopes_supported": ["openid", "atryum:mcp"],
+        }
+
+    def issue_token(self, client_id: str, scope: str) -> dict[str, Any]:
+        now = int(time.time())
+        payload = {
+            "iss": self.issuer,
+            "sub": client_id,
+            "aud": "atryum",
+            "azp": client_id,
+            "client_id": client_id,
+            "scope": scope or "atryum:mcp",
+            "iat": now,
+            "exp": now + 3600,
+            "jti": str(uuid.uuid4()),
+        }
+        token = jwt.encode(payload, self.private_pem, algorithm="RS256", headers={"kid": self.kid})
+        return {
+            "access_token": token,
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": payload["scope"],
+        }
+
+    def register_client(self, body: dict[str, Any]) -> dict[str, Any]:
+        client_id = body.get("client_id") or f"dcr-{secrets.token_hex(8)}"
+        client_secret = body.get("client_secret") or secrets.token_urlsafe(24)
+        record = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "client_name": body.get("client_name", "integration-dcr-client"),
+            "grant_types": body.get("grant_types", ["client_credentials"]),
+            "token_endpoint_auth_method": body.get(
+                "token_endpoint_auth_method", "client_secret_post"
+            ),
+            "scope": body.get("scope", "atryum:mcp"),
+        }
+        self.clients[client_id] = record
+        return {
+            **record,
+            "client_id_issued_at": int(time.time()),
+            "client_secret_expires_at": 0,
+        }
+
+
+class Handler(BaseHTTPRequestHandler):
+    @property
+    def mock(self) -> MockOIDC:
+        return self.server.mock  # type: ignore[attr-defined]
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        return
+
+    def _json(self, status: int, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length == 0:
+            return {}
+        raw = self.rfile.read(length)
+        if not raw:
+            return {}
+        return json.loads(raw.decode("utf-8"))
+
+    def _read_form(self) -> dict[str, list[str]]:
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length).decode("utf-8") if length else ""
+        return parse_qs(raw, keep_blank_values=True)
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        if path == f"/realms/{self.mock.realm}/.well-known/openid-configuration":
+            self._json(200, self.mock.discovery())
+            return
+        if path == f"/realms/{self.mock.realm}/protocol/openid-connect/certs":
+            self._json(200, self.mock.jwks)
+            return
+        if path == "/healthz":
+            self._json(200, {"status": "ok"})
+            return
+        self._json(404, {"error": "not_found", "path": path})
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        if path == f"/realms/{self.mock.realm}/protocol/openid-connect/token":
+            form = self._read_form()
+            grant = (form.get("grant_type") or [""])[0]
+            if grant != "client_credentials":
+                self._json(400, {"error": "unsupported_grant_type"})
+                return
+            client_id = (form.get("client_id") or [""])[0]
+            client_secret = (form.get("client_secret") or [""])[0]
+            scope = (form.get("scope") or ["atryum:mcp"])[0]
+            record = self.mock.clients.get(client_id)
+            if record is None or record.get("client_secret") != client_secret:
+                self._json(401, {"error": "invalid_client"})
+                return
+            self._json(200, self.mock.issue_token(client_id, scope))
+            return
+
+        if path == f"/realms/{self.mock.realm}/clients-registrations/openid-connect":
+            body = self._read_json()
+            self._json(201, self.mock.register_client(body))
+            return
+
+        self._json(404, {"error": "not_found", "path": path})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Mock OIDC for Atryum integration tests")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9090)
+    parser.add_argument("--realm", default="atryum")
+    parser.add_argument("--env-file", default="")
+    args = parser.parse_args()
+
+    env_path = Path(args.env_file) if args.env_file else None
+    mock = MockOIDC(args.host, args.port, args.realm, env_path)
+
+    httpd = ThreadingHTTPServer((args.host, args.port), Handler)
+    httpd.mock = mock  # type: ignore[attr-defined]
+    print(f"mock-oidc listening on {mock.base} (issuer={mock.issuer})", flush=True)
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/auth/mock-oidc/requirements.txt
+++ b/integrations/auth/mock-oidc/requirements.txt
@@ -1,0 +1,2 @@
+PyJWT[crypto]==2.10.1
+cryptography==44.0.2

--- a/integrations/config/auth-protocols.yaml
+++ b/integrations/config/auth-protocols.yaml
@@ -1,0 +1,98 @@
+# Harness → Atryum authentication protocols to exercise in the matrix.
+#
+# Each protocol describes how to configure inbound auth on Atryum and how
+# harnesses should present credentials when connecting to /mcp/{server}.
+#
+# status:
+#   implemented — wired end-to-end in this suite
+#   placeholder — listed for future work; runner skips with a note
+
+auth_protocols:
+  - id: no-auth
+    display_name: No inbound auth
+    status: implemented
+    description: >
+      No [[auth]] blocks in atryum.toml. Harnesses may pass ?agent_id= on the
+      MCP URL for best-effort identity tagging.
+    atryum_template: fixtures/atryum/base.toml
+    harness_auth:
+      type: query_param
+      agent_id_from: harness_id
+    env: {}
+
+  - id: oauth-client-credentials
+    display_name: OAuth client credentials (pre-shared)
+    status: implemented
+    description: >
+      Lightweight mock OIDC issues tokens via client_credentials grant.
+      Mirrors Keycloak confidential-client setup without running Keycloak.
+    atryum_template: fixtures/atryum/oauth-client-credentials.toml
+    harness_auth:
+      type: bearer
+      token_command: >
+        curl -fsS -X POST "$MOCK_OIDC_TOKEN_URL"
+        -d "grant_type=client_credentials"
+        -d "client_id=$MOCK_OIDC_CLIENT_ID"
+        -d "client_secret=$MOCK_OIDC_CLIENT_SECRET"
+        -d "scope=atryum:mcp" | jq -r .access_token
+    env:
+      MOCK_OIDC_CLIENT_ID: test-client
+      MOCK_OIDC_CLIENT_SECRET: test-secret
+    requires: [mock-oidc]
+
+  - id: oauth-dcr
+    display_name: OAuth Dynamic Client Registration (RFC 7591)
+    status: implemented
+    description: >
+      Harness-side MCP clients self-register against the mock OIDC DCR endpoint,
+      then obtain tokens. Mirrors Claude Code / MCP SDK DCR flows.
+    atryum_template: fixtures/atryum/oauth-dcr.toml
+    harness_auth:
+      type: oauth-dcr
+      registration_url_env: MOCK_OIDC_DCR_URL
+      token_url_env: MOCK_OIDC_TOKEN_URL
+      scope: atryum:mcp
+    env: {}
+    requires: [mock-oidc]
+
+  - id: static-bearer
+    display_name: Static bearer token (pre-generated JWT)
+    status: placeholder
+    description: >
+      Placeholder for deployments that pin a long-lived service token out-of-band.
+      Would pass Authorization: Bearer on MCP requests without a live token endpoint.
+    atryum_template: fixtures/atryum/static-bearer.toml
+    harness_auth:
+      type: bearer
+      token_env: ATRYUM_STATIC_BEARER_TOKEN
+    env:
+      ATRYUM_STATIC_BEARER_TOKEN: ""
+    requires: [mock-oidc]
+
+  - id: basic-auth
+    display_name: HTTP Basic authentication
+    status: placeholder
+    description: >
+      Placeholder — Atryum inbound /mcp/ auth is OIDC bearer-only today.
+      Listed so the matrix can grow when basic auth lands.
+    atryum_template: fixtures/atryum/basic-auth.toml
+    harness_auth:
+      type: basic
+      username_env: ATRYUM_BASIC_USER
+      password_env: ATRYUM_BASIC_PASSWORD
+    env: {}
+    requires: []
+
+  - id: api-key-pair
+    display_name: API key + secret (legacy reporting endpoints)
+    status: placeholder
+    description: >
+      Placeholder for X-API-Key / X-API-Secret on legacy read endpoints.
+      Not used for /mcp/ today but reserved for future harness auth modes.
+    atryum_template: fixtures/atryum/api-key-pair.toml
+    harness_auth:
+      type: api-key
+      key_env: ATRYUM_API_KEY
+      secret_env: ATRYUM_API_SECRET
+    env: {}
+    requires: []

--- a/integrations/config/harnesses.yaml
+++ b/integrations/config/harnesses.yaml
@@ -1,0 +1,166 @@
+# Agent harness registry for integration tests.
+#
+# LLM billing: codex/claude use OPENAI_API_KEY / ANTHROPIC_API_KEY (API billing),
+# not subscription OAuth. Harness→Atryum auth is separate (see auth-protocols.yaml).
+
+harnesses:
+  - id: fake-agent
+    display_name: Fake Agent (fake_agent.py)
+    cli: python3
+    invoke: ""
+    api_key_env: ""
+    hook: null
+    mcp_transport: direct-jsonrpc
+    mcp_config_path: null
+    mcp_config_template: null
+    skip_reason: ""
+    tags: [baseline, no-llm, mcp-only]
+
+  - id: codex
+    display_name: OpenAI Codex CLI
+    cli: codex
+    invoke: 'HOME="$CODEX_TEST_HOME" codex exec --dangerously-bypass-approvals-and-sandbox "$PROMPT"'
+    api_key_env: OPENAI_API_KEY
+    api_key_env_optional: true
+    hook: null
+    mcp_transport: codex-config-toml
+    mcp_config_path: "$CODEX_TEST_HOME/.codex/config.toml"
+    mcp_config_template: |
+      [mcp_servers.calculator_via_atryum]
+      command = "npx"
+      args = ["-y", "mcp-remote", "$ATRYUM_MCP_URL"]
+    skip_reason: ""
+    tags: [mcp-only]
+
+  - id: claude-code
+    display_name: Claude Code
+    cli: claude
+    invoke: 'claude -p "$PROMPT" --output-format text --dangerously-skip-permissions --mcp-config "$CLAUDE_MCP_CONFIG"'
+    api_key_env: ANTHROPIC_API_KEY
+    api_key_env_optional: true
+    hook:
+      type: command
+      source: claude-code
+      host: claude
+      events: [PreToolUse, PostToolUse]
+      script: shared-agent-hook/atryum-hook.mjs
+    mcp_transport: mcp-remote-stdio
+    mcp_config_path: "mcp-claude.json"
+    mcp_config_template: |
+      {
+        "mcpServers": {
+          "calculator_via_atryum": {
+            "command": "npx",
+            "args": ["-y", "mcp-remote", "$ATRYUM_MCP_URL"]
+          }
+        }
+      }
+    skip_reason: ""
+    tags: [hook, mcp]
+
+  - id: cursor
+    display_name: Cursor Agent CLI
+    cli: cursor
+    invoke: 'cursor agent -p "$PROMPT" --force'
+    api_key_env: CURSOR_API_KEY
+    hook:
+      type: command
+      source: cursor
+      host: cursor
+      events: [preToolUse, postToolUse]
+      script: shared-agent-hook/atryum-hook.mjs
+    mcp_transport: mcp-remote-stdio
+    mcp_config_path: "mcp-cursor.json"
+    mcp_config_template: |
+      {
+        "mcpServers": {
+          "calculator_via_atryum": {
+            "command": "npx",
+            "args": ["-y", "mcp-remote", "$ATRYUM_MCP_URL"]
+          }
+        }
+      }
+    skip_reason: ""
+    tags: [hook, mcp]
+
+  - id: amp
+    display_name: Amp
+    cli: amp
+    invoke: 'AMP_SETTINGS_FILE="$AMP_SETTINGS_FILE" amp --execute "$PROMPT" --dangerously-allow-all'
+    api_key_env: AMP_API_KEY
+    api_key_env_optional: true
+    hook:
+      type: plugin
+      source: amp
+      script: amp-plugin/atryum.ts
+    mcp_transport: amp-settings-json
+    mcp_config_path: "amp-settings.json"
+    mcp_config_template: null
+    skip_reason: ""
+    tags: [hook, mcp]
+
+  - id: grok
+    display_name: Grok CLI
+    cli: grok
+    invoke: 'HOME="$GROK_TEST_HOME" grok --single "$PROMPT" --always-approve'
+    api_key_env: XAI_API_KEY
+    api_key_env_optional: true
+    hook: null
+    mcp_transport: grok-config-toml
+    mcp_config_path: "$GROK_TEST_HOME/.grok/config.toml"
+    mcp_config_template: |
+      [mcp_servers.calculator_via_atryum]
+      command = "npx"
+      args = ["-y", "mcp-remote", "$ATRYUM_MCP_URL"]
+    skip_reason: ""
+    tags: [mcp-only]
+
+  - id: pi
+    display_name: Pi Coding Agent
+    cli: pi
+    invoke: 'pi -p "$PROMPT"'
+    api_key_env: OPENAI_API_KEY
+    hook: null
+    mcp_transport: mcp-remote-stdio
+    mcp_config_path: "mcp-pi.json"
+    mcp_config_template: |
+      {
+        "mcpServers": {
+          "calculator_via_atryum": {
+            "command": "npx",
+            "args": ["-y", "mcp-remote", "$ATRYUM_MCP_URL"]
+          }
+        }
+      }
+    skip_reason: "placeholder — Pi MCP wiring not yet validated in examples/"
+    tags: [placeholder, mcp-only]
+
+  - id: agentforce
+    display_name: Salesforce Agentforce
+    cli: ""
+    invoke: ""
+    api_key_env: AGENTFORCE_API_KEY
+    hook:
+      type: external-invocations
+      source: agentforce
+      notes: "Autonomous agent — POST /api/v1/external/invocations; no local CLI"
+    mcp_transport: http
+    mcp_config_path: null
+    mcp_config_template: null
+    skip_reason: "placeholder — no local CLI; requires Agentforce runtime and custom orchestration"
+    tags: [placeholder, autonomous]
+
+  - id: foundry
+    display_name: Microsoft Foundry
+    cli: ""
+    invoke: ""
+    api_key_env: AZURE_OPENAI_API_KEY
+    hook:
+      type: external-invocations
+      source: foundry
+      notes: "Autonomous agent — POST /api/v1/external/invocations; no local CLI"
+    mcp_transport: http
+    mcp_config_path: null
+    mcp_config_template: null
+    skip_reason: "placeholder — no local CLI; requires Foundry agent runtime"
+    tags: [placeholder, autonomous]

--- a/integrations/config/mcp-targets.yaml
+++ b/integrations/config/mcp-targets.yaml
@@ -1,0 +1,46 @@
+# Upstream MCP servers used as integration test targets.
+#
+# Atryum bootstraps these into mcp_servers on first run (empty DB).
+
+mcp_targets:
+  - id: calculator
+    display_name: githejie/mcp-server-calculator
+    description: >
+      Safe stdio calculator MCP server. Tool `calculate` evaluates arithmetic
+      expressions — ideal PoC upstream with no external credentials.
+    upstream:
+      name: calculator
+      mode: stdio
+      command: __INTEGRATIONS_PYTHON__
+      args: ["-m", "mcp_server_calculator"]
+      timeout_seconds: 30
+      enabled: true
+    verify:
+      tool: calculate
+      arguments:
+        expression: "17 * 23"
+      expect_substrings: ["391"]
+    prompt: |
+      Use the calculator_via_atryum MCP server's calculate tool to evaluate
+      17 * 23. Reply with only the numeric result, nothing else.
+
+  - id: calc-mcp
+    display_name: "@coo-quack/calc-mcp (Atryum demo default)"
+    description: >
+      The calc server bundled with `atryum setup demo`. Kept as an alternate
+      target when the pip calculator package is unavailable.
+    upstream:
+      name: calc
+      mode: stdio
+      command: npx
+      args: ["-y", "@coo-quack/calc-mcp@latest"]
+      timeout_seconds: 30
+      enabled: true
+    verify:
+      tool: math
+      arguments:
+        expression: "17 + 23"
+      expect_substrings: ["40"]
+    prompt: |
+      Use the calc_via_atryum MCP server's math tool to evaluate 17 + 23.
+      Reply with only the numeric result, nothing else.

--- a/integrations/fixtures/atryum/api-key-pair.toml
+++ b/integrations/fixtures/atryum/api-key-pair.toml
@@ -1,0 +1,23 @@
+# PLACEHOLDER — API key pair protects legacy reporting endpoints, not /mcp/.
+
+[server]
+listen_addr = ":__ATRYUM_PORT__"
+public_base_url = "http://localhost:__ATRYUM_PORT__"
+database_path = "__RUN_DIR__/atryum.db"
+database_url = ""
+log_level = "info"
+
+[backend]
+base_url = ""
+
+[defaults]
+request_timeout_seconds = 30
+
+[api_key]
+key = "integration-test-key"
+secret = "integration-test-secret"
+
+[auth_debug]
+skip_verify = false
+
+__UPSTREAMS_BLOCK__

--- a/integrations/fixtures/atryum/base.toml
+++ b/integrations/fixtures/atryum/base.toml
@@ -1,0 +1,17 @@
+[server]
+listen_addr = ":__ATRYUM_PORT__"
+public_base_url = "http://localhost:__ATRYUM_PORT__"
+database_path = "__RUN_DIR__/atryum.db"
+database_url = ""
+log_level = "info"
+
+[backend]
+base_url = ""
+
+[defaults]
+request_timeout_seconds = 30
+
+[auth_debug]
+skip_verify = false
+
+__UPSTREAMS_BLOCK__

--- a/integrations/fixtures/atryum/basic-auth.toml
+++ b/integrations/fixtures/atryum/basic-auth.toml
@@ -1,0 +1,19 @@
+# PLACEHOLDER — inbound HTTP Basic auth is not implemented on /mcp/ today.
+
+[server]
+listen_addr = ":__ATRYUM_PORT__"
+public_base_url = "http://localhost:__ATRYUM_PORT__"
+database_path = "__RUN_DIR__/atryum.db"
+database_url = ""
+log_level = "info"
+
+[backend]
+base_url = ""
+
+[defaults]
+request_timeout_seconds = 30
+
+[auth_debug]
+skip_verify = false
+
+__UPSTREAMS_BLOCK__

--- a/integrations/fixtures/atryum/oauth-client-credentials.toml
+++ b/integrations/fixtures/atryum/oauth-client-credentials.toml
@@ -1,0 +1,24 @@
+[server]
+listen_addr = ":__ATRYUM_PORT__"
+public_base_url = "http://localhost:__ATRYUM_PORT__"
+database_path = "__RUN_DIR__/atryum.db"
+database_url = ""
+log_level = "info"
+
+[backend]
+base_url = ""
+
+[defaults]
+request_timeout_seconds = 30
+
+[[auth]]
+enabled = true
+issuer = "__MOCK_OIDC_ISSUER__"
+audience = "atryum"
+required_scope = "atryum:mcp"
+agent_id_claim = "client_id"
+
+[auth_debug]
+skip_verify = false
+
+__UPSTREAMS_BLOCK__

--- a/integrations/fixtures/atryum/oauth-dcr.toml
+++ b/integrations/fixtures/atryum/oauth-dcr.toml
@@ -1,0 +1,24 @@
+[server]
+listen_addr = ":__ATRYUM_PORT__"
+public_base_url = "http://localhost:__ATRYUM_PORT__"
+database_path = "__RUN_DIR__/atryum.db"
+database_url = ""
+log_level = "info"
+
+[backend]
+base_url = ""
+
+[defaults]
+request_timeout_seconds = 30
+
+[[auth]]
+enabled = true
+issuer = "__MOCK_OIDC_ISSUER__"
+audience = "atryum"
+required_scope = "atryum:mcp"
+agent_id_claim = "client_id"
+
+[auth_debug]
+skip_verify = false
+
+__UPSTREAMS_BLOCK__

--- a/integrations/fixtures/atryum/static-bearer.toml
+++ b/integrations/fixtures/atryum/static-bearer.toml
@@ -1,0 +1,27 @@
+# PLACEHOLDER — static bearer token inbound auth.
+# Not exercised until ATRYUM_STATIC_BEARER_TOKEN is wired in the runner.
+
+[server]
+listen_addr = ":__ATRYUM_PORT__"
+public_base_url = "http://localhost:__ATRYUM_PORT__"
+database_path = "__RUN_DIR__/atryum.db"
+database_url = ""
+log_level = "info"
+
+[backend]
+base_url = ""
+
+[defaults]
+request_timeout_seconds = 30
+
+[[auth]]
+enabled = true
+issuer = "__MOCK_OIDC_ISSUER__"
+audience = "atryum"
+required_scope = "atryum:mcp"
+agent_id_claim = "client_id"
+
+[auth_debug]
+skip_verify = false
+
+__UPSTREAMS_BLOCK__

--- a/integrations/lib/atryum.sh
+++ b/integrations/lib/atryum.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck source=lib/common.sh
+source "$INTEGRATIONS_ROOT/lib/common.sh"
+# shellcheck source=lib/yaml.sh
+source "$INTEGRATIONS_ROOT/lib/yaml.sh"
+
+render_upstream_block() {
+  local target_id="$1"
+  local py="${INTEGRATIONS_PYTHON:-python3}"
+  "$py" - "$INTEGRATIONS_ROOT" "$target_id" <<'PY'
+import json, os, subprocess, sys
+root, target_id = sys.argv[1], sys.argv[2]
+py = os.environ.get("INTEGRATIONS_PYTHON", "python3")
+os.environ.setdefault("INTEGRATIONS_PYTHON", py)
+item = json.loads(subprocess.check_output([
+    py, f"{root}/lib/registry.py",
+    f"{root}/config/mcp-targets.yaml", "mcp_targets", target_id,
+], text=True))
+u = item["upstream"]
+lines = [
+    "[[upstreams]]",
+    f'name = "{u["name"]}"',
+    f'mode = "{u["mode"]}"',
+]
+if u.get("command"):
+    cmd = u["command"]
+    if cmd == "__INTEGRATIONS_PYTHON__":
+        cmd = os.environ.get("INTEGRATIONS_PYTHON", "python3")
+    lines.append(f'command = "{cmd}"')
+args = u.get("args") or []
+if args:
+    quoted = ", ".join(f'"{a}"' for a in args)
+    lines.append(f"args = [{quoted}]")
+if u.get("base_url"):
+    lines.append(f'base_url = "{u["base_url"]}"')
+lines.append(f'timeout_seconds = {u.get("timeout_seconds", 30)}')
+lines.append(f'enabled = {"true" if u.get("enabled", True) else "false"}')
+print("\n".join(lines))
+PY
+}
+
+render_atryum_config() {
+  local auth_id="$1" target_id="$2" template_path="$3" out_path="$4"
+  local upstreams
+  upstreams="$(render_upstream_block "$target_id")"
+  sed \
+    -e "s|__ATRYUM_PORT__|${ATRYUM_PORT}|g" \
+    -e "s|__RUN_DIR__|${RUN_DIR}|g" \
+    -e "s|__MOCK_OIDC_ISSUER__|${MOCK_OIDC_ISSUER:-http://127.0.0.1:${MOCK_OIDC_PORT}/realms/atryum}|g" \
+    "$template_path" \
+    | awk -v block="$upstreams" '{gsub(/__UPSTREAMS_BLOCK__/, block); print}' \
+    >"$out_path"
+}
+
+build_atryum() {
+  if [[ -x "$REPO_ROOT/atryum" ]]; then
+    ATRYUM_BIN="$REPO_ROOT/atryum"
+    return 0
+  fi
+  log "Building atryum binary..."
+  (cd "$REPO_ROOT" && go build -o "$RUN_DIR/atryum" ./cmd/atryum)
+  ATRYUM_BIN="$RUN_DIR/atryum"
+}
+
+start_atryum() {
+  local config_path="$1"
+  build_atryum
+  log "Starting atryum on :${ATRYUM_PORT} (config: $config_path)"
+  ATRYUM_MCP_DEBUG="${ATRYUM_MCP_DEBUG:-1}" \
+    "$ATRYUM_BIN" run -config "$config_path" \
+    >"$RUN_DIR/atryum.log" 2>&1 &
+  echo $! >"$RUN_DIR/atryum.pid"
+  wait_for_http "$ATRYUM_URL/healthz" 80 0.25 || {
+    warn "atryum failed to become healthy; tailing log:"
+    tail -n 40 "$RUN_DIR/atryum.log" >&2 || true
+    return 1
+  }
+}
+
+seed_auto_approve_rules() {
+  log "Seeding catch-all auto_approve rule via admin API"
+  local payload
+  payload='{
+    "action": "auto_approve",
+    "server_patterns": ["*"],
+    "tool_patterns": ["*"],
+    "agent_id_pattern": "*",
+    "description": "integration test catch-all auto-approve"
+  }'
+  curl -fsS -X POST "$ATRYUM_URL/api/v1/admin/rules" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" >/dev/null || {
+    warn "failed to create auto_approve rule; tailing atryum log:"
+    tail -n 20 "$RUN_DIR/atryum.log" >&2 || true
+    return 1
+  }
+}
+
+verify_upstream_direct() {
+  local target_id="$1"
+  local auth_id="${2:-no-auth}"
+  local parsed server_name tool_name args_json expect_joined
+  local py="${INTEGRATIONS_PYTHON:-python3}"
+  parsed="$("$py" - "$INTEGRATIONS_ROOT" "$target_id" "$py" <<'PY'
+import json, subprocess, sys
+root, target_id, py = sys.argv[1], sys.argv[2], sys.argv[3]
+item = json.loads(subprocess.check_output([
+    py, f"{root}/lib/registry.py",
+    f"{root}/config/mcp-targets.yaml", "mcp_targets", target_id,
+], text=True))
+v = item["verify"]
+u = item["upstream"]
+print(u["name"])
+print(v["tool"])
+print(json.dumps(v["arguments"]))
+print("|".join(v["expect_substrings"]))
+PY
+)"
+  server_name="$(echo "$parsed" | sed -n '1p')"
+  tool_name="$(echo "$parsed" | sed -n '2p')"
+  args_json="$(echo "$parsed" | sed -n '3p')"
+  expect_joined="$(echo "$parsed" | sed -n '4p')"
+
+  log "Direct MCP smoke via fake_agent.py (server=$server_name tool=$tool_name auth=$auth_id)"
+  local bearer_args=()
+  case "$auth_id" in
+    oauth-client-credentials|oauth-dcr|static-bearer)
+      local token
+      token="$(fetch_bearer_token "$auth_id")" || return 1
+      bearer_args=(--bearer "$token")
+      ;;
+  esac
+  local output
+  output="$(
+    ATRYUM_URL="$ATRYUM_URL" \
+    python3 "$REPO_ROOT/scripts/fake_agent.py" mcp \
+      "$server_name" \
+      --tool "$tool_name" \
+      --arguments "$args_json" \
+      "${bearer_args[@]}" 2>&1
+  )" || return 1
+
+  local part
+  IFS='|' read -ra parts <<<"$expect_joined"
+  for part in "${parts[@]}"; do
+    if [[ "$output" != *"$part"* ]]; then
+      warn "expected substring '$part' in output:"
+      echo "$output" >&2
+      return 1
+    fi
+  done
+  log "Direct MCP verification passed"
+}

--- a/integrations/lib/auth.sh
+++ b/integrations/lib/auth.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck source=lib/common.sh
+source "$INTEGRATIONS_ROOT/lib/common.sh"
+# shellcheck source=lib/yaml.sh
+source "$INTEGRATIONS_ROOT/lib/yaml.sh"
+
+start_mock_oidc() {
+  ensure_python_deps
+  local venv="$INTEGRATIONS_ROOT/.venv"
+
+  log "Starting mock OIDC on :${MOCK_OIDC_PORT}"
+  "$venv/bin/python" "$INTEGRATIONS_ROOT/auth/mock-oidc/mock_oidc.py" \
+    --host 127.0.0.1 \
+    --port "$MOCK_OIDC_PORT" \
+    --env-file "$RUN_DIR/mock-oidc.env" \
+    >"$RUN_DIR/mock-oidc.log" 2>&1 &
+  echo $! >"$RUN_DIR/mock-oidc.pid"
+
+  wait_for_http "http://127.0.0.1:${MOCK_OIDC_PORT}/healthz" 40 0.25 || {
+    tail -n 30 "$RUN_DIR/mock-oidc.log" >&2 || true
+    return 1
+  }
+  # shellcheck disable=SC1090
+  source "$RUN_DIR/mock-oidc.env"
+  export MOCK_OIDC_ISSUER MOCK_OIDC_TOKEN_URL MOCK_OIDC_DCR_URL MOCK_OIDC_CLIENT_ID MOCK_OIDC_CLIENT_SECRET
+}
+
+auth_protocol_status() {
+  yaml_get_field "$INTEGRATIONS_ROOT/config/auth-protocols.yaml" auth_protocols "$1" status
+}
+
+auth_protocol_template() {
+  local rel
+  rel="$(yaml_get_field "$INTEGRATIONS_ROOT/config/auth-protocols.yaml" auth_protocols "$1" atryum_template)"
+  echo "$INTEGRATIONS_ROOT/$rel"
+}
+
+auth_requires_mock_oidc() {
+  local auth_id="$1"
+  local py="${INTEGRATIONS_PYTHON:-python3}"
+  "$py" - "$INTEGRATIONS_ROOT" "$auth_id" "$py" <<'PY'
+import json, subprocess, sys
+root, auth_id, py = sys.argv[1], sys.argv[2], sys.argv[3]
+item = json.loads(subprocess.check_output([
+    py, f"{root}/lib/registry.py",
+    f"{root}/config/auth-protocols.yaml", "auth_protocols", auth_id,
+], text=True))
+reqs = item.get("requires") or []
+print("yes" if "mock-oidc" in reqs else "no")
+PY
+}
+
+build_mcp_url() {
+  local auth_id="$1" harness_id="$2" server_name="$3"
+  local base="$ATRYUM_URL/mcp/${server_name}"
+
+  case "$auth_id" in
+    no-auth)
+      echo "${base}?agent_id=${harness_id}"
+      ;;
+    oauth-client-credentials|oauth-dcr|static-bearer)
+      local token
+      token="$(fetch_bearer_token "$auth_id")" || return 1
+      # mcp-remote accepts OAuth bearer via query for some clients; primary path
+      # is Authorization header via MCP_REMOTE_HEADERS (set by caller).
+      export ATRYUM_BEARER_TOKEN="$token"
+      echo "$base"
+      ;;
+    *)
+      echo "$base"
+      ;;
+  esac
+}
+
+fetch_bearer_token() {
+  local auth_id="$1"
+  case "$auth_id" in
+    oauth-client-credentials)
+      curl -fsS -X POST "$MOCK_OIDC_TOKEN_URL" \
+        -d "grant_type=client_credentials" \
+        -d "client_id=${MOCK_OIDC_CLIENT_ID}" \
+        -d "client_secret=${MOCK_OIDC_CLIENT_SECRET}" \
+        -d "scope=atryum:mcp" \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])'
+      ;;
+    oauth-dcr)
+      local reg
+      reg="$(curl -fsS -X POST "$MOCK_OIDC_DCR_URL" \
+        -H 'Content-Type: application/json' \
+        -d '{"client_name":"integration-dcr","grant_types":["client_credentials"],"token_endpoint_auth_method":"client_secret_post","scope":"atryum:mcp"}')"
+      local client_id client_secret
+      client_id="$(echo "$reg" | python3 -c 'import json,sys; print(json.load(sys.stdin)["client_id"])')"
+      client_secret="$(echo "$reg" | python3 -c 'import json,sys; print(json.load(sys.stdin)["client_secret"])')"
+      curl -fsS -X POST "$MOCK_OIDC_TOKEN_URL" \
+        -d "grant_type=client_credentials" \
+        -d "client_id=${client_id}" \
+        -d "client_secret=${client_secret}" \
+        -d "scope=atryum:mcp" \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])'
+      ;;
+    static-bearer)
+      [[ -n "${ATRYUM_STATIC_BEARER_TOKEN:-}" ]] || return 1
+      echo "$ATRYUM_STATIC_BEARER_TOKEN"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+mcp_remote_headers_env() {
+  local auth_id="$1"
+  case "$auth_id" in
+    oauth-client-credentials|oauth-dcr|static-bearer)
+      local token
+      token="$(fetch_bearer_token "$auth_id")" || return 1
+      export MCP_REMOTE_HEADERS="Authorization: Bearer ${token}"
+      ;;
+    no-auth)
+      unset MCP_REMOTE_HEADERS || true
+      ;;
+  esac
+}

--- a/integrations/lib/common.sh
+++ b/integrations/lib/common.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Shared helpers for the integration test suite.
+
+set -euo pipefail
+
+INTEGRATIONS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$INTEGRATIONS_ROOT/.." && pwd)"
+
+export INTEGRATIONS_ROOT REPO_ROOT
+
+RUN_ID="${RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
+RUN_DIR="${RUN_DIR:-$INTEGRATIONS_ROOT/.run/$RUN_ID}"
+RESULTS_DIR="${RESULTS_DIR:-$INTEGRATIONS_ROOT/results}"
+HARNESS_CONFIG_DIR="${HARNESS_CONFIG_DIR:-$RUN_DIR/harness-config}"
+
+ATRYUM_PORT="${ATRYUM_PORT:-}"
+MOCK_OIDC_PORT="${MOCK_OIDC_PORT:-}"
+
+log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+mkdir -p "$RUN_DIR" "$RESULTS_DIR" "$HARNESS_CONFIG_DIR"
+
+ensure_python_deps() {
+  local venv="$INTEGRATIONS_ROOT/.venv"
+  if [[ ! -x "$venv/bin/python" ]]; then
+    log "Creating Python venv for integration helpers..."
+    python3 -m venv "$venv"
+    "$venv/bin/pip" install -q -r "$INTEGRATIONS_ROOT/requirements.txt"
+  fi
+  export INTEGRATIONS_PYTHON="$venv/bin/python"
+}
+
+registry_py() {
+  local py="${INTEGRATIONS_PYTHON:-$INTEGRATIONS_ROOT/.venv/bin/python}"
+  if [[ ! -x "$py" ]]; then
+    py=python3
+  fi
+  "$py" "$INTEGRATIONS_ROOT/lib/registry.py" "$@"
+}
+
+write_result() {
+  local name="$1" status="$2" detail="${3:-}"
+  local file="$RESULTS_DIR/${RUN_ID}-${name}.json"
+  printf '{"run_id":"%s","case":"%s","status":"%s","detail":%s,"ts":"%s"}\n' \
+    "$RUN_ID" "$name" "$status" "$(json_quote "$detail")" "$(date -Iseconds)" >"$file"
+}
+
+json_quote() {
+  python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"
+}
+
+wait_for_http() {
+  local url="$1" attempts="${2:-60}" delay="${3:-0.5}"
+  local i=0
+  while (( i < attempts )); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep "$delay"
+    i=$((i + 1))
+  done
+  return 1
+}
+
+free_port() {
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+pick_port() {
+  local var_name="$1"
+  local current="${!var_name:-}"
+  if [[ -n "$current" && "$current" != "0" ]]; then
+    return 0
+  fi
+  # shellcheck disable=SC2154
+  printf -v "$var_name" '%s' "$(free_port)"
+}
+
+cleanup_process() {
+  local pidfile="$1"
+  [[ -f "$pidfile" ]] || return 0
+  local pid
+  pid="$(cat "$pidfile")"
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  rm -f "$pidfile"
+}
+
+cleanup_all() {
+  cleanup_process "$RUN_DIR/mock-oidc.pid"
+  cleanup_process "$RUN_DIR/atryum.pid"
+}
+
+# Tear down the previous case and allocate a fresh run directory + ports.
+# Matrix cells must not share atryum.db — bootstrap only runs on an empty DB.
+reset_case_runtime() {
+  local case_suffix="${1:-}"
+  cleanup_all
+
+  CASE_SEQ="${CASE_SEQ:-0}"
+  CASE_SEQ=$((CASE_SEQ + 1))
+  RUN_ID="$(date +%Y%m%d-%H%M%S)-$$-${CASE_SEQ}"
+  if [[ -n "$case_suffix" ]]; then
+    RUN_ID="${RUN_ID}-${case_suffix}"
+  fi
+  export RUN_ID
+
+  RUN_DIR="$INTEGRATIONS_ROOT/.run/$RUN_ID"
+  HARNESS_CONFIG_DIR="$RUN_DIR/harness-config"
+  export RUN_DIR HARNESS_CONFIG_DIR
+
+  ATRYUM_PORT=""
+  MOCK_OIDC_PORT=""
+  export ATRYUM_PORT MOCK_OIDC_PORT
+  unset ATRYUM_URL MOCK_OIDC_ISSUER ATRYUM_BEARER_TOKEN MCP_REMOTE_HEADERS || true
+
+  mkdir -p "$RUN_DIR" "$RESULTS_DIR" "$HARNESS_CONFIG_DIR"
+}
+
+trap cleanup_all EXIT

--- a/integrations/lib/harness.sh
+++ b/integrations/lib/harness.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck source=lib/common.sh
+source "$INTEGRATIONS_ROOT/lib/common.sh"
+# shellcheck source=lib/yaml.sh
+source "$INTEGRATIONS_ROOT/lib/yaml.sh"
+# shellcheck source=lib/auth.sh
+source "$INTEGRATIONS_ROOT/lib/auth.sh"
+# shellcheck source=lib/atryum.sh
+source "$INTEGRATIONS_ROOT/lib/atryum.sh"
+
+harness_skip_reason() {
+  yaml_get_field "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses "$1" skip_reason
+}
+
+harness_api_key_env() {
+  yaml_get_field "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses "$1" api_key_env
+}
+
+harness_available() {
+  local harness_id="$1"
+  local skip
+  skip="$(harness_skip_reason "$harness_id")"
+  if [[ -n "$skip" ]]; then
+    warn "skip $harness_id: $skip"
+    return 1
+  fi
+
+  if [[ "$harness_id" == "fake-agent" ]]; then
+    return 0
+  fi
+
+  local cli
+  cli="$(yaml_get_field "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses "$harness_id" cli)"
+  if [[ -z "$cli" ]]; then
+    warn "skip $harness_id: no CLI configured"
+    return 1
+  fi
+  command -v "$cli" >/dev/null 2>&1 || {
+    warn "skip $harness_id: '$cli' not on PATH"
+    return 1
+  }
+
+  local key_env key_optional
+  key_env="$(harness_api_key_env "$harness_id")"
+  key_optional="$(yaml_get_field "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses "$harness_id" api_key_env_optional)"
+  if [[ -n "$key_env" && -z "${!key_env:-}" ]]; then
+    if [[ "$key_optional" == "true" ]]; then
+      return 0
+    fi
+    # Amp may already be authenticated via `amp login` without AMP_API_KEY.
+    if [[ "$harness_id" == "amp" ]] && amp threads list --json >/dev/null 2>&1; then
+      return 0
+    fi
+    warn "skip $harness_id: env $key_env is unset"
+    return 1
+  fi
+  return 0
+}
+
+install_hook() {
+  local harness_id="$1"
+  local hook_json
+  hook_json="$(yaml_get_field "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses "$harness_id" hook)"
+  [[ -n "$hook_json" && "$hook_json" != "null" ]] || return 0
+
+  local hook_type
+  hook_type="$(echo "$hook_json" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("type",""))')"
+
+  case "$hook_type" in
+    command)
+      local script host source
+      script="$(echo "$hook_json" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["script"])')"
+      host="$(echo "$hook_json" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["host"])')"
+      source="$(echo "$hook_json" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["source"])')"
+      local hook_dest="$HARNESS_CONFIG_DIR/atryum-hook.mjs"
+      cp "$REPO_ROOT/examples/$script" "$hook_dest"
+      chmod +x "$hook_dest"
+
+      case "$source" in
+        claude-code)
+          mkdir -p "$HARNESS_CONFIG_DIR/claude"
+          cat >"$HARNESS_CONFIG_DIR/claude/settings.json" <<EOF
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "*",
+      "hooks": [{
+        "type": "command",
+        "command": "ATRYUM_URL=${ATRYUM_URL} ATRYUM_HOOK_HOST=${host} ATRYUM_HOOK_EVENT=PreToolUse ATRYUM_SOURCE=${source} ATRYUM_AGENT_ID=${harness_id} node ${hook_dest}"
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "*",
+      "hooks": [{
+        "type": "command",
+        "command": "ATRYUM_URL=${ATRYUM_URL} ATRYUM_HOOK_HOST=${host} ATRYUM_HOOK_EVENT=PostToolUse ATRYUM_SOURCE=${source} ATRYUM_AGENT_ID=${harness_id} node ${hook_dest}"
+      }]
+    }]
+  }
+}
+EOF
+          export CLAUDE_CONFIG_DIR="$HARNESS_CONFIG_DIR/claude"
+          ;;
+        cursor)
+          mkdir -p "$HARNESS_CONFIG_DIR/cursor"
+          cat >"$HARNESS_CONFIG_DIR/cursor/hooks.json" <<EOF
+{
+  "hooks": {
+    "preToolUse": [{
+      "type": "command",
+      "command": "ATRYUM_URL=${ATRYUM_URL} ATRYUM_HOOK_HOST=${host} ATRYUM_HOOK_EVENT=preToolUse ATRYUM_SOURCE=${source} ATRYUM_AGENT_ID=${harness_id} node ${hook_dest}"
+    }],
+    "postToolUse": [{
+      "type": "command",
+      "command": "ATRYUM_URL=${ATRYUM_URL} ATRYUM_HOOK_HOST=${host} ATRYUM_HOOK_EVENT=postToolUse ATRYUM_SOURCE=${source} ATRYUM_AGENT_ID=${harness_id} node ${hook_dest}"
+    }]
+  }
+}
+EOF
+          export CURSOR_HOOKS_FILE="$HARNESS_CONFIG_DIR/cursor/hooks.json"
+          ;;
+      esac
+      ;;
+    plugin)
+      if [[ "${INTEGRATION_AMP_MCP_ONLY:-}" == "1" && "$harness_id" == "amp" ]]; then
+        warn "skipping amp plugin hook (INTEGRATION_AMP_MCP_ONLY=1)"
+        return 0
+      fi
+      local script
+      script="$(echo "$hook_json" | python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["script"])')"
+      mkdir -p "$HARNESS_CONFIG_DIR/amp/plugins"
+      cp "$REPO_ROOT/examples/$script" "$HARNESS_CONFIG_DIR/amp/plugins/atryum.ts"
+      export PLUGINS=all
+      export AMP_PLUGIN_DIR="$HARNESS_CONFIG_DIR/amp/plugins"
+      export ATRYUM_AGENT_ID="$harness_id"
+      export ATRYUM_URL
+      ;;
+    external-invocations)
+      warn "hook type external-invocations is documented only — no local install"
+      ;;
+  esac
+}
+
+configure_harness_mcp() {
+  local harness_id="$1" auth_id="$2" target_id="$3"
+  local template path transport server_name mcp_url dest py="${INTEGRATIONS_PYTHON:-python3}"
+  template="$("$py" "$INTEGRATIONS_ROOT/lib/registry.py" \
+    "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses "$harness_id" mcp_config_template)"
+  path="$("$py" "$INTEGRATIONS_ROOT/lib/registry.py" \
+    "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses "$harness_id" mcp_config_path)"
+  transport="$("$py" "$INTEGRATIONS_ROOT/lib/registry.py" \
+    "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses "$harness_id" mcp_transport)"
+
+  server_name="$(render_upstream_block "$target_id" | awk -F'"' '/^name =/{print $2; exit}')"
+
+  if [[ "$transport" == "direct-jsonrpc" ]]; then
+    export ATRYUM_MCP_SERVER="$server_name"
+    return 0
+  fi
+
+  export CODEX_TEST_HOME="${CODEX_TEST_HOME:-$HARNESS_CONFIG_DIR/codex-home}"
+  export GROK_TEST_HOME="${GROK_TEST_HOME:-$HARNESS_CONFIG_DIR/grok-home}"
+  export AMP_SETTINGS_FILE="${AMP_SETTINGS_FILE:-$HARNESS_CONFIG_DIR/amp/settings.json}"
+
+  mcp_remote_headers_env "$auth_id" || true
+  mcp_url="$(build_mcp_url "$auth_id" "$harness_id" "$server_name")"
+
+  case "$transport" in
+    amp-settings-json)
+      mkdir -p "$(dirname "$AMP_SETTINGS_FILE")"
+      rm -f "$AMP_SETTINGS_FILE"
+      local amp_env=()
+      if [[ -n "${MCP_REMOTE_HEADERS:-}" ]]; then
+        amp_env+=(--env "MCP_REMOTE_HEADERS=${MCP_REMOTE_HEADERS}")
+      fi
+      if ! AMP_SETTINGS_FILE="$AMP_SETTINGS_FILE" amp mcp add calculator_via_atryum \
+        "${amp_env[@]}" \
+        -- npx -y mcp-remote "$mcp_url"; then
+        warn "amp mcp add failed for $AMP_SETTINGS_FILE"
+        return 1
+      fi
+      return 0
+      ;;
+    codex-config-toml)
+      dest="$CODEX_TEST_HOME/.codex/config.toml"
+      mkdir -p "$(dirname "$dest")"
+      for cred in auth.json .credentials.json; do
+        if [[ -f "$HOME/.codex/$cred" ]]; then
+          cp "$HOME/.codex/$cred" "$CODEX_TEST_HOME/.codex/"
+        fi
+      done
+      if [[ -z "${OPENAI_API_KEY:-}" && -f "$HOME/.codex/auth.json" ]]; then
+        : # use copied login credentials
+      fi
+      ;;
+    grok-config-toml)
+      mkdir -p "$GROK_TEST_HOME/.grok"
+      if [[ -d "$HOME/.grok" ]]; then
+        cp -a "$HOME/.grok/." "$GROK_TEST_HOME/.grok/" 2>/dev/null || true
+      fi
+      local grok_env=()
+      if [[ -n "${MCP_REMOTE_HEADERS:-}" ]]; then
+        grok_env+=(--env "MCP_REMOTE_HEADERS=${MCP_REMOTE_HEADERS}")
+      fi
+      HOME="$GROK_TEST_HOME" grok mcp add calculator_via_atryum \
+        "${grok_env[@]}" \
+        --command npx \
+        --args -y mcp-remote "$mcp_url" >/dev/null 2>&1 || {
+        warn "grok mcp add failed; writing config.toml fallback"
+        dest="$GROK_TEST_HOME/.grok/config.toml"
+        mkdir -p "$(dirname "$dest")"
+        printf '%s\n' "$template" | sed "s|\$ATRYUM_MCP_URL|${mcp_url}|g" >"$dest"
+      }
+      return 0
+      ;;
+    *)
+      if [[ -z "$template" || "$template" == "null" || -z "$path" || "$path" == "null" ]]; then
+        return 0
+      fi
+      dest="$HARNESS_CONFIG_DIR/$(basename "$path")"
+      mkdir -p "$(dirname "$dest")"
+      ;;
+  esac
+
+  if [[ -n "${dest:-}" && -n "$template" && "$template" != "null" ]]; then
+    printf '%s\n' "$template" | sed "s|\$ATRYUM_MCP_URL|${mcp_url}|g" >"$dest"
+  fi
+
+  case "$harness_id" in
+    claude-code)
+      export CLAUDE_MCP_CONFIG="$dest"
+      ;;
+    cursor)
+      export CURSOR_MCP_CONFIG="$dest"
+      ;;
+    *)
+      export HARNESS_MCP_CONFIG="$dest"
+      ;;
+  esac
+}
+
+run_harness_case() {
+  local harness_id="$1" auth_id="$2" target_id="$3"
+  local prompt expect py="${INTEGRATIONS_PYTHON:-python3}"
+  prompt="$("$py" "$INTEGRATIONS_ROOT/lib/registry.py" \
+    "$INTEGRATIONS_ROOT/config/mcp-targets.yaml" mcp_targets "$target_id" prompt)"
+  local py="${INTEGRATIONS_PYTHON:-python3}"
+  expect="$("$py" - "$INTEGRATIONS_ROOT" "$target_id" "$py" <<'PY'
+import json, subprocess, sys
+root, target_id, py = sys.argv[1], sys.argv[2], sys.argv[3]
+item = json.loads(subprocess.check_output([
+    py, f"{root}/lib/registry.py",
+    f"{root}/config/mcp-targets.yaml", "mcp_targets", target_id,
+], text=True))
+print("|".join(item["verify"]["expect_substrings"]))
+PY
+)"
+
+  export CODEX_TEST_HOME="${CODEX_TEST_HOME:-$HARNESS_CONFIG_DIR/codex-home}"
+  export GROK_TEST_HOME="${GROK_TEST_HOME:-$HARNESS_CONFIG_DIR/grok-home}"
+  export AMP_SETTINGS_FILE="${AMP_SETTINGS_FILE:-$HARNESS_CONFIG_DIR/amp/settings.json}"
+  export CLAUDE_MCP_CONFIG="${CLAUDE_MCP_CONFIG:-}"
+
+  install_hook "$harness_id"
+  configure_harness_mcp "$harness_id" "$auth_id" "$target_id"
+
+  local invoke
+  log "Running harness=$harness_id auth=$auth_id target=$target_id"
+
+  local output rc=0
+  set +e
+  if [[ "$harness_id" == "fake-agent" ]]; then
+    local server_name tool_name args_json
+    server_name="$(render_upstream_block "$target_id" | awk -F'"' '/^name =/{print $2; exit}')"
+    tool_name="$("$py" - "$INTEGRATIONS_ROOT" "$target_id" "$py" <<'PY'
+import json, subprocess, sys
+root, target_id, py = sys.argv[1], sys.argv[2], sys.argv[3]
+item = json.loads(subprocess.check_output([
+    py, f"{root}/lib/registry.py",
+    f"{root}/config/mcp-targets.yaml", "mcp_targets", target_id,
+], text=True))
+print(item["verify"]["tool"])
+print(json.dumps(item["verify"]["arguments"]))
+PY
+)"
+    args_json="$(echo "$tool_name" | sed -n '2p')"
+    tool_name="$(echo "$tool_name" | sed -n '1p')"
+    local bearer_args=()
+    case "$auth_id" in
+      oauth-client-credentials|oauth-dcr|static-bearer)
+        local token
+        token="$(fetch_bearer_token "$auth_id")" || return 1
+        bearer_args=(--bearer "$token")
+        ;;
+    esac
+    log "Command: python3 $REPO_ROOT/scripts/fake_agent.py mcp $server_name --tool $tool_name --arguments $args_json"
+    output="$(
+      ATRYUM_URL="$ATRYUM_URL" \
+      python3 "$REPO_ROOT/scripts/fake_agent.py" mcp "$server_name" \
+        --tool "$tool_name" \
+        --arguments "$args_json" \
+        "${bearer_args[@]}" 2>&1
+    )"
+    rc=$?
+  else
+    local invoke
+    invoke="$(registry_py "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses "$harness_id" invoke)"
+    invoke="${invoke//\$PROMPT/$prompt}"
+    invoke="${invoke//\$WORKDIR/$RUN_DIR}"
+    invoke="${invoke//\$ATRYUM_URL/$ATRYUM_URL}"
+    invoke="${invoke//\$CODEX_TEST_HOME/$CODEX_TEST_HOME}"
+    invoke="${invoke//\$GROK_TEST_HOME/$GROK_TEST_HOME}"
+    invoke="${invoke//\$CLAUDE_MCP_CONFIG/${CLAUDE_MCP_CONFIG:-}}"
+    invoke="${invoke//\$AMP_SETTINGS_FILE/${AMP_SETTINGS_FILE:-}}"
+    local harness_timeout="${HARNESS_TIMEOUT_SECONDS:-180}"
+    log "Command: $invoke (timeout=${harness_timeout}s)"
+    # shellcheck disable=SC2086
+    output="$(timeout "$harness_timeout" bash -c "$invoke" 2>&1)"
+    rc=$?
+    if (( rc == 124 )); then
+      warn "harness timed out after ${harness_timeout}s"
+    fi
+  fi
+  set -e
+  echo "$output" >"$RUN_DIR/${harness_id}-${auth_id}-${target_id}.log"
+
+  if (( rc != 0 )); then
+    warn "harness exited $rc"
+    echo "$output" >&2
+    return 1
+  fi
+
+  local part
+  IFS='|' read -ra parts <<<"$expect"
+  for part in "${parts[@]}"; do
+    if [[ "$output" != *"$part"* ]]; then
+      warn "expected '$part' in harness output"
+      echo "$output" >&2
+      return 1
+    fi
+  done
+  log "Harness output contained expected value(s): ${expect//|/, }"
+}

--- a/integrations/lib/registry.py
+++ b/integrations/lib/registry.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Read integration registry YAML files with or without PyYAML installed."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_registry(path: Path, section: str) -> list[dict[str, Any]]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(text) or {}
+        items = data.get(section, [])
+        return items if isinstance(items, list) else []
+    except ImportError:
+        return _parse_flat_registry(text, section)
+
+
+def _parse_flat_registry(text: str, section: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    in_section = False
+    multiline_key: str | None = None
+    multiline_lines: list[str] = []
+
+    def flush_multiline() -> None:
+        nonlocal multiline_key, multiline_lines
+        if current is not None and multiline_key is not None:
+            current[multiline_key] = "\n".join(multiline_lines).rstrip("\n")
+        multiline_key = None
+        multiline_lines = []
+
+    for line in text.splitlines():
+        if line.strip() == f"{section}:":
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if line.startswith("  - id:"):
+            flush_multiline()
+            if current is not None:
+                items.append(current)
+            current = {"id": line.split(":", 1)[1].strip()}
+            continue
+        if line.startswith("    ") and current is not None:
+            if multiline_key is not None:
+                if line.startswith("      "):
+                    multiline_lines.append(line[6:])
+                    continue
+                flush_multiline()
+            if ":" not in line.strip():
+                continue
+            key, val = line.strip().split(":", 1)
+            val = val.strip()
+            if val == "|":
+                multiline_key = key
+                multiline_lines = []
+                continue
+            if val in ("null", "~"):
+                current[key] = None
+            elif val.startswith("[") and val.endswith("]"):
+                current[key] = [v.strip() for v in val[1:-1].split(",") if v.strip()]
+            elif val.startswith('"') and val.endswith('"'):
+                current[key] = val[1:-1]
+            elif val.startswith("'") and val.endswith("'"):
+                current[key] = val[1:-1]
+            else:
+                current[key] = val
+            continue
+        if line and not line.startswith(" "):
+            break
+
+    flush_multiline()
+    if current is not None:
+        items.append(current)
+    return items
+
+
+def get_item(path: Path, section: str, item_id: str) -> dict[str, Any]:
+    for item in load_registry(path, section):
+        if item.get("id") == item_id:
+            return item
+    raise KeyError(f"{item_id} not found in {section} of {path}")
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print("usage: registry.py <file> <section> [id] [field]", file=sys.stderr)
+        raise SystemExit(2)
+
+    path = Path(sys.argv[1])
+    section = sys.argv[2]
+    if len(sys.argv) == 3:
+        for item in load_registry(path, section):
+            print(item["id"])
+        return
+
+    item_id = sys.argv[3]
+    item = get_item(path, section, item_id)
+    if len(sys.argv) == 4:
+        print(json.dumps(item))
+        return
+
+    field = sys.argv[4]
+    val = item.get(field)
+    if val is None:
+        print("", end="")
+    elif isinstance(val, (dict, list)):
+        print(json.dumps(val))
+    else:
+        print(val, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/lib/yaml.sh
+++ b/integrations/lib/yaml.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Minimal YAML readers — avoids extra dependencies beyond python3.
+
+set -euo pipefail
+
+yaml_list_ids() {
+  local file="$1" section="$2"
+  python3 - "$file" "$section" <<'PY'
+import sys
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except ImportError:
+    yaml = None
+
+path, section = sys.argv[1], sys.argv[2]
+text = Path(path).read_text(encoding="utf-8")
+
+if yaml is not None:
+    data = yaml.safe_load(text) or {}
+    for item in data.get(section, []):
+        print(item["id"])
+    raise SystemExit(0)
+
+# Fallback: line-oriented parser for our flat registry files.
+items = []
+current = None
+in_section = False
+for line in text.splitlines():
+    if line.strip() == f"{section}:":
+        in_section = True
+        continue
+    if in_section and line.startswith("  - id:"):
+        if current:
+            items.append(current)
+        current = line.split(":", 1)[1].strip()
+    elif in_section and line.startswith("  - ") and not line.startswith("  - id:"):
+        if current:
+            items.append(current)
+            current = None
+    elif in_section and line and not line.startswith(" "):
+        break
+if current:
+    items.append(current)
+for item in items:
+    print(item)
+PY
+}
+
+yaml_get_field() {
+  local file="$1" section="$2" id="$3" field="$4"
+  python3 - "$file" "$section" "$id" "$field" <<'PY'
+import sys
+from pathlib import Path
+
+try:
+    import yaml  # type: ignore
+except ImportError:
+    yaml = None
+
+path, section, wanted_id, field = sys.argv[1:5]
+text = Path(path).read_text(encoding="utf-8")
+
+if yaml is not None:
+    data = yaml.safe_load(text) or {}
+    for item in data.get(section, []):
+        if item.get("id") == wanted_id:
+            val = item.get(field)
+            if val is None:
+                print("", end="")
+            elif isinstance(val, (dict, list)):
+                import json
+                print(json.dumps(val))
+            else:
+                print(val)
+            raise SystemExit(0)
+    raise SystemExit(1)
+
+# Fallback parser
+items = {}
+current_id = None
+current: dict = {}
+in_section = False
+for line in text.splitlines():
+    if line.strip() == f"{section}:":
+        in_section = True
+        continue
+    if not in_section:
+        continue
+    if line.startswith("  - id:"):
+        if current_id:
+            items[current_id] = current
+        current_id = line.split(":", 1)[1].strip()
+        current = {"id": current_id}
+        continue
+    if line.startswith("    ") and current_id and ":" in line:
+        key, val = line.strip().split(":", 1)
+        val = val.strip()
+        if val in ('""', "''"):
+            val = ""
+        elif val.startswith('"') and val.endswith('"'):
+            val = val[1:-1]
+        elif val == "null":
+            val = ""
+        current[key] = val
+    elif line.startswith("  - ") and not line.startswith("  - id:"):
+        pass
+    elif line and not line.startswith(" "):
+        break
+if current_id:
+    items[current_id] = current
+
+item = items.get(wanted_id)
+if not item:
+    raise SystemExit(1)
+val = item.get(field, "")
+print(val if val is not None else "", end="")
+PY
+}

--- a/integrations/requirements.txt
+++ b/integrations/requirements.txt
@@ -1,0 +1,4 @@
+PyYAML==6.0.2
+PyJWT[crypto]==2.10.1
+cryptography==44.0.2
+mcp-server-calculator==0.1.1

--- a/integrations/scripts/agent_harness_integration_tests.sh
+++ b/integrations/scripts/agent_harness_integration_tests.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Agent harness integration tests — exercise harnesses through Atryum to MCP upstreams.
+#
+# Usage:
+#   ./scripts/agent_harness_integration_tests.sh list
+#   ./scripts/agent_harness_integration_tests.sh run --harness <id> --auth <id> [--target <id>]
+#   ./scripts/agent_harness_integration_tests.sh matrix [--only-passing] [--harnesses a,b] [--auth x,y] [--targets t]
+#
+# Environment (harness LLM credentials — never committed):
+#   OPENAI_API_KEY, ANTHROPIC_API_KEY, AMP_API_KEY, CURSOR_API_KEY, XAI_API_KEY
+
+set -euo pipefail
+
+INTEGRATIONS_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+export INTEGRATIONS_ROOT
+
+# shellcheck source=../lib/common.sh
+source "$INTEGRATIONS_ROOT/lib/common.sh"
+# shellcheck source=../lib/yaml.sh
+source "$INTEGRATIONS_ROOT/lib/yaml.sh"
+# shellcheck source=../lib/auth.sh
+source "$INTEGRATIONS_ROOT/lib/auth.sh"
+# shellcheck source=../lib/atryum.sh
+source "$INTEGRATIONS_ROOT/lib/atryum.sh"
+# shellcheck source=../lib/harness.sh
+source "$INTEGRATIONS_ROOT/lib/harness.sh"
+
+CMD="${1:-help}"
+shift || true
+
+usage() {
+  cat <<'EOF'
+Agent harness integration tests
+
+Commands:
+  list                              List harnesses, auth protocols, and MCP targets
+  run                               Run a single harness × auth × target case
+  matrix                            Run the full matrix (skips unavailable cases)
+  help                              Show this help
+
+Run options:
+  --harness ID                      Harness id (required)
+  --auth ID                         Auth protocol id (required)
+  --target ID                       MCP target id (default: calculator)
+  --skip-direct                     Skip fake_agent.py MCP verification
+
+Matrix options:
+  --harnesses a,b                   Filter harness ids
+  --auth a,b                        Filter auth protocol ids
+  --targets a,b                     Filter MCP target ids
+  --only-passing                    Skip placeholder auth modes
+
+Examples:
+  ./scripts/agent_harness_integration_tests.sh run --harness fake-agent --auth no-auth
+  ./scripts/agent_harness_integration_tests.sh run --harness codex --auth no-auth
+  ./scripts/agent_harness_integration_tests.sh matrix --only-passing
+  ./scripts/agent_harness_integration_tests.sh matrix --harnesses fake-agent --auth no-auth,oauth-client-credentials
+EOF
+}
+
+cmd_list() {
+  echo "Harnesses:"
+  yaml_list_ids "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses | sed 's/^/  /'
+  echo
+  echo "Auth protocols:"
+  yaml_list_ids "$INTEGRATIONS_ROOT/config/auth-protocols.yaml" auth_protocols | sed 's/^/  /'
+  echo
+  echo "MCP targets:"
+  yaml_list_ids "$INTEGRATIONS_ROOT/config/mcp-targets.yaml" mcp_targets | sed 's/^/  /'
+}
+
+prepare_runtime() {
+  need_cmd python3
+  need_cmd curl
+  need_cmd go
+  ensure_python_deps
+
+  pick_port ATRYUM_PORT
+  pick_port MOCK_OIDC_PORT
+  export ATRYUM_PORT MOCK_OIDC_PORT
+  ATRYUM_URL="http://127.0.0.1:${ATRYUM_PORT}"
+  export ATRYUM_URL
+}
+
+run_single_case() {
+  local harness_id="$1" auth_id="$2" target_id="$3" skip_direct="${4:-0}"
+  local case_name="${harness_id}__${auth_id}__${target_id}"
+
+  reset_case_runtime "$case_name"
+  prepare_runtime
+  log "Ports: atryum=$ATRYUM_PORT mock_oidc=$MOCK_OIDC_PORT"
+
+  log "Case: $case_name (run_dir=$RUN_DIR)"
+
+  local auth_status
+  auth_status="$(auth_protocol_status "$auth_id")"
+  if [[ "$auth_status" == "placeholder" ]]; then
+    warn "auth protocol '$auth_id' is a placeholder — skipping"
+    write_result "$case_name" "skipped" "auth protocol placeholder"
+    return 0
+  fi
+
+  harness_available "$harness_id" || {
+    write_result "$case_name" "skipped" "harness unavailable"
+    return 0
+  }
+
+  if [[ "$(auth_requires_mock_oidc "$auth_id")" == "yes" ]]; then
+    start_mock_oidc
+  fi
+
+  local template config_path
+  template="$(auth_protocol_template "$auth_id")"
+  config_path="$RUN_DIR/atryum.toml"
+  render_atryum_config "$auth_id" "$target_id" "$template" "$config_path"
+  start_atryum "$config_path"
+  seed_auto_approve_rules
+
+  if (( skip_direct == 0 )); then
+    verify_upstream_direct "$target_id" "$auth_id" || {
+      write_result "$case_name" "failed" "direct MCP verification failed"
+      return 1
+    }
+  fi
+
+  if run_harness_case "$harness_id" "$auth_id" "$target_id"; then
+    write_result "$case_name" "passed" ""
+    log "PASS: $case_name"
+    return 0
+  fi
+
+  write_result "$case_name" "failed" "harness run failed — see $RUN_DIR"
+  die "FAIL: $case_name"
+}
+
+cmd_run() {
+  local harness_id="" auth_id="" target_id="calculator" skip_direct=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --harness) harness_id="$2"; shift 2 ;;
+      --auth) auth_id="$2"; shift 2 ;;
+      --target) target_id="$2"; shift 2 ;;
+      --skip-direct) skip_direct=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "unknown run argument: $1" ;;
+    esac
+  done
+
+  [[ -n "$harness_id" ]] || die "--harness is required"
+  [[ -n "$auth_id" ]] || die "--auth is required"
+  run_single_case "$harness_id" "$auth_id" "$target_id" "$skip_direct"
+}
+
+in_csv_list() {
+  local needle="$1" csv="$2"
+  [[ -z "$csv" ]] && return 0
+  [[ ",${csv}," == *",${needle},"* ]]
+}
+
+cmd_matrix() {
+  local harness_filter="" auth_filter="" target_filter="" only_passing=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --harnesses) harness_filter="$2"; shift 2 ;;
+      --auth) auth_filter="$2"; shift 2 ;;
+      --targets) target_filter="$2"; shift 2 ;;
+      --only-passing) only_passing=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "unknown matrix argument: $1" ;;
+    esac
+  done
+
+  local passed=0 failed=0 skipped=0 harness auth target
+
+  for harness in $(yaml_list_ids "$INTEGRATIONS_ROOT/config/harnesses.yaml" harnesses); do
+    in_csv_list "$harness" "$harness_filter" || continue
+    for auth in $(yaml_list_ids "$INTEGRATIONS_ROOT/config/auth-protocols.yaml" auth_protocols); do
+      in_csv_list "$auth" "$auth_filter" || continue
+      if (( only_passing )); then
+        local status
+        status="$(auth_protocol_status "$auth")"
+        [[ "$status" == "implemented" ]] || { skipped=$((skipped + 1)); continue; }
+      fi
+      for target in $(yaml_list_ids "$INTEGRATIONS_ROOT/config/mcp-targets.yaml" mcp_targets); do
+        in_csv_list "$target" "$target_filter" || continue
+        log "Matrix cell: harness=$harness auth=$auth target=$target"
+        set +e
+        run_single_case "$harness" "$auth" "$target"
+        local rc=$?
+        set -e
+        case "$rc" in
+          0) passed=$((passed + 1)) ;;
+          *) failed=$((failed + 1)) ;;
+        esac
+      done
+    done
+  done
+
+  log "Matrix complete: passed=$passed failed=$failed skipped=$skipped"
+  (( failed == 0 ))
+}
+
+case "$CMD" in
+  list) cmd_list "$@" ;;
+  run) cmd_run "$@" ;;
+  matrix) cmd_matrix "$@" ;;
+  help|-h|--help) usage ;;
+  *)
+    die "unknown command: $CMD (try: help)"
+    ;;
+esac


### PR DESCRIPTION
## Why this exists

Atryum sits between a growing set of agent harnesses — each with its own ideas about MCP transport, session negotiation, OAuth, hooks, and CLI shape. Unit tests cover the gateway logic; they don't tell us whether Codex, Claude Code, Amp, or the next harness can actually reach an upstream tool through Atryum in a realistic configuration.

This PR adds an integration layer whose purpose is to exercise those real paths: stand up an isolated Atryum instance, wire a harness the way `examples/` documents, point it at a safe upstream MCP server, and observe whether the expected result comes back.

## What it does

Each case is a **harness × inbound-auth × MCP-target** cell. For every run:

1. A dedicated Atryum process starts on an ephemeral port (SQLite, fresh DB).
2. A catch-all `auto_approve` **rule** is seeded via the admin API — approval is through the rule engine, not a policy provider override.
3. The upstream MCP server is bootstrapped from config (default: [mcp-server-calculator](https://github.com/githejie/mcp-server-calculator), installed into a local `.venv`).
4. `fake_agent.py` verifies the MCP proxy path directly (JSON-RPC through Atryum, with bearer token when auth is enabled).
5. The harness is configured in an isolated scratch directory (MCP aliases, hooks from `examples/`, credential copies where login state matters) and invoked with a prompt that names the MCP server alias and expects a specific numeric answer.

The matrix is data-driven: `config/harnesses.yaml`, `config/auth-protocols.yaml`, and `config/mcp-targets.yaml`. Adding a harness or auth mode is mostly registry edits, not new shell spaghetti.

## Harness coverage

| Harness | Hook (`examples/`) | Status |
|---------|-------------------|--------|
| `fake-agent` | — | Baseline; no LLM, runs in CI |
| `codex` | — | MCP via isolated `~/.codex` + `codex exec` |
| `claude-code` | `shared-agent-hook` | MCP via `--mcp-config`; API-key or existing auth |
| `amp` | `amp-plugin` | MCP via `amp mcp add`; API-key or `amp login` |
| `grok` | — | MCP via isolated `~/.grok` + `grok --single` |
| `cursor`, `pi`, `agentforce`, `foundry` | various | Registered; skipped or placeholder until validated |

Harness **LLM billing** (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) is separate from **harness→Atryum auth** (`no-auth`, `oauth-client-credentials`, `oauth-dcr`). Codex and Claude are tested with API-key billing or pre-existing CLI login — not subscription OAuth.

## Auth protocols

- **Implemented:** `no-auth`, `oauth-client-credentials`, `oauth-dcr` — the latter two use a lightweight Python mock OIDC (`auth/mock-oidc/`), not Keycloak. Fast enough for CI; faithful enough for token validation against `[[auth]]` blocks.
- **Placeholder:** `static-bearer`, `basic-auth`, `api-key-pair` — registered so the matrix can grow without restructuring.

## CI

`.github/workflows/agent-harness-integration-tests.yml` runs the `fake-agent` baseline on PRs touching integration or MCP code — no secrets required.

A second job can run live harnesses when repository secrets are present (or via `workflow_dispatch` / `RUN_LIVE_HARNESS_INTEGRATION_TESTS=true`).

## Local operation

Entry point: `integrations/scripts/agent_harness_integration_tests.sh` (`list` / `run` / `matrix`).

Just targets: `integration-list`, `integration-test`, `integration-test-matrix`.

Developed in a worktree (`integrations-suite` branch); `shell.nix` is gitignored for NixOS devs who want it locally.

Artifacts land under `integrations/.run/` and `integrations/results/`. Ports are auto-selected to avoid colliding with a dev `:8080` instance.

## Verification prompts

Prompts live in `config/mcp-targets.yaml`. The default calculator target asks the harness to use `calculator_via_atryum`'s `calculate` tool for `17 * 23` and return only the numeric result; success means `391` appears in stdout. The MCP alias name matches what each harness config wires via `mcp-remote` — distinct from Atryum's upstream name `calculator`.

## Known gaps / follow-ups

- **Cursor** CLI not validated in this environment (no `cursor` on PATH during development).
- **Amp plugin + hook path** works for MCP; deeper hook coverage for native Amp tools could be expanded.
- **Log-based MCP assertions** — current pass/fail is output substring matching; Atryum invocation logs could be correlated for stricter proof.
- **Placeholder auth modes** need implementation when inbound support lands.

## Tested locally (rebased on `main` @ MCP session negotiation)

- `fake-agent` × `no-auth` × `calculator`
- `fake-agent` × `oauth-client-credentials` / `oauth-dcr` × `calculator`
- `codex`, `claude-code`, `amp`, `grok` × `no-auth` × `calculator`