### PR TITLE
Claude managed agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Atryum runs standalone and enforces locally. It is the open-source nervous syste
 
 ## How agents reach Atryum
 
-Atryum mediates two kinds of tool calls:
+Atryum mediates three kinds of tool calls:
 
 - **Pre-tool hooks from agent harnesses.** Managed harnesses (Claude Code, Cursor, amp, Pi) and autonomous ones (Microsoft Foundry, custom orchestrators) post their intended tool call to `POST /api/v1/external/invocations` (when the harness executes the tool itself) or `POST /api/v1/invocations` (when Atryum should execute it). The harness blocks on the response and only proceeds if Atryum returns an approved status. In the hook path Atryum never touches the tool — it just answers "may this call happen."
 - **Direct MCP proxying.** Agents that speak MCP connect to `POST /mcp/{server}` as their MCP endpoint. Atryum implements the JSON-RPC surface (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) and proxies calls to the configured upstream — HTTP or stdio. Because Atryum is the MCP client to the upstream, it holds the credentials (OAuth tokens, bearer tokens, custom headers) and the agent never sees them. The same approval engine runs on every `tools/call`.
-- **Claude Managed Agents events bridge.** Anthropic's hosted harness runs the agent loop on its own infrastructure and never calls Atryum, so for those sessions Atryum dials *out*: it streams a registered session's [events](https://platform.claude.com/docs/en/managed-agents/events-and-streaming), records every event as an invocation, and — when the session blocks on a tool call (`session.status_idle` / `requires_action`) — runs the normal approval rules and answers Claude with a `user.tool_confirmation` (or `user.custom_tool_result`). This gates both built-in and MCP tools. Enable it by declaring one or more `[[managed_agents]]` accounts (each with a `name` and `api_key`) and register sessions via `POST /api/v1/admin/managed-agents/sessions` (set `"account"` to target a specific account when more than one is configured). See `examples/managed-agents/`.
+- **Claude Managed Agents events bridge.** Anthropic's hosted harness runs the agent loop on its own infrastructure and never calls Atryum, so for those sessions Atryum dials *out*: it streams a registered session's [events](https://platform.claude.com/docs/en/managed-agents/events-and-streaming), records the raw session events on a synthetic audit invocation, and — when the session blocks on a tool call (`session.status_idle` / `requires_action`) — runs the normal approval rules and answers Claude with a `user.tool_confirmation` (or `user.custom_tool_result`). Each tool call is also recorded as its own invocation. This gates both built-in and MCP tools. Enable it by declaring one or more `[[managed_agents]]` accounts (each with a `name` and `api_key`) and register sessions via `POST /api/v1/admin/managed-agents/sessions` (set `"account"` to target a specific account when more than one is configured). See `examples/managed-agents/`.
 
 These paths converge on a single service so rules, audit, and the UI work identically regardless of how the call arrived.
 
@@ -45,7 +45,7 @@ External invocations (the hook path where the harness executes the tool itself) 
 
 Three pieces of identity travel with every invocation:
 
-- **Authenticated agent ID** — the `sub` (or configured claim) on the bearer token presented by the harness. Used for `agent_id_pattern` matching.
+- **Authenticated agent ID** — the configured claim on the bearer token presented by the harness. By default Atryum uses `client_id`, then falls back to `azp`, then `sub`. Used for `agent_id_pattern` matching.
 - **Agent record** — an optional local row in the `agents` table that maps one or more authenticated agent IDs to a named agent for organizational rule targeting.
 - **Client info** — `clientInfo.name` and `clientInfo.version` from the MCP `initialize` handshake (e.g., `claude-code 1.2.3`, `cursor 0.42`, `amp 0.0.1234`). Captured even when auth is disabled, so anonymous traffic is still attributable to a harness.
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Atryum mediates two kinds of tool calls:
 
 - **Pre-tool hooks from agent harnesses.** Managed harnesses (Claude Code, Cursor, amp, Pi) and autonomous ones (Microsoft Foundry, custom orchestrators) post their intended tool call to `POST /api/v1/external/invocations` (when the harness executes the tool itself) or `POST /api/v1/invocations` (when Atryum should execute it). The harness blocks on the response and only proceeds if Atryum returns an approved status. In the hook path Atryum never touches the tool — it just answers "may this call happen."
 - **Direct MCP proxying.** Agents that speak MCP connect to `POST /mcp/{server}` as their MCP endpoint. Atryum implements the JSON-RPC surface (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) and proxies calls to the configured upstream — HTTP or stdio. Because Atryum is the MCP client to the upstream, it holds the credentials (OAuth tokens, bearer tokens, custom headers) and the agent never sees them. The same approval engine runs on every `tools/call`.
+- **Claude Managed Agents events bridge.** Anthropic's hosted harness runs the agent loop on its own infrastructure and never calls Atryum, so for those sessions Atryum dials *out*: it streams a registered session's [events](https://platform.claude.com/docs/en/managed-agents/events-and-streaming), records every event as an invocation, and — when the session blocks on a tool call (`session.status_idle` / `requires_action`) — runs the normal approval rules and answers Claude with a `user.tool_confirmation` (or `user.custom_tool_result`). This gates both built-in and MCP tools. Enable it with `[managed_agents]` and register sessions via `POST /api/v1/admin/managed-agents/sessions`. See `examples/managed-agents/`.
 
-The two paths converge on a single service so rules, audit, and the UI work identically regardless of how the call arrived.
+These paths converge on a single service so rules, audit, and the UI work identically regardless of how the call arrived.
 
 ## The rule engine
 
@@ -72,6 +73,7 @@ Admin (UI and operators):
 - `/api/v1/admin/rules`, `/{id}` (including reorder/move)
 - `/api/v1/admin/agents`, `/{id}`
 - `/api/v1/admin/settings`, `/api/v1/admin/policy`
+- `/api/v1/admin/managed-agents/sessions` — register a Claude Managed Agents session for the events bridge to watch (returns `501` when `[managed_agents]` is not configured)
 - `/api/v1/admin/oauth/callback` — OAuth callback for upstream MCP server connect flows
 
 ## Frontend
@@ -90,6 +92,7 @@ SQLite by default, PostgreSQL optional via `server.database_url`. Both are first
 - `invocation_events` — append-only lifecycle events.
 - `approval_rules` — the rule engine.
 - `agents` — local agent records and their authenticated-ID mappings.
+- `managed_agent_sessions` — Claude Managed Agents sessions watched by the events bridge, with each one's event cursor for resume-after-restart.
 
 ## Config
 
@@ -110,6 +113,10 @@ base_url = ""
 machine_key = ""
 machine_secret = ""
 connection_timeout_seconds = 5
+
+[managed_agents]                   # optional — Claude Managed Agents events bridge
+api_key  = ""                      # Anthropic API key; empty disables the bridge
+                                   # env override: ATRYUM_MANAGED_AGENTS_API_KEY, then ANTHROPIC_API_KEY
 
 [[auth]]                           # optional — repeatable per authorization server
 issuer    = "https://keycloak.example/realms/agents"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Atryum mediates two kinds of tool calls:
 
 - **Pre-tool hooks from agent harnesses.** Managed harnesses (Claude Code, Cursor, amp, Pi) and autonomous ones (Microsoft Foundry, custom orchestrators) post their intended tool call to `POST /api/v1/external/invocations` (when the harness executes the tool itself) or `POST /api/v1/invocations` (when Atryum should execute it). The harness blocks on the response and only proceeds if Atryum returns an approved status. In the hook path Atryum never touches the tool — it just answers "may this call happen."
 - **Direct MCP proxying.** Agents that speak MCP connect to `POST /mcp/{server}` as their MCP endpoint. Atryum implements the JSON-RPC surface (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) and proxies calls to the configured upstream — HTTP or stdio. Because Atryum is the MCP client to the upstream, it holds the credentials (OAuth tokens, bearer tokens, custom headers) and the agent never sees them. The same approval engine runs on every `tools/call`.
-- **Claude Managed Agents events bridge.** Anthropic's hosted harness runs the agent loop on its own infrastructure and never calls Atryum, so for those sessions Atryum dials *out*: it streams a registered session's [events](https://platform.claude.com/docs/en/managed-agents/events-and-streaming), records every event as an invocation, and — when the session blocks on a tool call (`session.status_idle` / `requires_action`) — runs the normal approval rules and answers Claude with a `user.tool_confirmation` (or `user.custom_tool_result`). This gates both built-in and MCP tools. Enable it with `[managed_agents]` and register sessions via `POST /api/v1/admin/managed-agents/sessions`. See `examples/managed-agents/`.
+- **Claude Managed Agents events bridge.** Anthropic's hosted harness runs the agent loop on its own infrastructure and never calls Atryum, so for those sessions Atryum dials *out*: it streams a registered session's [events](https://platform.claude.com/docs/en/managed-agents/events-and-streaming), records every event as an invocation, and — when the session blocks on a tool call (`session.status_idle` / `requires_action`) — runs the normal approval rules and answers Claude with a `user.tool_confirmation` (or `user.custom_tool_result`). This gates both built-in and MCP tools. Enable it by declaring one or more `[[managed_agents]]` accounts (each with a `name` and `api_key`) and register sessions via `POST /api/v1/admin/managed-agents/sessions` (set `"account"` to target a specific account when more than one is configured). See `examples/managed-agents/`.
 
 These paths converge on a single service so rules, audit, and the UI work identically regardless of how the call arrived.
 
@@ -73,7 +73,7 @@ Admin (UI and operators):
 - `/api/v1/admin/rules`, `/{id}` (including reorder/move)
 - `/api/v1/admin/agents`, `/{id}`
 - `/api/v1/admin/settings`, `/api/v1/admin/policy`
-- `/api/v1/admin/managed-agents/sessions` — register a Claude Managed Agents session for the events bridge to watch (returns `501` when `[managed_agents]` is not configured)
+- `/api/v1/admin/managed-agents/sessions` — register a Claude Managed Agents session for the events bridge to watch (body may include `"account"` to choose which `[[managed_agents]]` entry; returns `501` when no `[[managed_agents]]` account is configured)
 - `/api/v1/admin/oauth/callback` — OAuth callback for upstream MCP server connect flows
 
 ## Frontend
@@ -114,9 +114,10 @@ machine_key = ""
 machine_secret = ""
 connection_timeout_seconds = 5
 
-[managed_agents]                   # optional — Claude Managed Agents events bridge
-api_key  = ""                      # Anthropic API key; empty disables the bridge
-                                   # env override: ATRYUM_MANAGED_AGENTS_API_KEY, then ANTHROPIC_API_KEY
+[[managed_agents]]                 # optional, repeatable — one per Anthropic account
+name     = "default"               # unique label; the session-registration "account" targets it
+api_key  = ""                      # Anthropic API key; empty entries are skipped
+                                   # env override (single account only): ATRYUM_MANAGED_AGENTS_API_KEY, then ANTHROPIC_API_KEY
 
 [[auth]]                           # optional — repeatable per authorization server
 issuer    = "https://keycloak.example/realms/agents"

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -46,17 +46,23 @@ connection_timeout_seconds = 5
 [defaults]
 request_timeout_seconds = 30
 
-# Optional Claude Managed Agents events bridge. When api_key is set, Atryum
-# connects outbound to Anthropic's Managed Agents "events and streaming" API for
-# every session registered via POST /api/v1/admin/managed-agents/sessions. It
-# records each session event in the invocations table and, when a session blocks
-# on a tool call (permission_policy = always_ask, or a custom tool), runs the
-# normal approval rules and replies to Claude with the decision. When api_key is
-# empty the bridge is disabled. See examples/managed-agents/.
+# Optional Claude Managed Agents events bridge. Declare one [[managed_agents]]
+# table per Anthropic account/workspace you want to watch. When an entry's
+# api_key is set, Atryum connects outbound to Anthropic's Managed Agents
+# "events and streaming" API for every session registered (via
+# POST /api/v1/admin/managed-agents/sessions) against that account. It records
+# each session event in the invocations table and, when a session blocks on a
+# tool call (permission_policy = always_ask, or a custom tool), runs the normal
+# approval rules and replies to Claude with the decision. Entries with an empty
+# api_key are skipped; with no usable entry the bridge is disabled. See
+# examples/managed-agents/.
 #
-# Environment overrides for api_key: ATRYUM_MANAGED_AGENTS_API_KEY (highest),
-# then ANTHROPIC_API_KEY (only when api_key is otherwise empty).
-[managed_agents]
+# Environment overrides for api_key (single-account convenience only):
+# ATRYUM_MANAGED_AGENTS_API_KEY (highest), then ANTHROPIC_API_KEY. These apply
+# only when zero or one [[managed_agents]] entry is configured. With multiple
+# entries each must set its own api_key in TOML.
+[[managed_agents]]
+name    = "default"   # unique label; targeted by the session-registration "account" field
 api_key = ""
 # Optional tuning (defaults shown):
 # base_url                  = "https://api.anthropic.com"
@@ -64,6 +70,11 @@ api_key = ""
 # reconnect_backoff_seconds = 2
 # client_name               = "claude-managed-agents"
 # client_version            = ""
+
+# Add more accounts by repeating the table:
+# [[managed_agents]]
+# name    = "staging"
+# api_key = ""
 
 # Agent sync and AI evaluation settings (org, record type, constitution field)
 # are managed through the Atryum Settings UI and stored in the database.

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -46,6 +46,25 @@ connection_timeout_seconds = 5
 [defaults]
 request_timeout_seconds = 30
 
+# Optional Claude Managed Agents events bridge. When api_key is set, Atryum
+# connects outbound to Anthropic's Managed Agents "events and streaming" API for
+# every session registered via POST /api/v1/admin/managed-agents/sessions. It
+# records each session event in the invocations table and, when a session blocks
+# on a tool call (permission_policy = always_ask, or a custom tool), runs the
+# normal approval rules and replies to Claude with the decision. When api_key is
+# empty the bridge is disabled. See examples/managed-agents/.
+#
+# Environment overrides for api_key: ATRYUM_MANAGED_AGENTS_API_KEY (highest),
+# then ANTHROPIC_API_KEY (only when api_key is otherwise empty).
+[managed_agents]
+api_key = ""
+# Optional tuning (defaults shown):
+# base_url                  = "https://api.anthropic.com"
+# poll_interval_millis      = 1000
+# reconnect_backoff_seconds = 2
+# client_name               = "claude-managed-agents"
+# client_version            = ""
+
 # Agent sync and AI evaluation settings (org, record type, constitution field)
 # are managed through the Atryum Settings UI and stored in the database.
 # They no longer need to be configured here.

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -247,35 +247,40 @@ func runServer(args []string) error {
 	// sessions, streams their events into the invocations table, and gates
 	// blocking tool calls through the normal approval rules.
 	var managedSvc *managedagents.Service
-	if cfg.ManagedAgents.APIKey != "" {
-		managedSessionRepo := store.NewManagedAgentSessionRepoWithDialect(db, dialect)
-		managedClient := managedagents.NewAnthropicHTTPClient(managedagents.Config{
-			BaseURL:       cfg.ManagedAgents.BaseURL,
-			APIKey:        cfg.ManagedAgents.APIKey,
-			ClientName:    cfg.ManagedAgents.ClientName,
-			ClientVersion: cfg.ManagedAgents.ClientVersion,
+	var managedAccounts []managedagents.Account
+	for _, ma := range cfg.ManagedAgents {
+		if ma.APIKey == "" {
+			continue
+		}
+		acctCfg := managedagents.Config{
+			Name:             ma.Name,
+			BaseURL:          ma.BaseURL,
+			APIKey:           ma.APIKey,
+			PollInterval:     time.Duration(ma.PollIntervalMillis) * time.Millisecond,
+			ReconnectBackoff: time.Duration(ma.ReconnectBackoffSeconds) * time.Second,
+			ClientName:       ma.ClientName,
+			ClientVersion:    ma.ClientVersion,
+		}
+		managedAccounts = append(managedAccounts, managedagents.Account{
+			Client: managedagents.NewAnthropicHTTPClient(acctCfg),
+			Config: acctCfg,
 		})
+	}
+	if len(managedAccounts) > 0 {
+		managedSessionRepo := store.NewManagedAgentSessionRepoWithDialect(db, dialect)
 		managedSvc = managedagents.NewService(
-			managedClient,
 			service, // *invocation.Service satisfies InvocationGateway
 			&managedSessionStoreAdapter{repo: managedSessionRepo},
 			&managedAuditAdapter{inv: invRepo, events: eventRepo},
-			managedagents.Config{
-				BaseURL:          cfg.ManagedAgents.BaseURL,
-				APIKey:           cfg.ManagedAgents.APIKey,
-				PollInterval:     time.Duration(cfg.ManagedAgents.PollIntervalMillis) * time.Millisecond,
-				ReconnectBackoff: time.Duration(cfg.ManagedAgents.ReconnectBackoffSeconds) * time.Second,
-				ClientName:       cfg.ManagedAgents.ClientName,
-				ClientVersion:    cfg.ManagedAgents.ClientVersion,
-			},
+			managedAccounts,
 		)
 		if err := managedSvc.Start(context.Background()); err != nil {
 			return fmt.Errorf("start managed agents bridge: %w", err)
 		}
 		handler.SetManagedAgents(managedSvc)
-		log.Printf("claude managed agents bridge enabled")
+		log.Printf("claude managed agents bridge enabled (%d account(s))", len(managedAccounts))
 	} else {
-		log.Printf("claude managed agents bridge disabled (no [managed_agents].api_key)")
+		log.Printf("claude managed agents bridge disabled (no [[managed_agents]] entry with api_key)")
 	}
 
 	srv := &http.Server{
@@ -315,6 +320,7 @@ type managedSessionStoreAdapter struct {
 func (a *managedSessionStoreAdapter) Upsert(ctx context.Context, s managedagents.SessionRegistration) error {
 	return a.repo.Upsert(ctx, store.ManagedAgentSession{
 		SessionID:   s.SessionID,
+		Account:     s.Account,
 		AgentID:     s.AgentID,
 		Description: s.Description,
 		LastEventID: s.LastEventID,
@@ -349,6 +355,7 @@ func (a *managedSessionStoreAdapter) UpdateCursor(ctx context.Context, sessionID
 func managedSessionToReg(row store.ManagedAgentSession) managedagents.SessionRegistration {
 	return managedagents.SessionRegistration{
 		SessionID:   row.SessionID,
+		Account:     row.Account,
 		AgentID:     row.AgentID,
 		Description: row.Description,
 		LastEventID: row.LastEventID,

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -268,12 +268,15 @@ func runServer(args []string) error {
 	}
 	if len(managedAccounts) > 0 {
 		managedSessionRepo := store.NewManagedAgentSessionRepoWithDialect(db, dialect)
-		managedSvc = managedagents.NewService(
+		managedSvc, err = managedagents.NewService(
 			service, // *invocation.Service satisfies InvocationGateway
 			&managedSessionStoreAdapter{repo: managedSessionRepo},
 			&managedAuditAdapter{inv: invRepo, events: eventRepo},
 			managedAccounts,
 		)
+		if err != nil {
+			return fmt.Errorf("configure managed agents bridge: %w", err)
+		}
 		if err := managedSvc.Start(context.Background()); err != nil {
 			return fmt.Errorf("start managed agents bridge: %w", err)
 		}

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -22,6 +22,7 @@ import (
 	"atryum/internal/config"
 	"atryum/internal/invocation"
 	"atryum/internal/invocation/policy"
+	"atryum/internal/managedagents"
 	"atryum/internal/mcp"
 	"atryum/internal/store"
 
@@ -241,6 +242,42 @@ func runServer(args []string) error {
 		log.Printf("WARNING: inbound auth debug skip_verify enabled; /mcp/ Authorization header is ignored entirely")
 	}
 
+	// Optional Claude Managed Agents events bridge. Enabled only when an
+	// Anthropic API key is configured (TOML or env). It watches registered
+	// sessions, streams their events into the invocations table, and gates
+	// blocking tool calls through the normal approval rules.
+	var managedSvc *managedagents.Service
+	if cfg.ManagedAgents.APIKey != "" {
+		managedSessionRepo := store.NewManagedAgentSessionRepoWithDialect(db, dialect)
+		managedClient := managedagents.NewAnthropicHTTPClient(managedagents.Config{
+			BaseURL:       cfg.ManagedAgents.BaseURL,
+			APIKey:        cfg.ManagedAgents.APIKey,
+			ClientName:    cfg.ManagedAgents.ClientName,
+			ClientVersion: cfg.ManagedAgents.ClientVersion,
+		})
+		managedSvc = managedagents.NewService(
+			managedClient,
+			service, // *invocation.Service satisfies InvocationGateway
+			&managedSessionStoreAdapter{repo: managedSessionRepo},
+			&managedAuditAdapter{inv: invRepo, events: eventRepo},
+			managedagents.Config{
+				BaseURL:          cfg.ManagedAgents.BaseURL,
+				APIKey:           cfg.ManagedAgents.APIKey,
+				PollInterval:     time.Duration(cfg.ManagedAgents.PollIntervalMillis) * time.Millisecond,
+				ReconnectBackoff: time.Duration(cfg.ManagedAgents.ReconnectBackoffSeconds) * time.Second,
+				ClientName:       cfg.ManagedAgents.ClientName,
+				ClientVersion:    cfg.ManagedAgents.ClientVersion,
+			},
+		)
+		if err := managedSvc.Start(context.Background()); err != nil {
+			return fmt.Errorf("start managed agents bridge: %w", err)
+		}
+		handler.SetManagedAgents(managedSvc)
+		log.Printf("claude managed agents bridge enabled")
+	} else {
+		log.Printf("claude managed agents bridge disabled (no [managed_agents].api_key)")
+	}
+
 	srv := &http.Server{
 		Addr:              cfg.Server.ListenAddr,
 		Handler:           handler.Routes(),
@@ -258,10 +295,85 @@ func runServer(args []string) error {
 	defer stop()
 	<-ctx.Done()
 
+	if managedSvc != nil {
+		_ = managedSvc.Close()
+	}
+
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = srv.Shutdown(shutdownCtx)
 	return nil
+}
+
+// managedSessionStoreAdapter bridges store.ManagedAgentSessionRepo →
+// managedagents.SessionStore, converting between the store row and the
+// managedagents registration type.
+type managedSessionStoreAdapter struct {
+	repo *store.ManagedAgentSessionRepo
+}
+
+func (a *managedSessionStoreAdapter) Upsert(ctx context.Context, s managedagents.SessionRegistration) error {
+	return a.repo.Upsert(ctx, store.ManagedAgentSession{
+		SessionID:   s.SessionID,
+		AgentID:     s.AgentID,
+		Description: s.Description,
+		LastEventID: s.LastEventID,
+		CreatedAt:   s.CreatedAt,
+	})
+}
+
+func (a *managedSessionStoreAdapter) Get(ctx context.Context, sessionID string) (managedagents.SessionRegistration, error) {
+	row, err := a.repo.Get(ctx, sessionID)
+	if err != nil {
+		return managedagents.SessionRegistration{}, err
+	}
+	return managedSessionToReg(row), nil
+}
+
+func (a *managedSessionStoreAdapter) List(ctx context.Context) ([]managedagents.SessionRegistration, error) {
+	rows, err := a.repo.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]managedagents.SessionRegistration, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, managedSessionToReg(row))
+	}
+	return out, nil
+}
+
+func (a *managedSessionStoreAdapter) UpdateCursor(ctx context.Context, sessionID, lastEventID string) error {
+	return a.repo.UpdateCursor(ctx, sessionID, lastEventID)
+}
+
+func managedSessionToReg(row store.ManagedAgentSession) managedagents.SessionRegistration {
+	return managedagents.SessionRegistration{
+		SessionID:   row.SessionID,
+		AgentID:     row.AgentID,
+		Description: row.Description,
+		LastEventID: row.LastEventID,
+		CreatedAt:   row.CreatedAt,
+		UpdatedAt:   row.UpdatedAt,
+	}
+}
+
+// managedAuditAdapter bridges the invocation/event repos →
+// managedagents.InvocationAuditStore for the synthetic per-session audit row.
+type managedAuditAdapter struct {
+	inv    *store.InvocationRepo
+	events *store.EventRepo
+}
+
+func (a *managedAuditAdapter) Create(ctx context.Context, inv invocation.Invocation) error {
+	return a.inv.Create(ctx, inv)
+}
+
+func (a *managedAuditAdapter) GetByIdempotencyKey(ctx context.Context, key string) (invocation.Invocation, error) {
+	return a.inv.GetByIdempotencyKey(ctx, key)
+}
+
+func (a *managedAuditAdapter) CreateEvent(ctx context.Context, evt invocation.Event) error {
+	return a.events.Create(ctx, evt)
 }
 
 func initEnabledServerStatuses(ctx context.Context, repo *store.ServerRepo, serverAdmin *api.ServerAdminService) error {

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -386,6 +386,10 @@ func (a *managedAuditAdapter) CreateEvent(ctx context.Context, evt invocation.Ev
 	return a.events.Create(ctx, evt)
 }
 
+func (a *managedAuditAdapter) ListEvents(ctx context.Context, invocationID string, filter invocation.EventListFilter) ([]invocation.Event, int, error) {
+	return a.events.ListByInvocation(ctx, invocationID, filter)
+}
+
 func initEnabledServerStatuses(ctx context.Context, repo *store.ServerRepo, serverAdmin *api.ServerAdminService) error {
 	enabled := true
 	const pageSize = 100

--- a/examples/managed-agents/README.md
+++ b/examples/managed-agents/README.md
@@ -65,9 +65,15 @@ Because Atryum answers the harness's own confirmation prompts, it can gate the
 
 ### 1. Enable the bridge in `atryum.toml`
 
+Declare one `[[managed_agents]]` table per Anthropic account/workspace. The
+`name` is a unique label the session-registration API uses to target a specific
+account.
+
 ```toml
-[managed_agents]
-# Anthropic API key. Env overrides: ATRYUM_MANAGED_AGENTS_API_KEY, then ANTHROPIC_API_KEY.
+[[managed_agents]]
+name    = "default"   # unique label; targeted by the registration "account" field
+# Anthropic API key. Env overrides (single account only):
+# ATRYUM_MANAGED_AGENTS_API_KEY, then ANTHROPIC_API_KEY.
 api_key = "sk-ant-..."
 # Optional tuning (defaults shown):
 # base_url                  = "https://api.anthropic.com"
@@ -75,10 +81,17 @@ api_key = "sk-ant-..."
 # reconnect_backoff_seconds = 2      # SSE reconnect backoff
 # client_name               = "claude-managed-agents"  # shown in the Agent column
 # client_version            = ""
+
+# Watch a second account by repeating the table:
+# [[managed_agents]]
+# name    = "staging"
+# api_key = "sk-ant-..."
 ```
 
-When `api_key` is empty the bridge is disabled and the admin endpoint returns
-`501`.
+Entries with an empty `api_key` are skipped; when no account has a usable key
+the bridge is disabled and the admin endpoint returns `501`. The
+`ATRYUM_MANAGED_AGENTS_API_KEY` / `ANTHROPIC_API_KEY` env overrides apply only
+when zero or one `[[managed_agents]]` entry is configured.
 
 ### 2. Create an agent whose tools ask for confirmation
 
@@ -110,6 +123,7 @@ curl -sS -X POST http://localhost:8080/api/v1/admin/managed-agents/sessions \
   -H "content-type: application/json" \
   -d '{
     "session_id": "sess_...",
+    "account": "default",          // optional when only one [[managed_agents]] is configured; required to disambiguate when several are
     "agent_id": "my-agent",        // optional: tags invocations & enables agent-scoped rules
     "description": "prod coding agent"
   }'

--- a/examples/managed-agents/README.md
+++ b/examples/managed-agents/README.md
@@ -1,0 +1,155 @@
+# Atryum Claude Managed Agents setup
+
+[Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview)
+is Anthropic's *hosted* agent harness: the agent loop runs on Anthropic's
+infrastructure, and tools execute in an Anthropic-managed (or self-hosted)
+sandbox. Unlike Claude Code, it exposes **no `PreToolUse` / `PostToolUse`
+hook**, so the command-hook adapter in `examples/claude-code-hook` does not
+apply here.
+
+The only integration surface is **MCP**. You declare Atryum's `/mcp/{server}`
+endpoint as one of the agent's MCP servers; every `tools/call` the agent makes
+to that server is gated by Atryum's rule engine and recorded as an invocation.
+
+```
+ ┌──────────────────────────────┐  outbound HTTPS     ┌────────────────────────┐  approval + audit  ┌──────────┐
+ │ Anthropic cloud              │  POST /mcp/{server} │ Your Atryum            │───────────────────▶│ upstream │
+ │ Managed Agent + sandbox      │────────────────────▶│ /mcp/{server}          │◀── result ─────────│   MCP    │
+ │ (Claude runs the agent loop) │◀── JSON-RPC result ─│ (rule engine + audit)  │                    └──────────┘
+ └──────────────────────────────┘                     └────────────────────────┘
+        │
+        └─ bash / read / write / web_fetch ...  ← run in the sandbox, NOT visible to Atryum (cannot be gated)
+```
+
+## What this covers
+
+- Managed-agent calls to MCP tools routed through Atryum
+- Atryum approval rules, invocation logging, and admin UI for those MCP calls
+
+## What this does not cover
+
+- The built-in agent toolset (`bash`, `read`, `write`, `edit`, `glob`, `grep`,
+  `web_fetch`, `web_search`). These run inside Anthropic's sandbox with no
+  interception point, so Atryum cannot see or gate them. If you need a tool
+  gated, expose an equivalent through an MCP server behind Atryum and omit it
+  from the built-in toolset.
+
+## Prerequisites
+
+1. **Atryum reachable from Anthropic's cloud.** The agent runs on Anthropic's
+   infrastructure, so it makes the outbound call to Atryum — `localhost:8080`
+   will not work. Use a public HTTPS ingress, or an
+   [MCP tunnel](https://platform.claude.com/docs/en/agents-and-tools/mcp-tunnels/overview)
+   if Atryum sits in a private network.
+2. **A bearer token Atryum will accept.** Atryum's `/mcp/` auth validates
+   **OIDC JWTs** against a configured `[[auth]]` block (issuer, audience, JWKS,
+   optional scope). Mint a JWT from that issuer to present to Atryum. For a
+   quick no-auth test, run Atryum with `[auth_debug] skip_verify = true`
+   (local/dev only) and skip the vault credential below.
+
+## Setup
+
+All requests require the `managed-agents-2026-04-01` beta header. The SDKs set
+it automatically.
+
+### 1. Create the agent — declare Atryum as an MCP server
+
+The `url` points at Atryum's `/mcp/{server}` endpoint (replace `shortcut` with
+the MCP server name you registered in Atryum). Set the toolset's
+`permission_policy` to `always_allow` so **Atryum** is the gate rather than
+Anthropic's own per-call confirmation prompt.
+
+```bash
+curl -sS https://api.anthropic.com/v1/agents \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "content-type: application/json" \
+  -d '{
+    "name": "Atryum-gated agent",
+    "model": "claude-opus-4-8",
+    "system": "Use the shortcut tools to manage tickets.",
+    "mcp_servers": [
+      { "type": "url", "name": "atryum-shortcut",
+        "url": "https://atryum.example.com/mcp/shortcut" }
+    ],
+    "tools": [
+      { "type": "agent_toolset_20260401" },
+      { "type": "mcp_toolset", "mcp_server_name": "atryum-shortcut",
+        "default_config": { "permission_policy": { "type": "always_allow" } } }
+    ]
+  }'
+```
+
+Save the returned `id` (and `version`). Every `mcp_servers` entry must be
+referenced by an `mcp_toolset`, and vice versa.
+
+### 2. Store the Atryum bearer token in a vault
+
+The `mcp_servers` array carries **no auth**. Credentials are supplied at
+session time via a [vault](https://platform.claude.com/docs/en/managed-agents/vaults).
+Anthropic sends `access_token` as `Authorization: Bearer <token>` to the MCP
+URL, so the token must be a JWT Atryum accepts. `mcp_server_url` must match the
+agent's `url` exactly.
+
+```bash
+curl -sS https://api.anthropic.com/v1/vaults/$VAULT_ID/credentials \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "content-type: application/json" \
+  -d '{
+    "display_name": "Atryum JWT",
+    "auth": {
+      "type": "mcp_oauth",
+      "mcp_server_url": "https://atryum.example.com/mcp/shortcut",
+      "access_token": "<OIDC JWT from your IdP>",
+      "refresh": {
+        "refresh_token": "<refresh token>",
+        "client_id": "<your OAuth client_id>",
+        "token_endpoint": "https://your-idp/realms/atryum/protocol/openid-connect/token",
+        "token_endpoint_auth": { "type": "client_secret_post", "client_secret": "<secret>" }
+      }
+    }
+  }'
+```
+
+The `refresh` block lets Anthropic auto-rotate the JWT before it expires. Omit
+it only if you accept the token expiring (the agent then loses access). When
+running Atryum with `skip_verify`, skip this step entirely.
+
+### 3. Start a session with the vault attached
+
+```bash
+curl -sS https://api.anthropic.com/v1/sessions \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "anthropic-beta: managed-agents-2026-04-01" \
+  -H "content-type: application/json" \
+  -d '{ "agent": "'"$AGENT_ID"'", "environment_id": "'"$ENV_ID"'", "vault_ids": ["'"$VAULT_ID"'"] }'
+```
+
+When the agent calls a `shortcut` tool, Anthropic's server posts to
+`https://atryum.example.com/mcp/shortcut` with the JWT. Atryum runs the MCP
+handshake (`initialize`, `tools/list`, `tools/call`), evaluates the call against
+your approval rules (auto-approve, auto-deny, or park for human approval), holds
+the connection until decided, and records the invocation with its full event
+log.
+
+## Agent identity
+
+The `sub` (or configured `agent_id_claim`) on the JWT is the authenticated
+agent ID Atryum uses for `agent_id_pattern` rule matching. Map it to an Agent
+Record in the Atryum UI so agent-scoped rules apply.
+
+## Atryum-side changes
+
+No repository code changes are required for the standard OIDC-JWT path — just:
+
+- make Atryum internet-reachable, and
+- add an `[[auth]]` block matching the JWT issuer/audience you mint tokens from
+  (see `atryum.example.toml`).
+
+A code change would only be needed if you cannot mint a signed JWT and must
+present a static/opaque bearer token; Atryum's `/mcp/` validator has no
+static-bearer path today.

--- a/examples/managed-agents/README.md
+++ b/examples/managed-agents/README.md
@@ -1,63 +1,86 @@
-# Atryum Claude Managed Agents setup
+# Atryum + Claude Managed Agents
 
 [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents/overview)
-is Anthropic's *hosted* agent harness: the agent loop runs on Anthropic's
-infrastructure, and tools execute in an Anthropic-managed (or self-hosted)
-sandbox. Unlike Claude Code, it exposes **no `PreToolUse` / `PostToolUse`
-hook**, so the command-hook adapter in `examples/claude-code-hook` does not
-apply here.
+is Anthropic's *hosted* agent harness: Anthropic runs the agent loop and
+executes tools on its own infrastructure. Unlike Claude Code, it exposes no
+`PreToolUse` / `PostToolUse` hook, so the command-hook adapter in
+`examples/claude-code-hook` does not apply.
 
-The only integration surface is **MCP**. You declare Atryum's `/mcp/{server}`
-endpoint as one of the agent's MCP servers; every `tools/call` the agent makes
-to that server is gated by Atryum's rule engine and recorded as an invocation.
+Atryum integrates two ways:
+
+| | Events bridge (recommended) | MCP proxy |
+| --- | --- | --- |
+| What it gates | **Any** blocking tool call — built-in (`bash`, `read`, `write`, …) **and** MCP tools | only MCP tool calls routed through Atryum |
+| How | Atryum streams the session's events and answers the harness's confirmation prompts | the agent's `mcp_servers[].url` points at Atryum's `/mcp/{server}` |
+| Tool config | `permission_policy: always_ask` (or custom tools) | `permission_policy: always_allow` (Atryum is the gate) |
+| Credentials | Anthropic holds them | Atryum holds the upstream credentials |
+| Who calls whom | Atryum → Anthropic (outbound) | Anthropic → Atryum (inbound) |
+
+This page documents the **events bridge**. For the MCP proxy path, see the
+[MCP connector](#appendix-mcp-proxy-path) appendix at the bottom.
+
+## Events bridge: how it works
 
 ```
- ┌──────────────────────────────┐  outbound HTTPS     ┌────────────────────────┐  approval + audit  ┌──────────┐
- │ Anthropic cloud              │  POST /mcp/{server} │ Your Atryum            │───────────────────▶│ upstream │
- │ Managed Agent + sandbox      │────────────────────▶│ /mcp/{server}          │◀── result ─────────│   MCP    │
- │ (Claude runs the agent loop) │◀── JSON-RPC result ─│ (rule engine + audit)  │                    └──────────┘
- └──────────────────────────────┘                     └────────────────────────┘
-        │
-        └─ bash / read / write / web_fetch ...  ← run in the sandbox, NOT visible to Atryum (cannot be gated)
+ ┌────────────────────────────┐   GET  /v1/sessions/{id}/events/stream   ┌────────────────────────┐
+ │ Anthropic cloud            │◀─────────────────────────────────────────│ Atryum events bridge   │
+ │ Managed Agent + sandbox    │   POST /v1/sessions/{id}/events           │ (watcher per session)  │
+ │ runs tools, blocks on      │──────────── tool_confirmation ──────────▶ │  • records invocations │
+ │ always_ask confirmations   │                                           │  • runs approval rules │
+ └────────────────────────────┘                                          └────────────────────────┘
 ```
 
-## What this covers
+When a session is registered, Atryum opens an outbound connection to its event
+stream and:
 
-- Managed-agent calls to MCP tools routed through Atryum
-- Atryum approval rules, invocation logging, and admin UI for those MCP calls
+1. **Records every session event** into the invocations table. Each watched
+   session gets one synthetic audit invocation (tool `_managed_agent_session`)
+   whose `invocation_events` are the raw Anthropic events.
+2. **Turns each tool call into an invocation.** `agent.tool_use`,
+   `agent.mcp_tool_use`, and `agent.custom_tool_use` events are submitted to the
+   normal Atryum approval engine (same path as the external/hook integration).
+3. **Answers blocking tool calls.** When the session emits
+   `session.status_idle` with `stop_reason: requires_action`, Atryum waits for
+   the rule decision (`auto_approve` / `auto_deny` / human approval) and replies
+   to Claude:
+   - hosted/MCP tools → `user.tool_confirmation` with `result: "allow"|"deny"`
+     (and `deny_message` on denial).
+   - custom tools → `user.custom_tool_result` carrying an Atryum decision
+     envelope (see [Custom tools](#custom-tools)).
+4. **Records the outcome.** The later tool-result event is recorded on the
+   invocation as `completed` / `failed`.
 
-## What this does not cover
-
-- The built-in agent toolset (`bash`, `read`, `write`, `edit`, `glob`, `grep`,
-  `web_fetch`, `web_search`). These run inside Anthropic's sandbox with no
-  interception point, so Atryum cannot see or gate them. If you need a tool
-  gated, expose an equivalent through an MCP server behind Atryum and omit it
-  from the built-in toolset.
+Because Atryum answers the harness's own confirmation prompts, it can gate the
+**built-in agent toolset** (`bash`, file ops, web) — not just MCP tools.
 
 ## Prerequisites
 
-1. **Atryum reachable from Anthropic's cloud.** The agent runs on Anthropic's
-   infrastructure, so it makes the outbound call to Atryum — `localhost:8080`
-   will not work. Use a public HTTPS ingress, or an
-   [MCP tunnel](https://platform.claude.com/docs/en/agents-and-tools/mcp-tunnels/overview)
-   if Atryum sits in a private network.
-2. **A bearer token Atryum will accept.** Atryum's `/mcp/` auth validates
-   **OIDC JWTs** against a configured `[[auth]]` block (issuer, audience, JWKS,
-   optional scope). Mint a JWT from that issuer to present to Atryum. For a
-   quick no-auth test, run Atryum with `[auth_debug] skip_verify = true`
-   (local/dev only) and skip the vault credential below.
+1. **An Anthropic API key** for the workspace the sessions run in.
+2. **Tools configured to ask.** Set the toolset `permission_policy` to
+   `always_ask` so the harness actually blocks and asks Atryum before running a
+   tool. Tools left at `always_allow` run without ever pausing, so Atryum can
+   only record them after the fact — it cannot gate them.
 
 ## Setup
 
-All requests require the `managed-agents-2026-04-01` beta header. The SDKs set
-it automatically.
+### 1. Enable the bridge in `atryum.toml`
 
-### 1. Create the agent — declare Atryum as an MCP server
+```toml
+[managed_agents]
+# Anthropic API key. Env overrides: ATRYUM_MANAGED_AGENTS_API_KEY, then ANTHROPIC_API_KEY.
+api_key = "sk-ant-..."
+# Optional tuning (defaults shown):
+# base_url                  = "https://api.anthropic.com"
+# poll_interval_millis      = 1000   # how often a pending approval is re-checked
+# reconnect_backoff_seconds = 2      # SSE reconnect backoff
+# client_name               = "claude-managed-agents"  # shown in the Agent column
+# client_version            = ""
+```
 
-The `url` points at Atryum's `/mcp/{server}` endpoint (replace `shortcut` with
-the MCP server name you registered in Atryum). Set the toolset's
-`permission_policy` to `always_allow` so **Atryum** is the gate rather than
-Anthropic's own per-call confirmation prompt.
+When `api_key` is empty the bridge is disabled and the admin endpoint returns
+`501`.
+
+### 2. Create an agent whose tools ask for confirmation
 
 ```bash
 curl -sS https://api.anthropic.com/v1/agents \
@@ -68,88 +91,103 @@ curl -sS https://api.anthropic.com/v1/agents \
   -d '{
     "name": "Atryum-gated agent",
     "model": "claude-opus-4-8",
-    "system": "Use the shortcut tools to manage tickets.",
-    "mcp_servers": [
-      { "type": "url", "name": "atryum-shortcut",
-        "url": "https://atryum.example.com/mcp/shortcut" }
-    ],
+    "system": "You are a careful coding agent.",
     "tools": [
-      { "type": "agent_toolset_20260401" },
-      { "type": "mcp_toolset", "mcp_server_name": "atryum-shortcut",
-        "default_config": { "permission_policy": { "type": "always_allow" } } }
+      { "type": "agent_toolset_20260401",
+        "default_config": { "permission_policy": { "type": "always_ask" } } }
     ]
   }'
 ```
 
-Save the returned `id` (and `version`). Every `mcp_servers` entry must be
-referenced by an `mcp_toolset`, and vice versa.
+Create an environment and a session as usual (see the
+[quickstart](https://platform.claude.com/docs/en/managed-agents/quickstart)),
+and note the session ID.
 
-### 2. Store the Atryum bearer token in a vault
-
-The `mcp_servers` array carries **no auth**. Credentials are supplied at
-session time via a [vault](https://platform.claude.com/docs/en/managed-agents/vaults).
-Anthropic sends `access_token` as `Authorization: Bearer <token>` to the MCP
-URL, so the token must be a JWT Atryum accepts. `mcp_server_url` must match the
-agent's `url` exactly.
+### 3. Register the session with Atryum
 
 ```bash
-curl -sS https://api.anthropic.com/v1/vaults/$VAULT_ID/credentials \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
-  -H "anthropic-version: 2023-06-01" \
-  -H "anthropic-beta: managed-agents-2026-04-01" \
+curl -sS -X POST http://localhost:8080/api/v1/admin/managed-agents/sessions \
   -H "content-type: application/json" \
   -d '{
-    "display_name": "Atryum JWT",
-    "auth": {
-      "type": "mcp_oauth",
-      "mcp_server_url": "https://atryum.example.com/mcp/shortcut",
-      "access_token": "<OIDC JWT from your IdP>",
-      "refresh": {
-        "refresh_token": "<refresh token>",
-        "client_id": "<your OAuth client_id>",
-        "token_endpoint": "https://your-idp/realms/atryum/protocol/openid-connect/token",
-        "token_endpoint_auth": { "type": "client_secret_post", "client_secret": "<secret>" }
-      }
-    }
+    "session_id": "sess_...",
+    "agent_id": "my-agent",        // optional: tags invocations & enables agent-scoped rules
+    "description": "prod coding agent"
   }'
 ```
 
-The `refresh` block lets Anthropic auto-rotate the JWT before it expires. Omit
-it only if you accept the token expiring (the agent then loses access). When
-running Atryum with `skip_verify`, skip this step entirely.
+Atryum starts watching immediately and resumes watching registered sessions on
+restart (the cursor is persisted, so it replays anything missed). Send the
+session a user message; blocking tool calls now flow through your Atryum rules
+and appear live in the invocations UI.
 
-### 3. Start a session with the vault attached
+### Approval rules
 
-```bash
-curl -sS https://api.anthropic.com/v1/sessions \
-  -H "x-api-key: $ANTHROPIC_API_KEY" \
-  -H "anthropic-version: 2023-06-01" \
-  -H "anthropic-beta: managed-agents-2026-04-01" \
-  -H "content-type: application/json" \
-  -d '{ "agent": "'"$AGENT_ID"'", "environment_id": "'"$ENV_ID"'", "vault_ids": ["'"$VAULT_ID"'"] }'
+Rules match on `(server, tool, agent)` exactly as for any other invocation:
+
+- **Built-in tools** match with server = the configured `client_name`
+  (default `claude-managed-agents`) and tool = `bash` / `read` / `write` / …
+- **MCP tools** match with server = the MCP server name reported by Anthropic
+  (falling back to `client_name` when none is reported).
+
+With the default `manual_approval` policy, anything without a matching rule
+parks for human approval (fails closed).
+
+### Custom tools
+
+Custom tools have no native allow/deny envelope, so on a decision Atryum sends a
+`user.custom_tool_result` whose content is a structured block your tool can read:
+
+```json
+{ "atryum": { "decision": "allow", "invocation_id": "inv_..." } }
+```
+```json
+{ "atryum": { "decision": "deny", "invocation_id": "inv_...", "deny_message": "..." } }
 ```
 
-When the agent calls a `shortcut` tool, Anthropic's server posts to
-`https://atryum.example.com/mcp/shortcut` with the JWT. Atryum runs the MCP
-handshake (`initialize`, `tools/list`, `tools/call`), evaluates the call against
-your approval rules (auto-approve, auto-deny, or park for human approval), holds
-the connection until decided, and records the invocation with its full event
-log.
+## What shows up in the invocations table
 
-## Agent identity
+- One **audit invocation** per watched session (`_managed_agent_session`) with
+  every raw session event as an `invocation_event`.
+- One **invocation per tool call**, carrying the approval decision, the matched
+  rule, the tool input, and the execution outcome.
 
-The `sub` (or configured `agent_id_claim`) on the JWT is the authenticated
-agent ID Atryum uses for `agent_id_pattern` rule matching. Map it to an Agent
-Record in the Atryum UI so agent-scoped rules apply.
+## Notes & limits
 
-## Atryum-side changes
+- **Reachability is reversed** vs. the MCP path: Atryum dials out to Anthropic,
+  so Atryum does *not* need a public ingress. It only needs outbound HTTPS to
+  `api.anthropic.com`.
+- **Long human approvals are fine.** The session sits idle (durable, checkpointed
+  by Anthropic) while Atryum holds the confirmation; there is no synchronous
+  HTTP timeout as there is on the MCP proxy path.
+- **Tool-use creation is idempotent** (keyed on the Anthropic event ID), so
+  stream reconnects and restarts don't double-submit. Raw event audit is
+  at-least-once.
 
-No repository code changes are required for the standard OIDC-JWT path — just:
+---
 
-- make Atryum internet-reachable, and
-- add an `[[auth]]` block matching the JWT issuer/audience you mint tokens from
-  (see `atryum.example.toml`).
+## Appendix: MCP proxy path
 
-A code change would only be needed if you cannot mint a signed JWT and must
-present a static/opaque bearer token; Atryum's `/mcp/` validator has no
-static-bearer path today.
+If you'd rather have Atryum hold the upstream credentials and proxy MCP traffic,
+declare Atryum's `/mcp/{server}` as the agent's MCP server and authenticate with
+a vault credential whose `access_token` is an OIDC JWT Atryum accepts (a
+configured `[[auth]]` issuer). In this mode Anthropic calls **into** Atryum, so
+Atryum must be reachable from Anthropic's cloud (public ingress or an MCP
+tunnel), and only MCP tool calls are gated.
+
+```json
+{
+  "mcp_servers": [
+    { "type": "url", "name": "atryum-shortcut", "url": "https://atryum.example.com/mcp/shortcut" }
+  ],
+  "tools": [
+    { "type": "mcp_toolset", "mcp_server_name": "atryum-shortcut",
+      "default_config": { "permission_policy": { "type": "always_allow" } } }
+  ]
+}
+```
+
+Provide the JWT via a session `vault_ids` credential (`type: mcp_oauth`,
+`mcp_server_url` matching the agent's `url`). Because the call is a synchronous
+MCP `tools/call`, human approvals must complete within the connector timeout —
+prefer auto-approve/auto-deny rules here, and use the events bridge above for
+long human approvals.

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -93,7 +93,7 @@ func defaultClaims() jwt.MapClaims {
 
 func newAuthedHandler(t *testing.T, svc service, rig *authTestRig) http.Handler {
 	t.Helper()
-	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil, nil)
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 	h.SetAuthValidator(rig.v)
 	return h.Routes()
 }
@@ -185,7 +185,7 @@ func TestAgentRulesRequiresAuthAndUsesTokenAgentID(t *testing.T) {
 		{ID: "own-rule", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "agent-007", Enabled: true, Order: 0},
 		{ID: "other-rule", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentIDPattern: "other", Enabled: true, Order: 1},
 	}}
-	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, nil, nil, nil, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, nil, nil, nil, nil, nil, nil)
 	h.SetAuthValidator(rig.v)
 	handler := h.Routes()
 
@@ -279,7 +279,7 @@ func TestProtectedResourceMetadataServed(t *testing.T) {
 
 // Sanity: when no validator is configured, /mcp/ behaves as before.
 func TestMCPNoValidatorPreservesAnonymousAccess(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`))
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
@@ -289,7 +289,7 @@ func TestMCPNoValidatorPreservesAnonymousAccess(t *testing.T) {
 }
 
 func TestProtectedResourceMetadataNotServedWhenAuthDisabled(t *testing.T) {
-	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil)
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
 	req.Host = "atryum.example"
 	w := httptest.NewRecorder()

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -25,6 +25,7 @@ import (
 	backendclient "atryum/internal/backend"
 	"atryum/internal/invocation"
 	"atryum/internal/invocation/policy"
+	"atryum/internal/managedagents"
 	"atryum/internal/mcp"
 	authprovider "atryum/internal/mcp/auth_provider"
 	"atryum/internal/store"
@@ -144,6 +145,16 @@ type Handler struct {
 	// absent we fall back to remote IP + User-Agent.
 	clientInfoMu    sync.RWMutex
 	clientInfoCache map[string]clientInfoSnapshot
+
+	// managedAgents is the optional Claude Managed Agents events bridge.
+	// nil when not configured (no anthropic api key).
+	managedAgents managedAgentsAdmin
+}
+
+// managedAgentsAdmin is the slice of the managed-agents service the admin API
+// needs to register a session for watching.
+type managedAgentsAdmin interface {
+	RegisterSession(ctx context.Context, req managedagents.RegisterSessionRequest) (managedagents.SessionRegistration, error)
 }
 
 type PolicyStatusResponse struct {
@@ -472,6 +483,12 @@ func (h *Handler) SetAuthDebugSkipVerify(enabled bool) {
 	h.authDebugSkip = enabled
 }
 
+// SetManagedAgents installs the optional Claude Managed Agents events bridge,
+// enabling the POST /api/v1/admin/managed-agents/sessions endpoint.
+func (h *Handler) SetManagedAgents(m managedAgentsAdmin) {
+	h.managedAgents = m
+}
+
 // SetAPIKeyAuth installs the static api-key/secret pair used to protect the
 // read-only invocation reporting endpoints.
 func (h *Handler) SetAPIKeyAuth(cfg auth.APIKeyConfig) {
@@ -517,6 +534,7 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/admin/vm/custom-fields", h.adminVMCustomFields)
 	mux.HandleFunc("/api/v1/admin/oauth/callback", h.oauthCallback)
 	mux.HandleFunc("/api/v1/admin/policy", h.adminPolicy)
+	mux.HandleFunc("/api/v1/admin/managed-agents/sessions", h.adminManagedAgentSessions)
 	agentRulesHandler := auth.MiddlewareWithOptions(h.authValidator, "/.well-known/oauth-protected-resource", auth.MiddlewareOptions{SkipVerify: h.authDebugSkip, DebugLogIdentity: h.debug})(http.HandlerFunc(h.agentRules))
 	agentRulesHandler = h.noAuthAgentIDHint(agentRulesHandler)
 	mux.Handle("/api/v1/agent/rules", agentRulesHandler)
@@ -3118,6 +3136,31 @@ func (h *Handler) externalInvocations(w http.ResponseWriter, r *http.Request) {
 	h.debugf("external submit user-agent=%q", r.Header.Get("User-Agent"))
 
 	resp, err := h.svc.Submit(r.Context(), req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// adminManagedAgentSessions registers a Claude Managed Agents session for
+// Atryum to watch. Once registered, Atryum streams the session's events into
+// the invocations table and gates blocking tool calls through approval rules.
+func (h *Handler) adminManagedAgentSessions(w http.ResponseWriter, r *http.Request) {
+	if h.managedAgents == nil {
+		writeError(w, http.StatusNotImplemented, "managed agents bridge not configured (set [managed_agents].api_key)")
+		return
+	}
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req managedagents.RegisterSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	resp, err := h.managedAgents.RegisterSession(r.Context(), req)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2123,25 +2123,25 @@ func (h *Handler) adminModelConfigs(w http.ResponseWriter, r *http.Request) {
 // and PUT /admin/settings. SyncError is non-empty when the post-save agent
 // sync failed; settings are persisted regardless.
 type AgentSyncSettingsResponse struct {
-	OrgCUID                    string `json:"org_cuid"`
-	AgentRecordTypeSlug        string `json:"agent_record_type_slug"`
-	ConstitutionFieldKey       string `json:"constitution_field_key"`
-	SummaryModelConfigCUID     string `json:"summary_model_config_cuid"`
-	SummaryAtryumLLMConfigID   string `json:"summary_atryum_llm_config_id"`
-	DefaultAgentVMCUID         string `json:"default_agent_vm_cuid"`
-	UpdatedAt                  string `json:"updated_at,omitempty"`
-	SyncError                  string `json:"sync_error,omitempty"`
-	BackendConfigured          bool   `json:"backend_configured"`
+	OrgCUID                  string `json:"org_cuid"`
+	AgentRecordTypeSlug      string `json:"agent_record_type_slug"`
+	ConstitutionFieldKey     string `json:"constitution_field_key"`
+	SummaryModelConfigCUID   string `json:"summary_model_config_cuid"`
+	SummaryAtryumLLMConfigID string `json:"summary_atryum_llm_config_id"`
+	DefaultAgentVMCUID       string `json:"default_agent_vm_cuid"`
+	UpdatedAt                string `json:"updated_at,omitempty"`
+	SyncError                string `json:"sync_error,omitempty"`
+	BackendConfigured        bool   `json:"backend_configured"`
 }
 
 // AgentSyncSettingsInput is the JSON body accepted by PUT /admin/settings.
 type AgentSyncSettingsInput struct {
-	OrgCUID                    string `json:"org_cuid"`
-	AgentRecordTypeSlug        string `json:"agent_record_type_slug"`
-	ConstitutionFieldKey       string `json:"constitution_field_key"`
-	SummaryModelConfigCUID     string `json:"summary_model_config_cuid"`
-	SummaryAtryumLLMConfigID   string `json:"summary_atryum_llm_config_id"`
-	DefaultAgentVMCUID         string `json:"default_agent_vm_cuid"`
+	OrgCUID                  string `json:"org_cuid"`
+	AgentRecordTypeSlug      string `json:"agent_record_type_slug"`
+	ConstitutionFieldKey     string `json:"constitution_field_key"`
+	SummaryModelConfigCUID   string `json:"summary_model_config_cuid"`
+	SummaryAtryumLLMConfigID string `json:"summary_atryum_llm_config_id"`
+	DefaultAgentVMCUID       string `json:"default_agent_vm_cuid"`
 }
 
 // ─── Local LLM Config handlers ────────────────────────────────────────────────
@@ -3148,23 +3148,29 @@ func (h *Handler) externalInvocations(w http.ResponseWriter, r *http.Request) {
 // the invocations table and gates blocking tool calls through approval rules.
 func (h *Handler) adminManagedAgentSessions(w http.ResponseWriter, r *http.Request) {
 	if h.managedAgents == nil {
+		h.debugf("managed-agents session registration rejected: bridge not configured method=%s path=%s remote=%s", r.Method, r.URL.Path, r.RemoteAddr)
 		writeError(w, http.StatusNotImplemented, "managed agents bridge not configured (set [managed_agents].api_key)")
 		return
 	}
 	if r.Method != http.MethodPost {
+		h.debugf("managed-agents session registration rejected: method not allowed method=%s path=%s remote=%s", r.Method, r.URL.Path, r.RemoteAddr)
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
 	var req managedagents.RegisterSessionRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.debugf("managed-agents session registration rejected: invalid json remote=%s err=%v", r.RemoteAddr, err)
 		writeError(w, http.StatusBadRequest, "invalid json")
 		return
 	}
+	h.debugf("managed-agents session registration request session_id=%q account=%q agent_id=%q description=%q remote=%s", req.SessionID, req.Account, req.AgentID, req.Description, r.RemoteAddr)
 	resp, err := h.managedAgents.RegisterSession(r.Context(), req)
 	if err != nil {
+		h.debugf("managed-agents session registration failed session_id=%q account=%q agent_id=%q err=%v", req.SessionID, req.Account, req.AgentID, err)
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	h.debugf("managed-agents session registered session_id=%q account=%q agent_id=%q last_event_id=%q", resp.SessionID, resp.Account, resp.AgentID, resp.LastEventID)
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"atryum/internal/auth"
 	backendclient "atryum/internal/backend"
 	"atryum/internal/invocation"
+	"atryum/internal/managedagents"
 	"atryum/internal/mcp"
 	"atryum/internal/store"
 )
@@ -146,6 +147,19 @@ func (s *stubSummarizer) SummarizeInvocation(_ context.Context, req backendclien
 	return s.resp, s.err
 }
 
+type stubManagedAgentsAdmin struct {
+	err error
+	req managedagents.RegisterSessionRequest
+}
+
+func (s *stubManagedAgentsAdmin) RegisterSession(_ context.Context, req managedagents.RegisterSessionRequest) (managedagents.SessionRegistration, error) {
+	s.req = req
+	if s.err != nil {
+		return managedagents.SessionRegistration{}, s.err
+	}
+	return managedagents.SessionRegistration{SessionID: req.SessionID, Account: req.Account, AgentID: req.AgentID}, nil
+}
+
 type stubAgentSyncSettingsRepo struct {
 	settings store.AgentSyncSettings
 }
@@ -202,6 +216,50 @@ func TestAdminServerTestDebugLogsRequestContext(t *testing.T) {
 	}
 }
 
+func TestManagedAgentSessionRegistrationDebugLogsFailure(t *testing.T) {
+	t.Setenv("ATRYUM_MCP_DEBUG", "1")
+
+	var logs bytes.Buffer
+	prevWriter := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&logs)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevWriter)
+		log.SetFlags(prevFlags)
+	}()
+
+	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
+	h.SetManagedAgents(&stubManagedAgentsAdmin{err: fmt.Errorf("unknown managed-agent account %q", "default")})
+	body := strings.NewReader(`{
+		"session_id": "sesn_01K1L93ktjwd7CgFs7L5ZDXs",
+		"account": "default",
+		"agent_id": "agent_013popGjeyhH8qPYqziHxdLk"
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/managed-agents/sessions", body)
+	req.Header.Set("content-type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+	got := logs.String()
+	for _, want := range []string{
+		"managed-agents session registration request",
+		"session_id=\"sesn_01K1L93ktjwd7CgFs7L5ZDXs\"",
+		"account=\"default\"",
+		"agent_id=\"agent_013popGjeyhH8qPYqziHxdLk\"",
+		"managed-agents session registration failed",
+		"unknown managed-agent account \"default\"",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected logs to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
 type stubAgentsRepo struct {
 	records     []store.AgentRecord
 	err         error
@@ -254,9 +312,9 @@ func (s *stubAgentsRepo) UpdateAgentIDs(context.Context, string, string) error {
 func (s *stubAgentsRepo) UpdateMeta(context.Context, string, string, string, string) error {
 	return nil
 }
-func (s *stubAgentsRepo) Create(_ context.Context, _ store.AgentRecord) error      { return nil }
-func (s *stubAgentsRepo) Delete(context.Context, string) error                     { return nil }
-func (s *stubAgentsRepo) DeleteSynced(context.Context) error                       { return nil }
+func (s *stubAgentsRepo) Create(_ context.Context, _ store.AgentRecord) error { return nil }
+func (s *stubAgentsRepo) Delete(context.Context, string) error                { return nil }
+func (s *stubAgentsRepo) DeleteSynced(context.Context) error                  { return nil }
 func (s *stubAgentsRepo) DeleteAll(context.Context) error {
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,31 @@ type Config struct {
 	// (GET /invocations/{agent_id}, GET /agent_ids). When key or secret is
 	// empty, those endpoints refuse every request.
 	APIKey auth.APIKeyConfig `toml:"api_key"`
+	// ManagedAgents configures the optional Claude Managed Agents events
+	// bridge. When api_key is empty the bridge is disabled.
+	ManagedAgents ManagedAgentsConfig `toml:"managed_agents"`
+}
+
+// ManagedAgentsConfig configures Atryum's outbound connection to Anthropic's
+// Claude Managed Agents "events and streaming" API. When APIKey is empty the
+// bridge is disabled and no sessions are watched.
+type ManagedAgentsConfig struct {
+	BaseURL                 string `toml:"base_url"`
+	APIKey                  string `toml:"api_key"`
+	PollIntervalMillis      int    `toml:"poll_interval_millis"`
+	ReconnectBackoffSeconds int    `toml:"reconnect_backoff_seconds"`
+	ClientName              string `toml:"client_name"`
+	ClientVersion           string `toml:"client_version"`
+}
+
+// ApplyEnv lets ANTHROPIC_API_KEY / ATRYUM_MANAGED_AGENTS_API_KEY override the
+// TOML api_key (the env var wins when set).
+func (c *ManagedAgentsConfig) ApplyEnv() {
+	if value := os.Getenv("ATRYUM_MANAGED_AGENTS_API_KEY"); value != "" {
+		c.APIKey = value
+	} else if value := os.Getenv("ANTHROPIC_API_KEY"); value != "" && c.APIKey == "" {
+		c.APIKey = value
+	}
 }
 
 // BackendConfig configures Atryum's startup connection check to the ValidMind
@@ -106,6 +131,7 @@ func Load(path string) (Config, error) {
 		return cfg, err
 	}
 	cfg.Backend.ApplyEnv()
+	cfg.ManagedAgents.ApplyEnv()
 	return cfg, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,15 +25,19 @@ type Config struct {
 	// (GET /invocations/{agent_id}, GET /agent_ids). When key or secret is
 	// empty, those endpoints refuse every request.
 	APIKey auth.APIKeyConfig `toml:"api_key"`
-	// ManagedAgents configures the optional Claude Managed Agents events
-	// bridge. When api_key is empty the bridge is disabled.
-	ManagedAgents ManagedAgentsConfig `toml:"managed_agents"`
+	// ManagedAgents configures zero or more Claude Managed Agents events
+	// bridges, one per Anthropic account/workspace. Declare each as a
+	// repeated `[[managed_agents]]` table. An entry with an empty api_key is
+	// skipped.
+	ManagedAgents []ManagedAgentsConfig `toml:"managed_agents"`
 }
 
-// ManagedAgentsConfig configures Atryum's outbound connection to Anthropic's
-// Claude Managed Agents "events and streaming" API. When APIKey is empty the
-// bridge is disabled and no sessions are watched.
+// ManagedAgentsConfig configures one outbound connection to Anthropic's Claude
+// Managed Agents "events and streaming" API. When APIKey is empty the entry is
+// skipped. Name distinguishes entries when more than one is configured and is
+// used by the session-registration API to target a specific account.
 type ManagedAgentsConfig struct {
+	Name                    string `toml:"name"`
 	BaseURL                 string `toml:"base_url"`
 	APIKey                  string `toml:"api_key"`
 	PollIntervalMillis      int    `toml:"poll_interval_millis"`
@@ -42,13 +46,26 @@ type ManagedAgentsConfig struct {
 	ClientVersion           string `toml:"client_version"`
 }
 
-// ApplyEnv lets ANTHROPIC_API_KEY / ATRYUM_MANAGED_AGENTS_API_KEY override the
-// TOML api_key (the env var wins when set).
-func (c *ManagedAgentsConfig) ApplyEnv() {
-	if value := os.Getenv("ATRYUM_MANAGED_AGENTS_API_KEY"); value != "" {
-		c.APIKey = value
-	} else if value := os.Getenv("ANTHROPIC_API_KEY"); value != "" && c.APIKey == "" {
-		c.APIKey = value
+// applyManagedAgentsEnv lets ANTHROPIC_API_KEY / ATRYUM_MANAGED_AGENTS_API_KEY
+// configure the bridge without TOML in the common single-account case. The env
+// key is applied only when exactly zero or one entries are configured: with one
+// entry it fills an empty api_key; with none it creates a default entry. When
+// multiple entries are configured each must set its own api_key in TOML.
+func (c *Config) applyManagedAgentsEnv() {
+	envKey := os.Getenv("ATRYUM_MANAGED_AGENTS_API_KEY")
+	if envKey == "" {
+		envKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if envKey == "" {
+		return
+	}
+	switch len(c.ManagedAgents) {
+	case 0:
+		c.ManagedAgents = []ManagedAgentsConfig{{APIKey: envKey}}
+	case 1:
+		if c.ManagedAgents[0].APIKey == "" {
+			c.ManagedAgents[0].APIKey = envKey
+		}
 	}
 }
 
@@ -131,7 +148,7 @@ func Load(path string) (Config, error) {
 		return cfg, err
 	}
 	cfg.Backend.ApplyEnv()
-	cfg.ManagedAgents.ApplyEnv()
+	cfg.applyManagedAgentsEnv()
 	return cfg, nil
 }
 

--- a/internal/managedagents/anthropic.go
+++ b/internal/managedagents/anthropic.go
@@ -48,8 +48,15 @@ type rawEventEnvelope struct {
 }
 
 func parseEnvelope(raw json.RawMessage) RawEvent {
+	evt, _ := parseEnvelopeStrict(raw)
+	return evt
+}
+
+func parseEnvelopeStrict(raw json.RawMessage) (RawEvent, error) {
 	var env rawEventEnvelope
-	_ = json.Unmarshal(raw, &env)
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return RawEvent{}, err
+	}
 	evt := RawEvent{ID: env.ID, Type: env.Type, Raw: raw}
 	if env.ProcessedAt != "" {
 		if t, err := time.Parse(time.RFC3339Nano, env.ProcessedAt); err == nil {
@@ -59,7 +66,7 @@ func parseEnvelope(raw json.RawMessage) RawEvent {
 	if evt.ProcessedAt.IsZero() {
 		evt.ProcessedAt = time.Now().UTC()
 	}
-	return evt
+	return evt, nil
 }
 
 func (c *httpClient) ListEventsSince(ctx context.Context, sessionID, afterEventID string) ([]RawEvent, error) {
@@ -160,6 +167,7 @@ type sseStream struct {
 }
 
 func (s *sseStream) Next(ctx context.Context) (RawEvent, error) {
+	var dataLines []string
 	for {
 		if err := ctx.Err(); err != nil {
 			return RawEvent{}, err
@@ -168,21 +176,44 @@ func (s *sseStream) Next(ctx context.Context) (RawEvent, error) {
 			if err := s.scanner.Err(); err != nil {
 				return RawEvent{}, err
 			}
+			if len(dataLines) > 0 {
+				return parseSSEDataLines(dataLines)
+			}
 			return RawEvent{}, io.EOF
 		}
 		line := strings.TrimRight(s.scanner.Text(), "\r")
-		if line == "" || strings.HasPrefix(line, ":") {
-			continue // keep-alive ping or blank separator
+		if line == "" {
+			if len(dataLines) == 0 {
+				continue // blank separator with no message
+			}
+			evt, err := parseSSEDataLines(dataLines)
+			if err != nil {
+				return RawEvent{}, err
+			}
+			dataLines = nil
+			return evt, nil
+		}
+		if strings.HasPrefix(line, ":") {
+			continue // keep-alive ping
 		}
 		if !strings.HasPrefix(line, "data:") {
 			continue // ignore event:/id: lines; the JSON carries its own type
 		}
-		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
-		if data == "" {
-			continue
+		data := strings.TrimPrefix(line, "data:")
+		if strings.HasPrefix(data, " ") {
+			data = data[1:]
 		}
-		return parseEnvelope(json.RawMessage(data)), nil
+		dataLines = append(dataLines, data)
 	}
 }
 
 func (s *sseStream) Close() error { return s.body.Close() }
+
+func parseSSEDataLines(lines []string) (RawEvent, error) {
+	data := strings.Join(lines, "\n")
+	evt, err := parseEnvelopeStrict(json.RawMessage(data))
+	if err != nil {
+		return RawEvent{}, fmt.Errorf("stream events: decode SSE data: %w", err)
+	}
+	return evt, nil
+}

--- a/internal/managedagents/anthropic.go
+++ b/internal/managedagents/anthropic.go
@@ -1,0 +1,188 @@
+package managedagents
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// httpClient is the concrete AnthropicClient backed by api.anthropic.com.
+type httpClient struct {
+	base   string
+	apiKey string
+	http   *http.Client
+}
+
+// NewAnthropicHTTPClient builds an AnthropicClient for the given config.
+func NewAnthropicHTTPClient(cfg Config) AnthropicClient {
+	cfg = cfg.withDefaults()
+	return &httpClient{
+		base:   strings.TrimRight(cfg.BaseURL, "/"),
+		apiKey: cfg.APIKey,
+		// No client-wide timeout: the SSE stream is long-lived. Per-request
+		// timeouts are applied via context by callers.
+		http: &http.Client{},
+	}
+}
+
+func (c *httpClient) setHeaders(req *http.Request) {
+	req.Header.Set("x-api-key", c.apiKey)
+	req.Header.Set("anthropic-version", anthropicVer)
+	req.Header.Set("anthropic-beta", managedAgentsBeta)
+	req.Header.Set("content-type", "application/json")
+}
+
+// rawEventEnvelope captures the fields the bridge keys on. The full JSON is
+// retained separately so downstream handling has access to everything.
+type rawEventEnvelope struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	ProcessedAt string `json:"processed_at"`
+}
+
+func parseEnvelope(raw json.RawMessage) RawEvent {
+	var env rawEventEnvelope
+	_ = json.Unmarshal(raw, &env)
+	evt := RawEvent{ID: env.ID, Type: env.Type, Raw: raw}
+	if env.ProcessedAt != "" {
+		if t, err := time.Parse(time.RFC3339Nano, env.ProcessedAt); err == nil {
+			evt.ProcessedAt = t.UTC()
+		}
+	}
+	if evt.ProcessedAt.IsZero() {
+		evt.ProcessedAt = time.Now().UTC()
+	}
+	return evt
+}
+
+func (c *httpClient) ListEventsSince(ctx context.Context, sessionID, afterEventID string) ([]RawEvent, error) {
+	endpoint := fmt.Sprintf("%s/v1/sessions/%s/events", c.base, url.PathEscape(sessionID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setHeaders(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("list events: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var payload struct {
+		Data []json.RawMessage `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("list events: decode: %w", err)
+	}
+	events := make([]RawEvent, 0, len(payload.Data))
+	for _, raw := range payload.Data {
+		events = append(events, parseEnvelope(raw))
+	}
+	// Drop everything up to and including the cursor so callers only see new
+	// events. The API returns history oldest-first.
+	if afterEventID != "" {
+		idx := -1
+		for i, e := range events {
+			if e.ID == afterEventID {
+				idx = i
+				break
+			}
+		}
+		if idx >= 0 {
+			events = events[idx+1:]
+		}
+	}
+	return events, nil
+}
+
+func (c *httpClient) StreamEvents(ctx context.Context, sessionID string) (EventStream, error) {
+	endpoint := fmt.Sprintf("%s/v1/sessions/%s/events/stream", c.base, url.PathEscape(sessionID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setHeaders(req)
+	req.Header.Set("accept", "text/event-stream")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+		return nil, fmt.Errorf("stream events: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	scanner := bufio.NewScanner(resp.Body)
+	// A 1MiB line buffer accommodates large tool inputs/results inlined in a
+	// single SSE data frame.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	return &sseStream{body: resp.Body, scanner: scanner}, nil
+}
+
+func (c *httpClient) SendEvents(ctx context.Context, sessionID string, events []OutboundEvent) error {
+	endpoint := fmt.Sprintf("%s/v1/sessions/%s/events", c.base, url.PathEscape(sessionID))
+	body, err := json.Marshal(map[string]any{"events": events})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	c.setHeaders(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("send events: status %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+// sseStream parses `data:` lines from an SSE response body into RawEvents.
+type sseStream struct {
+	body    io.ReadCloser
+	scanner *bufio.Scanner
+}
+
+func (s *sseStream) Next(ctx context.Context) (RawEvent, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return RawEvent{}, err
+		}
+		if !s.scanner.Scan() {
+			if err := s.scanner.Err(); err != nil {
+				return RawEvent{}, err
+			}
+			return RawEvent{}, io.EOF
+		}
+		line := strings.TrimRight(s.scanner.Text(), "\r")
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue // keep-alive ping or blank separator
+		}
+		if !strings.HasPrefix(line, "data:") {
+			continue // ignore event:/id: lines; the JSON carries its own type
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" {
+			continue
+		}
+		return parseEnvelope(json.RawMessage(data)), nil
+	}
+}
+
+func (s *sseStream) Close() error { return s.body.Close() }

--- a/internal/managedagents/anthropic_test.go
+++ b/internal/managedagents/anthropic_test.go
@@ -68,6 +68,32 @@ func TestStreamEventsParsesSSE(t *testing.T) {
 	}
 }
 
+func TestStreamEventsParsesMultilineSSEData(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event: message\n")
+		fmt.Fprint(w, "data: {\"id\":\"e1\",\n")
+		fmt.Fprint(w, "data: \"type\":\"agent.tool_use\",\n")
+		fmt.Fprint(w, "data: \"name\":\"Bash\"}\n\n")
+	}))
+	defer srv.Close()
+
+	c := NewAnthropicHTTPClient(Config{BaseURL: srv.URL, APIKey: "k"})
+	stream, err := c.StreamEvents(context.Background(), "sess_1")
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	defer stream.Close()
+
+	evt, err := stream.Next(context.Background())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	if evt.ID != "e1" || evt.Type != "agent.tool_use" {
+		t.Fatalf("unexpected event: %+v raw=%s", evt, string(evt.Raw))
+	}
+}
+
 func TestSendEventsPostsFlattenedType(t *testing.T) {
 	var gotBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/managedagents/anthropic_test.go
+++ b/internal/managedagents/anthropic_test.go
@@ -1,0 +1,92 @@
+package managedagents
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListEventsSinceFiltersByCursor(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("anthropic-beta"); got != managedAgentsBeta {
+			t.Errorf("missing beta header, got %q", got)
+		}
+		fmt.Fprint(w, `{"data":[
+			{"id":"e1","type":"agent.message","processed_at":"2026-04-01T00:00:00Z"},
+			{"id":"e2","type":"agent.tool_use","processed_at":"2026-04-01T00:00:01Z"},
+			{"id":"e3","type":"session.status_idle","processed_at":"2026-04-01T00:00:02Z"}
+		]}`)
+	}))
+	defer srv.Close()
+
+	c := NewAnthropicHTTPClient(Config{BaseURL: srv.URL, APIKey: "k"})
+	events, err := c.ListEventsSince(context.Background(), "sess_1", "e1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events after cursor e1, got %d", len(events))
+	}
+	if events[0].ID != "e2" || events[1].ID != "e3" {
+		t.Fatalf("unexpected events: %+v", events)
+	}
+}
+
+func TestStreamEventsParsesSSE(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, ": keep-alive ping\n")
+		fmt.Fprint(w, "event: message\n")
+		fmt.Fprint(w, `data: {"id":"e1","type":"agent.tool_use","name":"Bash"}`+"\n\n")
+		fmt.Fprint(w, `data: {"id":"e2","type":"session.status_idle"}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	c := NewAnthropicHTTPClient(Config{BaseURL: srv.URL, APIKey: "k"})
+	stream, err := c.StreamEvents(context.Background(), "sess_1")
+	if err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	defer stream.Close()
+
+	e1, err := stream.Next(context.Background())
+	if err != nil {
+		t.Fatalf("next 1: %v", err)
+	}
+	if e1.ID != "e1" || e1.Type != "agent.tool_use" {
+		t.Fatalf("unexpected first event: %+v", e1)
+	}
+	e2, err := stream.Next(context.Background())
+	if err != nil {
+		t.Fatalf("next 2: %v", err)
+	}
+	if e2.ID != "e2" {
+		t.Fatalf("unexpected second event: %+v", e2)
+	}
+}
+
+func TestSendEventsPostsFlattenedType(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		gotBody = string(buf)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := NewAnthropicHTTPClient(Config{BaseURL: srv.URL, APIKey: "k"})
+	err := c.SendEvents(context.Background(), "sess_1", []OutboundEvent{{
+		Type:   "user.tool_confirmation",
+		Fields: map[string]any{"tool_use_id": "t1", "result": "allow"},
+	}})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if !strings.Contains(gotBody, `"type":"user.tool_confirmation"`) || !strings.Contains(gotBody, `"result":"allow"`) {
+		t.Fatalf("unexpected body: %s", gotBody)
+	}
+}

--- a/internal/managedagents/audit.go
+++ b/internal/managedagents/audit.go
@@ -29,7 +29,7 @@ func sessionAuditKey(sessionID string) string {
 // ensureSessionAuditInvocation returns the invocation ID of the session's audit
 // row, creating it on first use. It is idempotent across restarts via the
 // session-scoped idempotency key.
-func (s *Service) ensureSessionAuditInvocation(ctx context.Context, reg SessionRegistration) (string, error) {
+func (s *Service) ensureSessionAuditInvocation(ctx context.Context, reg SessionRegistration, cfg Config) (string, error) {
 	key := sessionAuditKey(reg.SessionID)
 	if existing, err := s.audit.GetByIdempotencyKey(ctx, key); err == nil && existing.InvocationID != "" {
 		return existing.InvocationID, nil
@@ -50,8 +50,8 @@ func (s *Service) ensureSessionAuditInvocation(ctx context.Context, reg SessionR
 		}),
 		SubmittedAt:   now,
 		CompletedAt:   &now,
-		ClientName:    strPtr(s.cfg.ClientName),
-		ClientVersion: optStrPtr(s.cfg.ClientVersion),
+		ClientName:    strPtr(cfg.ClientName),
+		ClientVersion: optStrPtr(cfg.ClientVersion),
 		AgentID:       optStrPtr(reg.AgentID),
 	}
 	if err := s.audit.Create(ctx, inv); err != nil {

--- a/internal/managedagents/audit.go
+++ b/internal/managedagents/audit.go
@@ -1,0 +1,96 @@
+package managedagents
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	"atryum/internal/invocation"
+)
+
+// sessionAuditTool is the synthetic tool name used for the per-session audit
+// invocation that collects every raw Anthropic event as invocation_events.
+const sessionAuditTool = "_managed_agent_session"
+
+// InvocationAuditStore is the minimal repository surface needed to create the
+// synthetic per-session audit invocation and append raw session events to it.
+type InvocationAuditStore interface {
+	Create(ctx context.Context, inv invocation.Invocation) error
+	GetByIdempotencyKey(ctx context.Context, key string) (invocation.Invocation, error)
+	CreateEvent(ctx context.Context, evt invocation.Event) error
+}
+
+func sessionAuditKey(sessionID string) string {
+	return "managed-agent-session:" + sessionID
+}
+
+// ensureSessionAuditInvocation returns the invocation ID of the session's audit
+// row, creating it on first use. It is idempotent across restarts via the
+// session-scoped idempotency key.
+func (s *Service) ensureSessionAuditInvocation(ctx context.Context, reg SessionRegistration) (string, error) {
+	key := sessionAuditKey(reg.SessionID)
+	if existing, err := s.audit.GetByIdempotencyKey(ctx, key); err == nil && existing.InvocationID != "" {
+		return existing.InvocationID, nil
+	}
+	now := time.Now().UTC()
+	id := "inv_" + uuid.NewString()
+	inv := invocation.Invocation{
+		InvocationID:   id,
+		RequestID:      strPtr(reg.SessionID),
+		IdempotencyKey: strPtr(key),
+		Tool:           sessionAuditTool,
+		Upstream:       "",
+		Status:         invocation.StatusSucceeded,
+		Input: mustJSON(map[string]any{
+			"session_id":  reg.SessionID,
+			"agent_id":    reg.AgentID,
+			"description": reg.Description,
+		}),
+		SubmittedAt:   now,
+		CompletedAt:   &now,
+		ClientName:    strPtr(s.cfg.ClientName),
+		ClientVersion: optStrPtr(s.cfg.ClientVersion),
+		AgentID:       optStrPtr(reg.AgentID),
+	}
+	if err := s.audit.Create(ctx, inv); err != nil {
+		// A concurrent watcher may have created it first; fall back to lookup.
+		if existing, gerr := s.audit.GetByIdempotencyKey(ctx, key); gerr == nil && existing.InvocationID != "" {
+			return existing.InvocationID, nil
+		}
+		return "", err
+	}
+	return id, nil
+}
+
+// appendSessionEvent records one raw Anthropic event on the session audit
+// invocation. Every event the bridge sees is captured here regardless of type.
+func (s *Service) appendSessionEvent(ctx context.Context, auditInvocationID, sessionID string, evt RawEvent) {
+	_ = s.audit.CreateEvent(ctx, invocation.Event{
+		InvocationID: auditInvocationID,
+		EventType:    "managed_agents.session_event",
+		Payload: mustJSON(map[string]any{
+			"session_id":   sessionID,
+			"event_id":     evt.ID,
+			"event_type":   evt.Type,
+			"processed_at": evt.ProcessedAt,
+			"raw":          json.RawMessage(evt.Raw),
+		}),
+		CreatedAt: evt.ProcessedAt,
+	})
+}
+
+func mustJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}
+
+func strPtr(s string) *string { return &s }
+
+func optStrPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/internal/managedagents/audit.go
+++ b/internal/managedagents/audit.go
@@ -20,6 +20,7 @@ type InvocationAuditStore interface {
 	Create(ctx context.Context, inv invocation.Invocation) error
 	GetByIdempotencyKey(ctx context.Context, key string) (invocation.Invocation, error)
 	CreateEvent(ctx context.Context, evt invocation.Event) error
+	ListEvents(ctx context.Context, invocationID string, filter invocation.EventListFilter) ([]invocation.Event, int, error)
 }
 
 func sessionAuditKey(sessionID string) string {

--- a/internal/managedagents/parse.go
+++ b/internal/managedagents/parse.go
@@ -1,0 +1,135 @@
+package managedagents
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Event type names emitted by Anthropic Managed Agents that the bridge keys on.
+const (
+	evtAgentToolUse       = "agent.tool_use"
+	evtAgentMCPToolUse    = "agent.mcp_tool_use"
+	evtAgentCustomToolUse = "agent.custom_tool_use"
+	evtSessionIdle        = "session.status_idle"
+
+	stopReasonRequiresAction = "requires_action"
+)
+
+// firstString returns the first non-empty string value among the given keys.
+func firstString(m map[string]json.RawMessage, keys ...string) string {
+	for _, k := range keys {
+		raw, ok := m[k]
+		if !ok {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil && s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// asObject decodes a RawEvent body into a generic key->raw map.
+func asObject(raw json.RawMessage) map[string]json.RawMessage {
+	var m map[string]json.RawMessage
+	_ = json.Unmarshal(raw, &m)
+	return m
+}
+
+// parseToolUse extracts the normalized tool-call fields from a tool-use event.
+// Returns ok=false when the event is not a tool-use event.
+func parseToolUse(evt RawEvent) (toolUse, bool) {
+	var custom bool
+	switch evt.Type {
+	case evtAgentToolUse, evtAgentMCPToolUse:
+	case evtAgentCustomToolUse:
+		custom = true
+	default:
+		return toolUse{}, false
+	}
+	m := asObject(evt.Raw)
+	tu := toolUse{
+		EventID:  evt.ID,
+		Kind:     evt.Type,
+		ToolName: firstString(m, "name", "tool_name", "tool"),
+		IsCustom: custom,
+	}
+	if tu.EventID == "" {
+		tu.EventID = firstString(m, "tool_use_id", "id")
+	}
+	tu.ServerName = firstString(m, "server_name", "mcp_server_name")
+	if raw, ok := m["input"]; ok {
+		_ = json.Unmarshal(raw, &tu.Input)
+	}
+	if tu.Input == nil {
+		if raw, ok := m["arguments"]; ok {
+			_ = json.Unmarshal(raw, &tu.Input)
+		}
+	}
+	return tu, tu.ToolName != ""
+}
+
+// requiresAction reports whether an idle event is blocking on client action and
+// returns the blocking event IDs. Returns ok=false for non-blocking idles
+// (e.g. stop_reason end_turn).
+func requiresAction(evt RawEvent) (eventIDs []string, ok bool) {
+	if evt.Type != evtSessionIdle {
+		return nil, false
+	}
+	m := asObject(evt.Raw)
+	raw, present := m["stop_reason"]
+	if !present {
+		return nil, false
+	}
+	var stop struct {
+		Type     string   `json:"type"`
+		EventIDs []string `json:"event_ids"`
+	}
+	if err := json.Unmarshal(raw, &stop); err != nil {
+		return nil, false
+	}
+	if stop.Type != stopReasonRequiresAction {
+		return nil, false
+	}
+	return stop.EventIDs, true
+}
+
+// toolResult holds the outcome parsed from a tool-result event.
+type toolResult struct {
+	ToolUseID string
+	IsError   bool
+	Content   json.RawMessage
+}
+
+// parseToolResult extracts a tool result keyed to its originating tool-use
+// event. Returns ok=false when the event is not a recognizable tool result.
+func parseToolResult(evt RawEvent) (toolResult, bool) {
+	if !strings.Contains(evt.Type, "tool_result") {
+		return toolResult{}, false
+	}
+	m := asObject(evt.Raw)
+	tr := toolResult{
+		ToolUseID: firstString(m, "tool_use_id", "custom_tool_use_id", "tool_use_event_id"),
+	}
+	if tr.ToolUseID == "" {
+		return toolResult{}, false
+	}
+	if raw, ok := m["is_error"]; ok {
+		_ = json.Unmarshal(raw, &tr.IsError)
+	}
+	if raw, ok := m["status"]; ok {
+		var status string
+		if json.Unmarshal(raw, &status) == nil && (status == "error" || status == "failed") {
+			tr.IsError = true
+		}
+	}
+	if raw, ok := m["content"]; ok {
+		tr.Content = raw
+	} else if raw, ok := m["result"]; ok {
+		tr.Content = raw
+	} else if raw, ok := m["output"]; ok {
+		tr.Content = raw
+	}
+	return tr, true
+}

--- a/internal/managedagents/service.go
+++ b/internal/managedagents/service.go
@@ -60,7 +60,7 @@ type Service struct {
 
 // NewService builds a bridge over one or more Anthropic accounts. Each account's
 // config is normalized (name defaulted) on construction.
-func NewService(inv InvocationGateway, sessions SessionStore, audit InvocationAuditStore, accounts []Account) *Service {
+func NewService(inv InvocationGateway, sessions SessionStore, audit InvocationAuditStore, accounts []Account) (*Service, error) {
 	s := &Service{
 		inv:      inv,
 		sessions: sessions,
@@ -70,6 +70,9 @@ func NewService(inv InvocationGateway, sessions SessionStore, audit InvocationAu
 	}
 	for _, a := range accounts {
 		cfg := a.Config.withDefaults()
+		if _, exists := s.accounts[cfg.Name]; exists {
+			return nil, fmt.Errorf("duplicate managed-agent account name %q", cfg.Name)
+		}
 		s.accounts[cfg.Name] = account{client: a.Client, cfg: cfg}
 	}
 	if len(s.accounts) == 1 {
@@ -77,7 +80,7 @@ func NewService(inv InvocationGateway, sessions SessionStore, audit InvocationAu
 			s.defaultAccount = name
 		}
 	}
-	return s
+	return s, nil
 }
 
 // Start resumes watching every previously-registered session. It is safe to

--- a/internal/managedagents/service.go
+++ b/internal/managedagents/service.go
@@ -28,14 +28,27 @@ type SessionStore interface {
 	UpdateCursor(ctx context.Context, sessionID, lastEventID string) error
 }
 
-// Service owns the Anthropic client, the session registry, and one watcher
-// goroutine per registered session.
+// Account pairs an Anthropic API client with its (defaulted) config.
+type account struct {
+	client AnthropicClient
+	cfg    Config
+}
+
+// Account is a configured Anthropic account the bridge can watch sessions for.
+type Account struct {
+	Client AnthropicClient
+	Config Config
+}
+
+// Service owns one Anthropic client per configured account, the session
+// registry, and one watcher goroutine per registered session.
 type Service struct {
-	client   AnthropicClient
 	inv      InvocationGateway
 	sessions SessionStore
 	audit    InvocationAuditStore
-	cfg      Config
+
+	accounts       map[string]account
+	defaultAccount string // the sole account's name, when exactly one is configured
 
 	rootCtx context.Context
 	cancel  context.CancelFunc
@@ -45,15 +58,26 @@ type Service struct {
 	wg       sync.WaitGroup
 }
 
-func NewService(client AnthropicClient, inv InvocationGateway, sessions SessionStore, audit InvocationAuditStore, cfg Config) *Service {
-	return &Service{
-		client:   client,
+// NewService builds a bridge over one or more Anthropic accounts. Each account's
+// config is normalized (name defaulted) on construction.
+func NewService(inv InvocationGateway, sessions SessionStore, audit InvocationAuditStore, accounts []Account) *Service {
+	s := &Service{
 		inv:      inv,
 		sessions: sessions,
 		audit:    audit,
-		cfg:      cfg.withDefaults(),
+		accounts: make(map[string]account, len(accounts)),
 		watchers: make(map[string]context.CancelFunc),
 	}
+	for _, a := range accounts {
+		cfg := a.Config.withDefaults()
+		s.accounts[cfg.Name] = account{client: a.Client, cfg: cfg}
+	}
+	if len(s.accounts) == 1 {
+		for name := range s.accounts {
+			s.defaultAccount = name
+		}
+	}
+	return s
 }
 
 // Start resumes watching every previously-registered session. It is safe to
@@ -64,10 +88,16 @@ func (s *Service) Start(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("list managed-agent sessions: %w", err)
 	}
+	started := 0
 	for _, reg := range regs {
+		if _, ok := s.accounts[reg.Account]; !ok {
+			slog.Warn("managed agents: skipping session for unknown account", "session_id", reg.SessionID, "account", reg.Account)
+			continue
+		}
 		s.startWatcher(reg)
+		started++
 	}
-	slog.Info("managed agents: started", "watched_sessions", len(regs))
+	slog.Info("managed agents: started", "accounts", len(s.accounts), "watched_sessions", started)
 	return nil
 }
 
@@ -86,9 +116,14 @@ func (s *Service) RegisterSession(ctx context.Context, req RegisterSessionReques
 	if sessionID == "" {
 		return SessionRegistration{}, fmt.Errorf("session_id is required")
 	}
+	accountName, err := s.resolveAccount(strings.TrimSpace(req.Account))
+	if err != nil {
+		return SessionRegistration{}, err
+	}
 	now := time.Now().UTC()
 	reg := SessionRegistration{
 		SessionID:   sessionID,
+		Account:     accountName,
 		AgentID:     strings.TrimSpace(req.AgentID),
 		Description: strings.TrimSpace(req.Description),
 		CreatedAt:   now,
@@ -106,12 +141,32 @@ func (s *Service) RegisterSession(ctx context.Context, req RegisterSessionReques
 	return stored, nil
 }
 
+// resolveAccount validates a requested account name (or picks the sole account
+// when the name is empty and exactly one account is configured).
+func (s *Service) resolveAccount(name string) (string, error) {
+	if name == "" {
+		if s.defaultAccount != "" {
+			return s.defaultAccount, nil
+		}
+		return "", fmt.Errorf("account is required (multiple managed-agent accounts are configured)")
+	}
+	if _, ok := s.accounts[name]; !ok {
+		return "", fmt.Errorf("unknown managed-agent account %q", name)
+	}
+	return name, nil
+}
+
 // startWatcher launches (or restarts) the watcher goroutine for a session.
 func (s *Service) startWatcher(reg SessionRegistration) {
 	if s.rootCtx == nil {
 		// Start() hasn't run yet; this happens only if RegisterSession is
 		// called before Start. Use a background root so the watcher still runs.
 		s.rootCtx, s.cancel = context.WithCancel(context.Background())
+	}
+	acct, ok := s.accounts[reg.Account]
+	if !ok {
+		slog.Warn("managed agents: cannot watch session for unknown account", "session_id", reg.SessionID, "account", reg.Account)
+		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -120,7 +175,7 @@ func (s *Service) startWatcher(reg SessionRegistration) {
 	}
 	ctx, cancel := context.WithCancel(s.rootCtx)
 	s.watchers[reg.SessionID] = cancel
-	w := &watcher{svc: s, reg: reg, lastEventID: reg.LastEventID, pending: make(map[string]pendingCall)}
+	w := &watcher{svc: s, acct: acct, reg: reg, lastEventID: reg.LastEventID, pending: make(map[string]pendingCall)}
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()

--- a/internal/managedagents/service.go
+++ b/internal/managedagents/service.go
@@ -1,0 +1,129 @@
+package managedagents
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"atryum/internal/invocation"
+)
+
+// InvocationGateway is the slice of invocation.Service the bridge reuses to run
+// approval rules and record execution outcomes — exactly the external/hook
+// path. The bridge never executes tools itself; Anthropic does.
+type InvocationGateway interface {
+	Submit(ctx context.Context, req invocation.ExternalSubmitRequest) (invocation.InvocationResponse, error)
+	Get(ctx context.Context, invocationID string) (invocation.InvocationResponse, error)
+	RecordExecution(ctx context.Context, invocationID string, update invocation.ExternalExecutionUpdate) (invocation.InvocationResponse, error)
+}
+
+// SessionStore persists which sessions are watched plus each one's cursor.
+type SessionStore interface {
+	Upsert(ctx context.Context, s SessionRegistration) error
+	Get(ctx context.Context, sessionID string) (SessionRegistration, error)
+	List(ctx context.Context) ([]SessionRegistration, error)
+	UpdateCursor(ctx context.Context, sessionID, lastEventID string) error
+}
+
+// Service owns the Anthropic client, the session registry, and one watcher
+// goroutine per registered session.
+type Service struct {
+	client   AnthropicClient
+	inv      InvocationGateway
+	sessions SessionStore
+	audit    InvocationAuditStore
+	cfg      Config
+
+	rootCtx context.Context
+	cancel  context.CancelFunc
+
+	mu       sync.Mutex
+	watchers map[string]context.CancelFunc
+	wg       sync.WaitGroup
+}
+
+func NewService(client AnthropicClient, inv InvocationGateway, sessions SessionStore, audit InvocationAuditStore, cfg Config) *Service {
+	return &Service{
+		client:   client,
+		inv:      inv,
+		sessions: sessions,
+		audit:    audit,
+		cfg:      cfg.withDefaults(),
+		watchers: make(map[string]context.CancelFunc),
+	}
+}
+
+// Start resumes watching every previously-registered session. It is safe to
+// call once at startup.
+func (s *Service) Start(ctx context.Context) error {
+	s.rootCtx, s.cancel = context.WithCancel(context.Background())
+	regs, err := s.sessions.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list managed-agent sessions: %w", err)
+	}
+	for _, reg := range regs {
+		s.startWatcher(reg)
+	}
+	slog.Info("managed agents: started", "watched_sessions", len(regs))
+	return nil
+}
+
+// Close stops all watchers and waits for them to drain.
+func (s *Service) Close() error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.wg.Wait()
+	return nil
+}
+
+// RegisterSession persists a session and begins watching it immediately.
+func (s *Service) RegisterSession(ctx context.Context, req RegisterSessionRequest) (SessionRegistration, error) {
+	sessionID := strings.TrimSpace(req.SessionID)
+	if sessionID == "" {
+		return SessionRegistration{}, fmt.Errorf("session_id is required")
+	}
+	now := time.Now().UTC()
+	reg := SessionRegistration{
+		SessionID:   sessionID,
+		AgentID:     strings.TrimSpace(req.AgentID),
+		Description: strings.TrimSpace(req.Description),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.sessions.Upsert(ctx, reg); err != nil {
+		return SessionRegistration{}, err
+	}
+	// Re-read to pick up the preserved cursor on re-registration.
+	stored, err := s.sessions.Get(ctx, sessionID)
+	if err != nil {
+		stored = reg
+	}
+	s.startWatcher(stored)
+	return stored, nil
+}
+
+// startWatcher launches (or restarts) the watcher goroutine for a session.
+func (s *Service) startWatcher(reg SessionRegistration) {
+	if s.rootCtx == nil {
+		// Start() hasn't run yet; this happens only if RegisterSession is
+		// called before Start. Use a background root so the watcher still runs.
+		s.rootCtx, s.cancel = context.WithCancel(context.Background())
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if cancel, ok := s.watchers[reg.SessionID]; ok {
+		cancel() // replace any existing watcher
+	}
+	ctx, cancel := context.WithCancel(s.rootCtx)
+	s.watchers[reg.SessionID] = cancel
+	w := &watcher{svc: s, reg: reg, lastEventID: reg.LastEventID, pending: make(map[string]pendingCall)}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		w.run(ctx)
+	}()
+}

--- a/internal/managedagents/types.go
+++ b/internal/managedagents/types.go
@@ -28,8 +28,11 @@ const (
 	defaultReconnectBackoff = 2 * time.Second
 )
 
-// Config holds the bridge's runtime settings.
+// Config holds one account's runtime settings.
 type Config struct {
+	// Name identifies the account when more than one is configured. Empty is
+	// allowed (and normalized to "default") for the single-account case.
+	Name             string
 	BaseURL          string
 	APIKey           string
 	PollInterval     time.Duration
@@ -38,7 +41,13 @@ type Config struct {
 	ClientVersion    string
 }
 
+// DefaultAccountName is used when an account is configured without a name.
+const DefaultAccountName = "default"
+
 func (c Config) withDefaults() Config {
+	if c.Name == "" {
+		c.Name = DefaultAccountName
+	}
 	if c.BaseURL == "" {
 		c.BaseURL = defaultBaseURL
 	}
@@ -82,8 +91,11 @@ func (e OutboundEvent) MarshalJSON() ([]byte, error) {
 }
 
 // RegisterSessionRequest is the admin API payload to start watching a session.
+// Account selects which configured Anthropic account watches the session; it may
+// be omitted when only one account is configured.
 type RegisterSessionRequest struct {
 	SessionID   string `json:"session_id"`
+	Account     string `json:"account,omitempty"`
 	AgentID     string `json:"agent_id,omitempty"`
 	Description string `json:"description,omitempty"`
 }
@@ -91,6 +103,7 @@ type RegisterSessionRequest struct {
 // SessionRegistration is returned to the admin caller and persisted.
 type SessionRegistration struct {
 	SessionID   string    `json:"session_id"`
+	Account     string    `json:"account"`
 	AgentID     string    `json:"agent_id,omitempty"`
 	Description string    `json:"description,omitempty"`
 	LastEventID string    `json:"last_event_id,omitempty"`

--- a/internal/managedagents/types.go
+++ b/internal/managedagents/types.go
@@ -1,0 +1,129 @@
+// Package managedagents bridges Anthropic's Claude Managed Agents "events and
+// streaming" API into Atryum's invocation/approval engine.
+//
+// Anthropic runs the agent loop and executes tools on its own infrastructure;
+// it does not call Atryum. To gate those tool calls, Atryum connects outbound
+// to a registered session's event stream, records every session event, and —
+// when the session blocks on a tool call (a `session.status_idle` event with
+// stop_reason `requires_action`) — runs the normal Atryum approval rules and
+// reports the decision back to Claude via a `user.tool_confirmation` (hosted /
+// MCP tools) or `user.custom_tool_result` (custom tools) event.
+package managedagents
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Anthropic API constants. These are pinned rather than configurable: the
+// Managed Agents surface is gated on exactly these beta/version headers.
+const (
+	defaultBaseURL    = "https://api.anthropic.com"
+	anthropicVer      = "2023-06-01"
+	managedAgentsBeta = "managed-agents-2026-04-01"
+
+	defaultClientName       = "claude-managed-agents"
+	defaultPollInterval     = time.Second
+	defaultReconnectBackoff = 2 * time.Second
+)
+
+// Config holds the bridge's runtime settings.
+type Config struct {
+	BaseURL          string
+	APIKey           string
+	PollInterval     time.Duration
+	ReconnectBackoff time.Duration
+	ClientName       string
+	ClientVersion    string
+}
+
+func (c Config) withDefaults() Config {
+	if c.BaseURL == "" {
+		c.BaseURL = defaultBaseURL
+	}
+	if c.PollInterval <= 0 {
+		c.PollInterval = defaultPollInterval
+	}
+	if c.ReconnectBackoff <= 0 {
+		c.ReconnectBackoff = defaultReconnectBackoff
+	}
+	if c.ClientName == "" {
+		c.ClientName = defaultClientName
+	}
+	return c
+}
+
+// RawEvent is a single Anthropic session event with its envelope fields
+// extracted and the full body preserved in Raw.
+type RawEvent struct {
+	ID          string
+	Type        string
+	ProcessedAt time.Time
+	Raw         json.RawMessage
+}
+
+// OutboundEvent is an event Atryum sends back to a session (e.g. a tool
+// confirmation). Fields is marshalled inline alongside Type.
+type OutboundEvent struct {
+	Type   string
+	Fields map[string]any
+}
+
+// MarshalJSON flattens Type and Fields into a single object so the wire format
+// is {"type": "...", <fields>}.
+func (e OutboundEvent) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, len(e.Fields)+1)
+	for k, v := range e.Fields {
+		out[k] = v
+	}
+	out["type"] = e.Type
+	return json.Marshal(out)
+}
+
+// RegisterSessionRequest is the admin API payload to start watching a session.
+type RegisterSessionRequest struct {
+	SessionID   string `json:"session_id"`
+	AgentID     string `json:"agent_id,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// SessionRegistration is returned to the admin caller and persisted.
+type SessionRegistration struct {
+	SessionID   string    `json:"session_id"`
+	AgentID     string    `json:"agent_id,omitempty"`
+	Description string    `json:"description,omitempty"`
+	LastEventID string    `json:"last_event_id,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// toolUse holds the normalized fields parsed out of an agent.tool_use,
+// agent.mcp_tool_use, or agent.custom_tool_use event.
+type toolUse struct {
+	EventID    string
+	Kind       string // the Anthropic event type
+	ToolName   string
+	ServerName string // MCP server name, when Kind == agent.mcp_tool_use
+	Input      map[string]any
+	IsCustom   bool
+}
+
+// AnthropicClient is the minimal Anthropic Managed Agents surface the bridge
+// needs. It is an interface so tests can supply a fake.
+type AnthropicClient interface {
+	// ListEventsSince returns events newer than afterEventID, oldest first.
+	// When afterEventID is empty it returns the full history.
+	ListEventsSince(ctx context.Context, sessionID, afterEventID string) ([]RawEvent, error)
+	// StreamEvents opens the live SSE stream for a session.
+	StreamEvents(ctx context.Context, sessionID string) (EventStream, error)
+	// SendEvents posts client events back to a session.
+	SendEvents(ctx context.Context, sessionID string, events []OutboundEvent) error
+}
+
+// EventStream is a live SSE subscription. Next blocks until the next event or
+// an error (including io.EOF / context cancellation on close).
+type EventStream interface {
+	Next(ctx context.Context) (RawEvent, error)
+	Close() error
+}

--- a/internal/managedagents/watcher.go
+++ b/internal/managedagents/watcher.go
@@ -21,8 +21,9 @@ type pendingCall struct {
 
 // watcher streams one session's events and drives the approval lifecycle.
 type watcher struct {
-	svc *Service
-	reg SessionRegistration
+	svc  *Service
+	acct account // the Anthropic account (client + cfg) this session belongs to
+	reg  SessionRegistration
 
 	auditID     string
 	lastEventID string
@@ -55,7 +56,7 @@ func (w *watcher) run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(w.svc.cfg.ReconnectBackoff):
+		case <-time.After(w.acct.cfg.ReconnectBackoff):
 		}
 	}
 }
@@ -63,7 +64,7 @@ func (w *watcher) run(ctx context.Context) {
 // catchUp replays events that arrived while disconnected, using the persisted
 // cursor. Tool-use creation is idempotent so replays are safe.
 func (w *watcher) catchUp(ctx context.Context) error {
-	events, err := w.svc.client.ListEventsSince(ctx, w.reg.SessionID, w.lastEventID)
+	events, err := w.acct.client.ListEventsSince(ctx, w.reg.SessionID, w.lastEventID)
 	if err != nil {
 		return err
 	}
@@ -78,7 +79,7 @@ func (w *watcher) catchUp(ctx context.Context) error {
 
 // follow consumes the live SSE stream until it errors or the context is done.
 func (w *watcher) follow(ctx context.Context) error {
-	stream, err := w.svc.client.StreamEvents(ctx, w.reg.SessionID)
+	stream, err := w.acct.client.StreamEvents(ctx, w.reg.SessionID)
 	if err != nil {
 		return err
 	}
@@ -133,7 +134,7 @@ func (w *watcher) ensureAudit(ctx context.Context) error {
 	if w.auditID != "" {
 		return nil
 	}
-	id, err := w.svc.ensureSessionAuditInvocation(ctx, w.reg)
+	id, err := w.svc.ensureSessionAuditInvocation(ctx, w.reg, w.acct.cfg)
 	if err != nil {
 		return err
 	}
@@ -159,8 +160,8 @@ func (w *watcher) handleToolUse(ctx context.Context, evt RawEvent) {
 		RequestID:      &eventID,
 		IdempotencyKey: &eventID, // dedupe across stream reconnects/replays
 		ThreadID:       w.reg.SessionID,
-		ClientName:     w.svc.cfg.ClientName,
-		ClientVersion:  w.svc.cfg.ClientVersion,
+		ClientName:     w.acct.cfg.ClientName,
+		ClientVersion:  w.acct.cfg.ClientVersion,
 		AgentID:        w.reg.AgentID,
 	})
 	if err != nil {
@@ -221,7 +222,7 @@ func (w *watcher) resolveDecision(ctx context.Context, blockingID string, pc pen
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(w.svc.cfg.PollInterval):
+			case <-time.After(w.acct.cfg.PollInterval):
 			}
 		}
 	}
@@ -229,7 +230,7 @@ func (w *watcher) resolveDecision(ctx context.Context, blockingID string, pc pen
 
 func (w *watcher) sendAllow(ctx context.Context, blockingID string, pc pendingCall) {
 	evt := allowEvent(blockingID, pc)
-	if err := w.svc.client.SendEvents(ctx, w.reg.SessionID, []OutboundEvent{evt}); err != nil {
+	if err := w.acct.client.SendEvents(ctx, w.reg.SessionID, []OutboundEvent{evt}); err != nil {
 		w.log().Warn("send allow failed", "tool_use_event_id", blockingID, "error", err)
 		return
 	}
@@ -242,7 +243,7 @@ func (w *watcher) sendAllow(ctx context.Context, blockingID string, pc pendingCa
 
 func (w *watcher) sendDeny(ctx context.Context, blockingID string, pc pendingCall, reason string) {
 	evt := denyEvent(blockingID, pc, reason)
-	if err := w.svc.client.SendEvents(ctx, w.reg.SessionID, []OutboundEvent{evt}); err != nil {
+	if err := w.acct.client.SendEvents(ctx, w.reg.SessionID, []OutboundEvent{evt}); err != nil {
 		w.log().Warn("send deny failed", "tool_use_event_id", blockingID, "error", err)
 		return
 	}
@@ -292,7 +293,7 @@ func (w *watcher) cfgSource(tu toolUse) string {
 	if tu.Kind == evtAgentMCPToolUse && tu.ServerName != "" {
 		return tu.ServerName
 	}
-	return w.svc.cfg.ClientName
+	return w.acct.cfg.ClientName
 }
 
 func isToolUse(eventType string) bool {

--- a/internal/managedagents/watcher.go
+++ b/internal/managedagents/watcher.go
@@ -20,6 +20,8 @@ type pendingCall struct {
 	KindKnown    bool
 }
 
+const toolUseKindEvent = "managed_agents.tool_use"
+
 // watcher streams one session's events and drives the approval lifecycle.
 type watcher struct {
 	svc  *Service
@@ -29,10 +31,9 @@ type watcher struct {
 	auditID     string
 	lastEventID string
 
-	mu             sync.Mutex
-	pending        map[string]pendingCall // keyed by tool-use event ID
-	toolUseCustom  map[string]bool
-	toolUseKindSet bool
+	mu            sync.Mutex
+	pending       map[string]pendingCall // keyed by tool-use event ID
+	toolUseCustom map[string]bool
 }
 
 func (w *watcher) log() *slog.Logger {
@@ -122,10 +123,14 @@ func (w *watcher) handleEvent(ctx context.Context, evt RawEvent) {
 
 	switch {
 	case isToolUse(evt.Type):
-		w.handleToolUse(ctx, evt)
+		if !w.handleToolUse(ctx, evt) {
+			return
+		}
 	case evt.Type == evtSessionIdle:
 		if ids, ok := requiresAction(evt); ok {
-			w.handleRequiresAction(ctx, ids)
+			if !w.handleRequiresAction(ctx, ids) {
+				return
+			}
 		}
 	default:
 		if tr, ok := parseToolResult(evt); ok {
@@ -153,10 +158,10 @@ func (w *watcher) ensureAudit(ctx context.Context) error {
 // handleToolUse submits the tool call to Atryum's approval engine. It does not
 // execute the tool — that's Anthropic's job. The invocation is recorded with
 // status from the rule engine (auto-approved/denied or pending_approval).
-func (w *watcher) handleToolUse(ctx context.Context, evt RawEvent) {
+func (w *watcher) handleToolUse(ctx context.Context, evt RawEvent) bool {
 	tu, ok := parseToolUse(evt)
 	if !ok {
-		return
+		return true
 	}
 	source := w.cfgSource(tu)
 	eventID := tu.EventID
@@ -174,7 +179,11 @@ func (w *watcher) handleToolUse(ctx context.Context, evt RawEvent) {
 	})
 	if err != nil {
 		w.log().Warn("submit tool call failed", "tool", tu.ToolName, "error", err)
-		return
+		return false
+	}
+	if err := w.recordToolUseKind(ctx, resp.InvocationID, tu); err != nil {
+		w.log().Warn("persist tool-use kind failed", "tool_use_event_id", eventID, "invocation_id", resp.InvocationID, "error", err)
+		return false
 	}
 	w.mu.Lock()
 	w.pending[eventID] = pendingCall{InvocationID: resp.InvocationID, IsCustom: tu.IsCustom, KindKnown: true}
@@ -184,21 +193,41 @@ func (w *watcher) handleToolUse(ctx context.Context, evt RawEvent) {
 	w.toolUseCustom[eventID] = tu.IsCustom
 	w.mu.Unlock()
 	w.log().Info("tool call submitted", "tool", tu.ToolName, "invocation_id", resp.InvocationID, "status", resp.Status)
+	return true
+}
+
+func (w *watcher) recordToolUseKind(ctx context.Context, invocationID string, tu toolUse) error {
+	if w.svc.audit == nil {
+		return nil
+	}
+	return w.svc.audit.CreateEvent(ctx, invocation.Event{
+		InvocationID: invocationID,
+		EventType:    toolUseKindEvent,
+		Payload: mustJSON(map[string]any{
+			"event_id":  tu.EventID,
+			"kind":      tu.Kind,
+			"is_custom": tu.IsCustom,
+		}),
+		CreatedAt: time.Now().UTC(),
+	})
 }
 
 // handleRequiresAction resolves each blocking tool-use event: it waits for the
 // Atryum decision and reports it back to Claude. Blocking IDs are handled
 // concurrently so one slow human approval doesn't stall the others.
-func (w *watcher) handleRequiresAction(ctx context.Context, blockingIDs []string) {
+func (w *watcher) handleRequiresAction(ctx context.Context, blockingIDs []string) bool {
 	var wg sync.WaitGroup
+	allResolved := true
 	for _, id := range blockingIDs {
 		pc, ok := w.pendingCall(ctx, id, true)
 		if !ok {
 			w.log().Warn("requires_action references unknown tool-use event; will retry on replay", "tool_use_event_id", id)
+			allResolved = false
 			continue
 		}
 		if !pc.KindKnown {
 			w.log().Warn("requires_action references recovered tool-use event with unknown kind; will retry on replay", "tool_use_event_id", id)
+			allResolved = false
 			continue
 		}
 		wg.Add(1)
@@ -208,6 +237,7 @@ func (w *watcher) handleRequiresAction(ctx context.Context, blockingIDs []string
 		}(id, pc)
 	}
 	wg.Wait()
+	return allResolved
 }
 
 // resolveDecision polls the invocation until a terminal approval decision is
@@ -315,8 +345,8 @@ func (w *watcher) pendingCall(ctx context.Context, toolUseEventID string, needKi
 		}
 	}
 	// Only cache a fully-resolved entry. When the kind was needed but couldn't
-	// be determined (e.g. a transient history-fetch error), leave it uncached
-	// so the next replay re-attempts recovery instead of permanently skipping.
+	// be determined, leave it uncached so the next replay re-attempts recovery
+	// instead of permanently skipping.
 	if pc.KindKnown || !needKind {
 		w.mu.Lock()
 		w.pending[toolUseEventID] = pc
@@ -327,41 +357,57 @@ func (w *watcher) pendingCall(ctx context.Context, toolUseEventID string, needKi
 }
 
 func (w *watcher) customToolUse(ctx context.Context, toolUseEventID string) (bool, bool) {
-	if isCustom, ok, loaded := w.cachedCustomToolUse(toolUseEventID); ok || loaded {
+	if isCustom, ok := w.cachedCustomToolUse(toolUseEventID); ok {
 		return isCustom, ok
 	}
-	events, err := w.acct.client.ListEventsSince(ctx, w.reg.SessionID, "")
+	inv, err := w.svc.audit.GetByIdempotencyKey(ctx, toolUseEventID)
 	if err != nil {
-		w.log().Debug("could not recover tool-use kind from session history", "tool_use_event_id", toolUseEventID, "error", err)
 		return false, false
 	}
-	kinds := make(map[string]bool)
-	for _, evt := range events {
-		if tu, ok := parseToolUse(evt); ok {
-			kinds[tu.EventID] = tu.IsCustom
-		}
+	events, _, err := w.svc.audit.ListEvents(ctx, inv.InvocationID, invocation.EventListFilter{Limit: 200})
+	if err != nil {
+		w.log().Debug("could not recover persisted tool-use kind", "tool_use_event_id", toolUseEventID, "invocation_id", inv.InvocationID, "error", err)
+		return false, false
 	}
+	isCustom, ok := findPersistedToolUseKind(events, toolUseEventID)
 	w.mu.Lock()
 	if w.toolUseCustom == nil {
-		w.toolUseCustom = make(map[string]bool, len(kinds))
+		w.toolUseCustom = make(map[string]bool)
 	}
-	for id, isCustom := range kinds {
-		w.toolUseCustom[id] = isCustom
+	if ok {
+		w.toolUseCustom[toolUseEventID] = isCustom
 	}
-	w.toolUseKindSet = true
-	isCustom, ok := w.toolUseCustom[toolUseEventID]
 	w.mu.Unlock()
 	return isCustom, ok
 }
 
-func (w *watcher) cachedCustomToolUse(toolUseEventID string) (isCustom bool, ok bool, loaded bool) {
+func findPersistedToolUseKind(events []invocation.Event, toolUseEventID string) (bool, bool) {
+	for _, evt := range events {
+		if evt.EventType != toolUseKindEvent {
+			continue
+		}
+		var payload struct {
+			EventID  string `json:"event_id"`
+			IsCustom bool   `json:"is_custom"`
+		}
+		if err := json.Unmarshal(evt.Payload, &payload); err != nil {
+			continue
+		}
+		if payload.EventID == toolUseEventID {
+			return payload.IsCustom, true
+		}
+	}
+	return false, false
+}
+
+func (w *watcher) cachedCustomToolUse(toolUseEventID string) (isCustom bool, ok bool) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.toolUseCustom == nil {
-		return false, false, w.toolUseKindSet
+		return false, false
 	}
 	isCustom, ok = w.toolUseCustom[toolUseEventID]
-	return isCustom, ok, w.toolUseKindSet
+	return isCustom, ok
 }
 
 func (w *watcher) advanceCursor(ctx context.Context, eventID string) {

--- a/internal/managedagents/watcher.go
+++ b/internal/managedagents/watcher.go
@@ -22,6 +22,11 @@ type pendingCall struct {
 
 const toolUseKindEvent = "managed_agents.tool_use"
 
+type decisionResult struct {
+	BlockingID string
+	Delivered  bool
+}
+
 // watcher streams one session's events and drives the approval lifecycle.
 type watcher struct {
 	svc  *Service
@@ -218,6 +223,7 @@ func (w *watcher) recordToolUseKind(ctx context.Context, invocationID string, tu
 func (w *watcher) handleRequiresAction(ctx context.Context, blockingIDs []string) bool {
 	var wg sync.WaitGroup
 	allResolved := true
+	results := make(chan decisionResult, len(blockingIDs))
 	for _, id := range blockingIDs {
 		pc, ok := w.pendingCall(ctx, id, true)
 		if !ok {
@@ -233,65 +239,72 @@ func (w *watcher) handleRequiresAction(ctx context.Context, blockingIDs []string
 		wg.Add(1)
 		go func(blockingID string, pc pendingCall) {
 			defer wg.Done()
-			w.resolveDecision(ctx, blockingID, pc)
+			results <- decisionResult{BlockingID: blockingID, Delivered: w.resolveDecision(ctx, blockingID, pc)}
 		}(id, pc)
 	}
 	wg.Wait()
+	close(results)
+	for result := range results {
+		if !result.Delivered {
+			w.log().Warn("requires_action confirmation not delivered; will retry on replay", "tool_use_event_id", result.BlockingID)
+			allResolved = false
+		}
+	}
 	return allResolved
 }
 
 // resolveDecision polls the invocation until a terminal approval decision is
 // reached, then sends the corresponding confirmation event to the session.
-func (w *watcher) resolveDecision(ctx context.Context, blockingID string, pc pendingCall) {
+func (w *watcher) resolveDecision(ctx context.Context, blockingID string, pc pendingCall) bool {
 	for {
 		if ctx.Err() != nil {
-			return
+			return false
 		}
 		resp, err := w.svc.inv.Get(ctx, pc.InvocationID)
 		if err != nil {
 			w.log().Warn("get invocation failed", "invocation_id", pc.InvocationID, "error", err)
-			return
+			return false
 		}
 		switch resp.Status {
 		case invocation.StatusApproved:
-			w.sendAllow(ctx, blockingID, pc)
-			return
+			return w.sendAllow(ctx, blockingID, pc)
 		case invocation.StatusDenied:
-			w.sendDeny(ctx, blockingID, pc, denyReason(resp))
-			return
+			return w.sendDeny(ctx, blockingID, pc, denyReason(resp))
 		case invocation.StatusExecuting, invocation.StatusSucceeded, invocation.StatusFailed, invocation.StatusCancelled:
 			// Already advanced (e.g. replayed after we sent the confirmation).
-			return
+			return true
 		default: // received, pending_approval
 			select {
 			case <-ctx.Done():
-				return
+				return false
 			case <-time.After(w.acct.cfg.PollInterval):
 			}
 		}
 	}
 }
 
-func (w *watcher) sendAllow(ctx context.Context, blockingID string, pc pendingCall) {
+func (w *watcher) sendAllow(ctx context.Context, blockingID string, pc pendingCall) bool {
 	evt := allowEvent(blockingID, pc)
 	if err := w.acct.client.SendEvents(ctx, w.reg.SessionID, []OutboundEvent{evt}); err != nil {
 		w.log().Warn("send allow failed", "tool_use_event_id", blockingID, "error", err)
-		return
+		return false
 	}
 	// Mark the invocation as running now that Claude will execute it.
 	if _, err := w.svc.inv.RecordExecution(ctx, pc.InvocationID, invocation.ExternalExecutionUpdate{ExecutionStatus: "running"}); err != nil {
 		w.log().Debug("record running failed", "invocation_id", pc.InvocationID, "error", err)
 	}
 	w.log().Info("tool call approved -> allow sent", "invocation_id", pc.InvocationID)
+	return true
 }
 
-func (w *watcher) sendDeny(ctx context.Context, blockingID string, pc pendingCall, reason string) {
+func (w *watcher) sendDeny(ctx context.Context, blockingID string, pc pendingCall, reason string) bool {
 	evt := denyEvent(blockingID, pc, reason)
 	if err := w.acct.client.SendEvents(ctx, w.reg.SessionID, []OutboundEvent{evt}); err != nil {
 		w.log().Warn("send deny failed", "tool_use_event_id", blockingID, "error", err)
-		return
+		return false
 	}
 	w.log().Info("tool call denied -> deny sent", "invocation_id", pc.InvocationID, "reason", reason)
+	return true
 }
 
 // handleToolResult records the executor outcome reported by Anthropic onto the

--- a/internal/managedagents/watcher.go
+++ b/internal/managedagents/watcher.go
@@ -1,0 +1,366 @@
+package managedagents
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"time"
+
+	"atryum/internal/invocation"
+)
+
+// pendingCall links an Anthropic tool-use event to the Atryum invocation it
+// created, so a later requires_action / tool_result can find it.
+type pendingCall struct {
+	InvocationID string
+	IsCustom     bool
+}
+
+// watcher streams one session's events and drives the approval lifecycle.
+type watcher struct {
+	svc *Service
+	reg SessionRegistration
+
+	auditID     string
+	lastEventID string
+
+	mu      sync.Mutex
+	pending map[string]pendingCall // keyed by tool-use event ID
+}
+
+func (w *watcher) log() *slog.Logger {
+	return slog.With("component", "managed_agents", "session_id", w.reg.SessionID)
+}
+
+// run is the per-session supervisor loop: catch up on missed history, then
+// follow the live stream, reconnecting with backoff until the context is done.
+func (w *watcher) run(ctx context.Context) {
+	w.log().Info("watcher started", "agent_id", w.reg.AgentID, "from_event_id", w.lastEventID)
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := w.catchUp(ctx); err != nil && ctx.Err() == nil {
+			w.log().Warn("catch-up failed", "error", err)
+		}
+		if err := w.follow(ctx); err != nil && ctx.Err() == nil {
+			w.log().Warn("stream ended; will reconnect", "error", err)
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(w.svc.cfg.ReconnectBackoff):
+		}
+	}
+}
+
+// catchUp replays events that arrived while disconnected, using the persisted
+// cursor. Tool-use creation is idempotent so replays are safe.
+func (w *watcher) catchUp(ctx context.Context) error {
+	events, err := w.svc.client.ListEventsSince(ctx, w.reg.SessionID, w.lastEventID)
+	if err != nil {
+		return err
+	}
+	for _, evt := range events {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		w.handleEvent(ctx, evt)
+	}
+	return nil
+}
+
+// follow consumes the live SSE stream until it errors or the context is done.
+func (w *watcher) follow(ctx context.Context) error {
+	stream, err := w.svc.client.StreamEvents(ctx, w.reg.SessionID)
+	if err != nil {
+		return err
+	}
+	// Closing the stream unblocks a Next() that is parked on a read when the
+	// context is cancelled.
+	go func() {
+		<-ctx.Done()
+		_ = stream.Close()
+	}()
+	defer stream.Close()
+	for {
+		evt, err := stream.Next(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) || ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return err
+		}
+		w.handleEvent(ctx, evt)
+	}
+}
+
+// handleEvent is the per-event state machine. Every event is audited; tool-use
+// events become invocations, requires_action drives approvals, and tool_result
+// records the outcome.
+func (w *watcher) handleEvent(ctx context.Context, evt RawEvent) {
+	if err := w.ensureAudit(ctx); err != nil {
+		w.log().Warn("could not create session audit invocation", "error", err)
+	} else {
+		w.svc.appendSessionEvent(ctx, w.auditID, w.reg.SessionID, evt)
+	}
+
+	switch {
+	case isToolUse(evt.Type):
+		w.handleToolUse(ctx, evt)
+	case evt.Type == evtSessionIdle:
+		if ids, ok := requiresAction(evt); ok {
+			w.handleRequiresAction(ctx, ids)
+		}
+	default:
+		if tr, ok := parseToolResult(evt); ok {
+			w.handleToolResult(ctx, tr)
+		}
+	}
+
+	if evt.ID != "" {
+		w.advanceCursor(ctx, evt.ID)
+	}
+}
+
+func (w *watcher) ensureAudit(ctx context.Context) error {
+	if w.auditID != "" {
+		return nil
+	}
+	id, err := w.svc.ensureSessionAuditInvocation(ctx, w.reg)
+	if err != nil {
+		return err
+	}
+	w.auditID = id
+	return nil
+}
+
+// handleToolUse submits the tool call to Atryum's approval engine. It does not
+// execute the tool — that's Anthropic's job. The invocation is recorded with
+// status from the rule engine (auto-approved/denied or pending_approval).
+func (w *watcher) handleToolUse(ctx context.Context, evt RawEvent) {
+	tu, ok := parseToolUse(evt)
+	if !ok {
+		return
+	}
+	source := w.cfgSource(tu)
+	eventID := tu.EventID
+	resp, err := w.svc.inv.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source:         source,
+		Tool:           tu.ToolName,
+		Description:    "Claude managed agent " + tu.Kind + " in session " + w.reg.SessionID,
+		Input:          tu.Input,
+		RequestID:      &eventID,
+		IdempotencyKey: &eventID, // dedupe across stream reconnects/replays
+		ThreadID:       w.reg.SessionID,
+		ClientName:     w.svc.cfg.ClientName,
+		ClientVersion:  w.svc.cfg.ClientVersion,
+		AgentID:        w.reg.AgentID,
+	})
+	if err != nil {
+		w.log().Warn("submit tool call failed", "tool", tu.ToolName, "error", err)
+		return
+	}
+	w.mu.Lock()
+	w.pending[eventID] = pendingCall{InvocationID: resp.InvocationID, IsCustom: tu.IsCustom}
+	w.mu.Unlock()
+	w.log().Info("tool call submitted", "tool", tu.ToolName, "invocation_id", resp.InvocationID, "status", resp.Status)
+}
+
+// handleRequiresAction resolves each blocking tool-use event: it waits for the
+// Atryum decision and reports it back to Claude. Blocking IDs are handled
+// concurrently so one slow human approval doesn't stall the others.
+func (w *watcher) handleRequiresAction(ctx context.Context, blockingIDs []string) {
+	var wg sync.WaitGroup
+	for _, id := range blockingIDs {
+		w.mu.Lock()
+		pc, ok := w.pending[id]
+		w.mu.Unlock()
+		if !ok {
+			w.log().Warn("requires_action references unknown tool-use event; will retry on replay", "tool_use_event_id", id)
+			continue
+		}
+		wg.Add(1)
+		go func(blockingID string, pc pendingCall) {
+			defer wg.Done()
+			w.resolveDecision(ctx, blockingID, pc)
+		}(id, pc)
+	}
+	wg.Wait()
+}
+
+// resolveDecision polls the invocation until a terminal approval decision is
+// reached, then sends the corresponding confirmation event to the session.
+func (w *watcher) resolveDecision(ctx context.Context, blockingID string, pc pendingCall) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		resp, err := w.svc.inv.Get(ctx, pc.InvocationID)
+		if err != nil {
+			w.log().Warn("get invocation failed", "invocation_id", pc.InvocationID, "error", err)
+			return
+		}
+		switch resp.Status {
+		case invocation.StatusApproved:
+			w.sendAllow(ctx, blockingID, pc)
+			return
+		case invocation.StatusDenied:
+			w.sendDeny(ctx, blockingID, pc, denyReason(resp))
+			return
+		case invocation.StatusExecuting, invocation.StatusSucceeded, invocation.StatusFailed, invocation.StatusCancelled:
+			// Already advanced (e.g. replayed after we sent the confirmation).
+			return
+		default: // received, pending_approval
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(w.svc.cfg.PollInterval):
+			}
+		}
+	}
+}
+
+func (w *watcher) sendAllow(ctx context.Context, blockingID string, pc pendingCall) {
+	evt := allowEvent(blockingID, pc)
+	if err := w.svc.client.SendEvents(ctx, w.reg.SessionID, []OutboundEvent{evt}); err != nil {
+		w.log().Warn("send allow failed", "tool_use_event_id", blockingID, "error", err)
+		return
+	}
+	// Mark the invocation as running now that Claude will execute it.
+	if _, err := w.svc.inv.RecordExecution(ctx, pc.InvocationID, invocation.ExternalExecutionUpdate{ExecutionStatus: "running"}); err != nil {
+		w.log().Debug("record running failed", "invocation_id", pc.InvocationID, "error", err)
+	}
+	w.log().Info("tool call approved -> allow sent", "invocation_id", pc.InvocationID)
+}
+
+func (w *watcher) sendDeny(ctx context.Context, blockingID string, pc pendingCall, reason string) {
+	evt := denyEvent(blockingID, pc, reason)
+	if err := w.svc.client.SendEvents(ctx, w.reg.SessionID, []OutboundEvent{evt}); err != nil {
+		w.log().Warn("send deny failed", "tool_use_event_id", blockingID, "error", err)
+		return
+	}
+	w.log().Info("tool call denied -> deny sent", "invocation_id", pc.InvocationID, "reason", reason)
+}
+
+// handleToolResult records the executor outcome reported by Anthropic onto the
+// matching invocation.
+func (w *watcher) handleToolResult(ctx context.Context, tr toolResult) {
+	w.mu.Lock()
+	pc, ok := w.pending[tr.ToolUseID]
+	w.mu.Unlock()
+	if !ok {
+		return
+	}
+	update := invocation.ExternalExecutionUpdate{}
+	if tr.IsError {
+		update.ExecutionStatus = "failed"
+		if len(tr.Content) > 0 {
+			update.Error = tr.Content
+		}
+	} else {
+		update.ExecutionStatus = "completed"
+		if len(tr.Content) > 0 {
+			update.Result = tr.Content
+		}
+	}
+	if _, err := w.svc.inv.RecordExecution(ctx, pc.InvocationID, update); err != nil {
+		w.log().Debug("record execution outcome failed", "invocation_id", pc.InvocationID, "error", err)
+	}
+	w.mu.Lock()
+	delete(w.pending, tr.ToolUseID)
+	w.mu.Unlock()
+}
+
+func (w *watcher) advanceCursor(ctx context.Context, eventID string) {
+	w.lastEventID = eventID
+	if err := w.svc.sessions.UpdateCursor(ctx, w.reg.SessionID, eventID); err != nil {
+		w.log().Debug("update cursor failed", "event_id", eventID, "error", err)
+	}
+}
+
+// cfgSource picks the approval-rule "server" for a tool call. MCP tool calls
+// match on their server name when available; everything else uses a stable
+// source so rules remain reusable across sessions.
+func (w *watcher) cfgSource(tu toolUse) string {
+	if tu.Kind == evtAgentMCPToolUse && tu.ServerName != "" {
+		return tu.ServerName
+	}
+	return w.svc.cfg.ClientName
+}
+
+func isToolUse(eventType string) bool {
+	switch eventType {
+	case evtAgentToolUse, evtAgentMCPToolUse, evtAgentCustomToolUse:
+		return true
+	default:
+		return false
+	}
+}
+
+func denyReason(resp invocation.InvocationResponse) string {
+	if resp.Approval != nil && resp.Approval.Reason != nil && *resp.Approval.Reason != "" {
+		return *resp.Approval.Reason
+	}
+	return "denied by Atryum policy"
+}
+
+// allowEvent builds the outbound confirmation for an approved call. Hosted/MCP
+// tools use user.tool_confirmation; custom tools use user.custom_tool_result
+// with an Atryum decision envelope (see README for the v1 contract).
+func allowEvent(blockingID string, pc pendingCall) OutboundEvent {
+	if pc.IsCustom {
+		return OutboundEvent{
+			Type: "user.custom_tool_result",
+			Fields: map[string]any{
+				"custom_tool_use_id": blockingID,
+				"content":            []any{atryumDecisionContent("allow", pc.InvocationID, "")},
+			},
+		}
+	}
+	return OutboundEvent{
+		Type: "user.tool_confirmation",
+		Fields: map[string]any{
+			"tool_use_id": blockingID,
+			"result":      "allow",
+		},
+	}
+}
+
+func denyEvent(blockingID string, pc pendingCall, reason string) OutboundEvent {
+	if pc.IsCustom {
+		return OutboundEvent{
+			Type: "user.custom_tool_result",
+			Fields: map[string]any{
+				"custom_tool_use_id": blockingID,
+				"content":            []any{atryumDecisionContent("deny", pc.InvocationID, reason)},
+			},
+		}
+	}
+	return OutboundEvent{
+		Type: "user.tool_confirmation",
+		Fields: map[string]any{
+			"tool_use_id":  blockingID,
+			"result":       "deny",
+			"deny_message": reason,
+		},
+	}
+}
+
+// atryumDecisionContent is the v1 envelope sent as a custom_tool_result content
+// block when a custom tool is gated. Custom tools have no native allow/deny, so
+// Atryum surfaces the decision as a structured text block the agent can read.
+func atryumDecisionContent(decision, invocationID, denyMessage string) map[string]any {
+	envelope := map[string]any{"decision": decision, "invocation_id": invocationID}
+	if denyMessage != "" {
+		envelope["deny_message"] = denyMessage
+	}
+	payload, _ := json.Marshal(map[string]any{"atryum": envelope})
+	return map[string]any{"type": "text", "text": string(payload)}
+}

--- a/internal/managedagents/watcher.go
+++ b/internal/managedagents/watcher.go
@@ -85,9 +85,14 @@ func (w *watcher) follow(ctx context.Context) error {
 	}
 	// Closing the stream unblocks a Next() that is parked on a read when the
 	// context is cancelled.
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
-		<-ctx.Done()
-		_ = stream.Close()
+		select {
+		case <-ctx.Done():
+			_ = stream.Close()
+		case <-done:
+		}
 	}()
 	defer stream.Close()
 	for {

--- a/internal/managedagents/watcher.go
+++ b/internal/managedagents/watcher.go
@@ -17,6 +17,7 @@ import (
 type pendingCall struct {
 	InvocationID string
 	IsCustom     bool
+	KindKnown    bool
 }
 
 // watcher streams one session's events and drives the approval lifecycle.
@@ -28,8 +29,10 @@ type watcher struct {
 	auditID     string
 	lastEventID string
 
-	mu      sync.Mutex
-	pending map[string]pendingCall // keyed by tool-use event ID
+	mu             sync.Mutex
+	pending        map[string]pendingCall // keyed by tool-use event ID
+	toolUseCustom  map[string]bool
+	toolUseKindSet bool
 }
 
 func (w *watcher) log() *slog.Logger {
@@ -174,7 +177,11 @@ func (w *watcher) handleToolUse(ctx context.Context, evt RawEvent) {
 		return
 	}
 	w.mu.Lock()
-	w.pending[eventID] = pendingCall{InvocationID: resp.InvocationID, IsCustom: tu.IsCustom}
+	w.pending[eventID] = pendingCall{InvocationID: resp.InvocationID, IsCustom: tu.IsCustom, KindKnown: true}
+	if w.toolUseCustom == nil {
+		w.toolUseCustom = make(map[string]bool)
+	}
+	w.toolUseCustom[eventID] = tu.IsCustom
 	w.mu.Unlock()
 	w.log().Info("tool call submitted", "tool", tu.ToolName, "invocation_id", resp.InvocationID, "status", resp.Status)
 }
@@ -185,11 +192,13 @@ func (w *watcher) handleToolUse(ctx context.Context, evt RawEvent) {
 func (w *watcher) handleRequiresAction(ctx context.Context, blockingIDs []string) {
 	var wg sync.WaitGroup
 	for _, id := range blockingIDs {
-		w.mu.Lock()
-		pc, ok := w.pending[id]
-		w.mu.Unlock()
+		pc, ok := w.pendingCall(ctx, id, true)
 		if !ok {
 			w.log().Warn("requires_action references unknown tool-use event; will retry on replay", "tool_use_event_id", id)
+			continue
+		}
+		if !pc.KindKnown {
+			w.log().Warn("requires_action references recovered tool-use event with unknown kind; will retry on replay", "tool_use_event_id", id)
 			continue
 		}
 		wg.Add(1)
@@ -258,9 +267,7 @@ func (w *watcher) sendDeny(ctx context.Context, blockingID string, pc pendingCal
 // handleToolResult records the executor outcome reported by Anthropic onto the
 // matching invocation.
 func (w *watcher) handleToolResult(ctx context.Context, tr toolResult) {
-	w.mu.Lock()
-	pc, ok := w.pending[tr.ToolUseID]
-	w.mu.Unlock()
+	pc, ok := w.pendingCall(ctx, tr.ToolUseID, false)
 	if !ok {
 		return
 	}
@@ -282,6 +289,79 @@ func (w *watcher) handleToolResult(ctx context.Context, tr toolResult) {
 	w.mu.Lock()
 	delete(w.pending, tr.ToolUseID)
 	w.mu.Unlock()
+}
+
+func (w *watcher) pendingCall(ctx context.Context, toolUseEventID string, needKind bool) (pendingCall, bool) {
+	w.mu.Lock()
+	pc, ok := w.pending[toolUseEventID]
+	w.mu.Unlock()
+	if ok {
+		return pc, true
+	}
+	if w.svc.audit == nil {
+		return pendingCall{}, false
+	}
+	inv, err := w.svc.audit.GetByIdempotencyKey(ctx, toolUseEventID)
+	if err != nil || inv.InvocationID == "" {
+		return pendingCall{}, false
+	}
+	pc = pendingCall{
+		InvocationID: inv.InvocationID,
+	}
+	if needKind {
+		if isCustom, ok := w.customToolUse(ctx, toolUseEventID); ok {
+			pc.IsCustom = isCustom
+			pc.KindKnown = true
+		}
+	}
+	// Only cache a fully-resolved entry. When the kind was needed but couldn't
+	// be determined (e.g. a transient history-fetch error), leave it uncached
+	// so the next replay re-attempts recovery instead of permanently skipping.
+	if pc.KindKnown || !needKind {
+		w.mu.Lock()
+		w.pending[toolUseEventID] = pc
+		w.mu.Unlock()
+	}
+	w.log().Info("recovered pending tool call", "tool_use_event_id", toolUseEventID, "invocation_id", pc.InvocationID)
+	return pc, true
+}
+
+func (w *watcher) customToolUse(ctx context.Context, toolUseEventID string) (bool, bool) {
+	if isCustom, ok, loaded := w.cachedCustomToolUse(toolUseEventID); ok || loaded {
+		return isCustom, ok
+	}
+	events, err := w.acct.client.ListEventsSince(ctx, w.reg.SessionID, "")
+	if err != nil {
+		w.log().Debug("could not recover tool-use kind from session history", "tool_use_event_id", toolUseEventID, "error", err)
+		return false, false
+	}
+	kinds := make(map[string]bool)
+	for _, evt := range events {
+		if tu, ok := parseToolUse(evt); ok {
+			kinds[tu.EventID] = tu.IsCustom
+		}
+	}
+	w.mu.Lock()
+	if w.toolUseCustom == nil {
+		w.toolUseCustom = make(map[string]bool, len(kinds))
+	}
+	for id, isCustom := range kinds {
+		w.toolUseCustom[id] = isCustom
+	}
+	w.toolUseKindSet = true
+	isCustom, ok := w.toolUseCustom[toolUseEventID]
+	w.mu.Unlock()
+	return isCustom, ok
+}
+
+func (w *watcher) cachedCustomToolUse(toolUseEventID string) (isCustom bool, ok bool, loaded bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.toolUseCustom == nil {
+		return false, false, w.toolUseKindSet
+	}
+	isCustom, ok = w.toolUseCustom[toolUseEventID]
+	return isCustom, ok, w.toolUseKindSet
 }
 
 func (w *watcher) advanceCursor(ctx context.Context, eventID string) {

--- a/internal/managedagents/watcher_test.go
+++ b/internal/managedagents/watcher_test.go
@@ -1,0 +1,347 @@
+package managedagents
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"atryum/internal/invocation"
+)
+
+// --- fakes ---
+
+type fakeGateway struct {
+	mu         sync.Mutex
+	submitted  []invocation.ExternalSubmitRequest
+	statusByID map[string]invocation.Status
+	denyReason map[string]string
+	executions []execCall
+	nextID     int
+}
+
+type execCall struct {
+	ID     string
+	Update invocation.ExternalExecutionUpdate
+}
+
+func newFakeGateway() *fakeGateway {
+	return &fakeGateway{statusByID: map[string]invocation.Status{}, denyReason: map[string]string{}}
+}
+
+func (g *fakeGateway) Submit(ctx context.Context, req invocation.ExternalSubmitRequest) (invocation.InvocationResponse, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.submitted = append(g.submitted, req)
+	g.nextID++
+	id := "inv_test_" + itoa(g.nextID)
+	status, ok := g.statusByID[*req.IdempotencyKey]
+	if !ok {
+		status = invocation.StatusPendingApproval
+	}
+	g.statusByID[id] = status
+	if reason, ok := g.denyReason[*req.IdempotencyKey]; ok {
+		g.denyReason[id] = reason
+	}
+	return invocation.InvocationResponse{InvocationID: id, Status: status}, nil
+}
+
+func (g *fakeGateway) Get(ctx context.Context, id string) (invocation.InvocationResponse, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	resp := invocation.InvocationResponse{InvocationID: id, Status: g.statusByID[id]}
+	if reason, ok := g.denyReason[id]; ok {
+		resp.Approval = &invocation.Approval{Status: "auto_denied", Reason: &reason}
+	}
+	return resp, nil
+}
+
+func (g *fakeGateway) RecordExecution(ctx context.Context, id string, update invocation.ExternalExecutionUpdate) (invocation.InvocationResponse, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.executions = append(g.executions, execCall{ID: id, Update: update})
+	return invocation.InvocationResponse{InvocationID: id}, nil
+}
+
+func (g *fakeGateway) setStatusForKey(key string, status invocation.Status) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.statusByID[key] = status
+}
+
+func (g *fakeGateway) submitCount() int { g.mu.Lock(); defer g.mu.Unlock(); return len(g.submitted) }
+
+type fakeClient struct {
+	mu   sync.Mutex
+	sent []sentEvent
+}
+
+type sentEvent struct {
+	SessionID string
+	Events    []OutboundEvent
+}
+
+func (c *fakeClient) ListEventsSince(ctx context.Context, sessionID, after string) ([]RawEvent, error) {
+	return nil, nil
+}
+func (c *fakeClient) StreamEvents(ctx context.Context, sessionID string) (EventStream, error) {
+	return nil, context.Canceled
+}
+func (c *fakeClient) SendEvents(ctx context.Context, sessionID string, events []OutboundEvent) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sent = append(c.sent, sentEvent{SessionID: sessionID, Events: events})
+	return nil
+}
+func (c *fakeClient) sentEvents() []sentEvent { c.mu.Lock(); defer c.mu.Unlock(); return c.sent }
+
+type fakeSessionStore struct {
+	mu      sync.Mutex
+	cursors map[string]string
+}
+
+func (s *fakeSessionStore) Upsert(ctx context.Context, r SessionRegistration) error { return nil }
+func (s *fakeSessionStore) Get(ctx context.Context, id string) (SessionRegistration, error) {
+	return SessionRegistration{SessionID: id}, nil
+}
+func (s *fakeSessionStore) List(ctx context.Context) ([]SessionRegistration, error) { return nil, nil }
+func (s *fakeSessionStore) UpdateCursor(ctx context.Context, id, lastEventID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cursors == nil {
+		s.cursors = map[string]string{}
+	}
+	s.cursors[id] = lastEventID
+	return nil
+}
+
+type fakeAudit struct {
+	mu     sync.Mutex
+	byKey  map[string]invocation.Invocation
+	events []invocation.Event
+}
+
+func newFakeAudit() *fakeAudit {
+	return &fakeAudit{byKey: map[string]invocation.Invocation{}}
+}
+func (a *fakeAudit) Create(ctx context.Context, inv invocation.Invocation) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if inv.IdempotencyKey != nil {
+		a.byKey[*inv.IdempotencyKey] = inv
+	}
+	return nil
+}
+func (a *fakeAudit) GetByIdempotencyKey(ctx context.Context, key string) (invocation.Invocation, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if inv, ok := a.byKey[key]; ok {
+		return inv, nil
+	}
+	return invocation.Invocation{}, errNotFound
+}
+func (a *fakeAudit) CreateEvent(ctx context.Context, evt invocation.Event) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.events = append(a.events, evt)
+	return nil
+}
+func (a *fakeAudit) eventCount() int { a.mu.Lock(); defer a.mu.Unlock(); return len(a.events) }
+
+var errNotFound = &notFoundError{}
+
+type notFoundError struct{}
+
+func (e *notFoundError) Error() string { return "not found" }
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
+// --- helpers ---
+
+func newTestWatcher(g InvocationGateway, c AnthropicClient, a InvocationAuditStore) *watcher {
+	svc := NewService(c, g, &fakeSessionStore{}, a, Config{PollInterval: time.Millisecond})
+	return &watcher{svc: svc, reg: SessionRegistration{SessionID: "sess_1", AgentID: "agent-1"}, pending: map[string]pendingCall{}}
+}
+
+func toolUseEvent(id, eventType, name string, input map[string]any) RawEvent {
+	body := map[string]any{"id": id, "type": eventType, "name": name, "input": input}
+	raw, _ := json.Marshal(body)
+	return RawEvent{ID: id, Type: eventType, Raw: raw, ProcessedAt: time.Now()}
+}
+
+func idleRequiresAction(id string, blockingIDs []string) RawEvent {
+	body := map[string]any{"id": id, "type": evtSessionIdle, "stop_reason": map[string]any{"type": stopReasonRequiresAction, "event_ids": blockingIDs}}
+	raw, _ := json.Marshal(body)
+	return RawEvent{ID: id, Type: evtSessionIdle, Raw: raw, ProcessedAt: time.Now()}
+}
+
+// --- tests ---
+
+func TestToolUseApprovedSendsAllow(t *testing.T) {
+	g := newFakeGateway()
+	g.statusByID["tool_evt_1"] = invocation.StatusPendingApproval
+	c := &fakeClient{}
+	a := newFakeAudit()
+	w := newTestWatcher(g, c, a)
+	ctx := context.Background()
+
+	w.handleEvent(ctx, toolUseEvent("tool_evt_1", evtAgentToolUse, "Bash", map[string]any{"command": "ls"}))
+	if g.submitCount() != 1 {
+		t.Fatalf("expected 1 submit, got %d", g.submitCount())
+	}
+	// Approve the pending invocation, then deliver requires_action.
+	w.mu.Lock()
+	invID := w.pending["tool_evt_1"].InvocationID
+	w.mu.Unlock()
+	g.setStatusForKey(invID, invocation.StatusApproved)
+
+	w.handleEvent(ctx, idleRequiresAction("idle_1", []string{"tool_evt_1"}))
+
+	sent := c.sentEvents()
+	if len(sent) != 1 {
+		t.Fatalf("expected 1 outbound event, got %d", len(sent))
+	}
+	evt := sent[0].Events[0]
+	if evt.Type != "user.tool_confirmation" || evt.Fields["result"] != "allow" {
+		t.Fatalf("expected allow tool_confirmation, got %+v", evt)
+	}
+	if evt.Fields["tool_use_id"] != "tool_evt_1" {
+		t.Fatalf("wrong tool_use_id: %v", evt.Fields["tool_use_id"])
+	}
+}
+
+func TestToolUseDeniedSendsDeny(t *testing.T) {
+	g := newFakeGateway()
+	g.statusByID["tool_evt_1"] = invocation.StatusDenied
+	g.denyReason["tool_evt_1"] = "matched approval rule (auto_deny)"
+	c := &fakeClient{}
+	w := newTestWatcher(g, c, newFakeAudit())
+	ctx := context.Background()
+
+	w.handleEvent(ctx, toolUseEvent("tool_evt_1", evtAgentMCPToolUse, "delete_repo", nil))
+	w.handleEvent(ctx, idleRequiresAction("idle_1", []string{"tool_evt_1"}))
+
+	sent := c.sentEvents()
+	if len(sent) != 1 {
+		t.Fatalf("expected 1 outbound event, got %d", len(sent))
+	}
+	evt := sent[0].Events[0]
+	if evt.Type != "user.tool_confirmation" || evt.Fields["result"] != "deny" {
+		t.Fatalf("expected deny tool_confirmation, got %+v", evt)
+	}
+	if evt.Fields["deny_message"] != "matched approval rule (auto_deny)" {
+		t.Fatalf("wrong deny_message: %v", evt.Fields["deny_message"])
+	}
+}
+
+func TestCustomToolApprovedSendsCustomResult(t *testing.T) {
+	g := newFakeGateway()
+	g.statusByID["custom_evt_1"] = invocation.StatusApproved
+	c := &fakeClient{}
+	w := newTestWatcher(g, c, newFakeAudit())
+	ctx := context.Background()
+
+	w.handleEvent(ctx, toolUseEvent("custom_evt_1", evtAgentCustomToolUse, "deploy", map[string]any{"env": "prod"}))
+	w.handleEvent(ctx, idleRequiresAction("idle_1", []string{"custom_evt_1"}))
+
+	sent := c.sentEvents()
+	if len(sent) != 1 {
+		t.Fatalf("expected 1 outbound event, got %d", len(sent))
+	}
+	evt := sent[0].Events[0]
+	if evt.Type != "user.custom_tool_result" {
+		t.Fatalf("expected custom_tool_result, got %+v", evt)
+	}
+	if evt.Fields["custom_tool_use_id"] != "custom_evt_1" {
+		t.Fatalf("wrong custom_tool_use_id: %v", evt.Fields["custom_tool_use_id"])
+	}
+}
+
+func TestEveryEventAudited(t *testing.T) {
+	g := newFakeGateway()
+	a := newFakeAudit()
+	w := newTestWatcher(g, &fakeClient{}, a)
+	ctx := context.Background()
+
+	w.handleEvent(ctx, RawEvent{ID: "e1", Type: "agent.message", Raw: json.RawMessage(`{"type":"agent.message"}`), ProcessedAt: time.Now()})
+	w.handleEvent(ctx, RawEvent{ID: "e2", Type: "session.status_running", Raw: json.RawMessage(`{"type":"session.status_running"}`), ProcessedAt: time.Now()})
+
+	if a.eventCount() != 2 {
+		t.Fatalf("expected 2 audited events, got %d", a.eventCount())
+	}
+	if g.submitCount() != 0 {
+		t.Fatalf("non-tool events should not create invocations, got %d", g.submitCount())
+	}
+}
+
+func TestMultipleBlockingIDsResolved(t *testing.T) {
+	g := newFakeGateway()
+	g.statusByID["t1"] = invocation.StatusApproved
+	g.statusByID["t2"] = invocation.StatusApproved
+	c := &fakeClient{}
+	w := newTestWatcher(g, c, newFakeAudit())
+	ctx := context.Background()
+
+	w.handleEvent(ctx, toolUseEvent("t1", evtAgentToolUse, "Read", nil))
+	w.handleEvent(ctx, toolUseEvent("t2", evtAgentToolUse, "Write", nil))
+	w.handleEvent(ctx, idleRequiresAction("idle_1", []string{"t1", "t2"}))
+
+	if len(c.sentEvents()) != 2 {
+		t.Fatalf("expected 2 confirmations, got %d", len(c.sentEvents()))
+	}
+}
+
+func TestToolResultRecordsExecution(t *testing.T) {
+	g := newFakeGateway()
+	g.statusByID["t1"] = invocation.StatusApproved
+	c := &fakeClient{}
+	w := newTestWatcher(g, c, newFakeAudit())
+	ctx := context.Background()
+
+	w.handleEvent(ctx, toolUseEvent("t1", evtAgentToolUse, "Bash", nil))
+	resultBody, _ := json.Marshal(map[string]any{"id": "r1", "type": "agent.tool_result", "tool_use_id": "t1", "content": "done"})
+	w.handleEvent(ctx, RawEvent{ID: "r1", Type: "agent.tool_result", Raw: resultBody, ProcessedAt: time.Now()})
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	foundCompleted := false
+	for _, e := range g.executions {
+		if e.Update.ExecutionStatus == "completed" {
+			foundCompleted = true
+		}
+	}
+	if !foundCompleted {
+		t.Fatalf("expected a completed RecordExecution, got %+v", g.executions)
+	}
+}
+
+func TestDuplicateToolUseUsesIdempotencyKey(t *testing.T) {
+	g := newFakeGateway()
+	c := &fakeClient{}
+	w := newTestWatcher(g, c, newFakeAudit())
+	ctx := context.Background()
+
+	evt := toolUseEvent("t1", evtAgentToolUse, "Bash", nil)
+	w.handleEvent(ctx, evt)
+	w.handleEvent(ctx, evt) // replay after reconnect
+
+	// Both submits carry the same idempotency key; the real service dedupes.
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for _, req := range g.submitted {
+		if req.IdempotencyKey == nil || *req.IdempotencyKey != "t1" {
+			t.Fatalf("expected idempotency key t1, got %v", req.IdempotencyKey)
+		}
+	}
+}

--- a/internal/managedagents/watcher_test.go
+++ b/internal/managedagents/watcher_test.go
@@ -171,9 +171,30 @@ func itoa(n int) string {
 
 func newTestWatcher(g InvocationGateway, c AnthropicClient, a InvocationAuditStore) *watcher {
 	cfg := Config{PollInterval: time.Millisecond}.withDefaults()
-	svc := NewService(g, &fakeSessionStore{}, a, []Account{{Client: c, Config: cfg}})
+	svc, err := NewService(g, &fakeSessionStore{}, a, []Account{{Client: c, Config: cfg}})
+	if err != nil {
+		panic(err)
+	}
 	acct := svc.accounts[cfg.Name]
 	return &watcher{svc: svc, acct: acct, reg: SessionRegistration{SessionID: "sess_1", Account: cfg.Name, AgentID: "agent-1"}, pending: map[string]pendingCall{}}
+}
+
+func TestNewServiceRejectsDuplicateAccountNames(t *testing.T) {
+	_, err := NewService(nil, nil, nil, []Account{
+		{Config: Config{Name: "prod"}},
+		{Config: Config{Name: "prod"}},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate explicit account name error")
+	}
+
+	_, err = NewService(nil, nil, nil, []Account{
+		{Config: Config{}},
+		{Config: Config{}},
+	})
+	if err == nil {
+		t.Fatal("expected duplicate default account name error")
+	}
 }
 
 func toolUseEvent(id, eventType, name string, input map[string]any) RawEvent {

--- a/internal/managedagents/watcher_test.go
+++ b/internal/managedagents/watcher_test.go
@@ -3,7 +3,6 @@ package managedagents
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"runtime"
 	"sync"
@@ -76,11 +75,9 @@ func (g *fakeGateway) setStatusForKey(key string, status invocation.Status) {
 func (g *fakeGateway) submitCount() int { g.mu.Lock(); defer g.mu.Unlock(); return len(g.submitted) }
 
 type fakeClient struct {
-	mu         sync.Mutex
-	sent       []sentEvent
-	history    []RawEvent
-	historyErr error
-	listCalls  int
+	mu      sync.Mutex
+	sent    []sentEvent
+	history []RawEvent
 }
 
 type sentEvent struct {
@@ -91,10 +88,6 @@ type sentEvent struct {
 func (c *fakeClient) ListEventsSince(ctx context.Context, sessionID, after string) ([]RawEvent, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.listCalls++
-	if c.historyErr != nil {
-		return nil, c.historyErr
-	}
 	return append([]RawEvent(nil), c.history...), nil
 }
 func (c *fakeClient) StreamEvents(ctx context.Context, sessionID string) (EventStream, error) {
@@ -107,7 +100,6 @@ func (c *fakeClient) SendEvents(ctx context.Context, sessionID string, events []
 	return nil
 }
 func (c *fakeClient) sentEvents() []sentEvent { c.mu.Lock(); defer c.mu.Unlock(); return c.sent }
-func (c *fakeClient) listEventCalls() int     { c.mu.Lock(); defer c.mu.Unlock(); return c.listCalls }
 
 type eofStreamClient struct{}
 
@@ -176,6 +168,17 @@ func (a *fakeAudit) CreateEvent(ctx context.Context, evt invocation.Event) error
 	defer a.mu.Unlock()
 	a.events = append(a.events, evt)
 	return nil
+}
+func (a *fakeAudit) ListEvents(ctx context.Context, invocationID string, filter invocation.EventListFilter) ([]invocation.Event, int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var out []invocation.Event
+	for _, evt := range a.events {
+		if evt.InvocationID == invocationID {
+			out = append(out, evt)
+		}
+	}
+	return out, len(out), nil
 }
 func (a *fakeAudit) eventCount() int { a.mu.Lock(); defer a.mu.Unlock(); return len(a.events) }
 
@@ -348,9 +351,7 @@ func TestRequiresActionRecoversPendingCallAfterRestart(t *testing.T) {
 	g := newFakeGateway()
 	g.statusByID["inv_recovered"] = invocation.StatusApproved
 	g.statusByID["inv_recovered_2"] = invocation.StatusApproved
-	toolEvent := toolUseEvent("custom_evt_1", evtAgentCustomToolUse, "deploy", map[string]any{"env": "prod"})
-	toolEvent2 := toolUseEvent("tool_evt_2", evtAgentToolUse, "Bash", map[string]any{"command": "ls"})
-	c := &fakeClient{history: []RawEvent{toolEvent, toolEvent2}}
+	c := &fakeClient{}
 	a := newFakeAudit()
 	key := "custom_evt_1"
 	if err := a.Create(context.Background(), invocation.Invocation{
@@ -361,6 +362,13 @@ func TestRequiresActionRecoversPendingCallAfterRestart(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed audit: %v", err)
 	}
+	if err := a.CreateEvent(context.Background(), invocation.Event{
+		InvocationID: "inv_recovered",
+		EventType:    toolUseKindEvent,
+		Payload:      mustJSON(map[string]any{"event_id": "custom_evt_1", "is_custom": true}),
+	}); err != nil {
+		t.Fatalf("seed kind event: %v", err)
+	}
 	key2 := "tool_evt_2"
 	if err := a.Create(context.Background(), invocation.Invocation{
 		InvocationID:   "inv_recovered_2",
@@ -369,6 +377,13 @@ func TestRequiresActionRecoversPendingCallAfterRestart(t *testing.T) {
 		Status:         invocation.StatusApproved,
 	}); err != nil {
 		t.Fatalf("seed audit 2: %v", err)
+	}
+	if err := a.CreateEvent(context.Background(), invocation.Event{
+		InvocationID: "inv_recovered_2",
+		EventType:    toolUseKindEvent,
+		Payload:      mustJSON(map[string]any{"event_id": "tool_evt_2", "is_custom": false}),
+	}); err != nil {
+		t.Fatalf("seed kind event 2: %v", err)
 	}
 	w := newTestWatcher(g, c, a)
 	ctx := context.Background()
@@ -389,15 +404,12 @@ func TestRequiresActionRecoversPendingCallAfterRestart(t *testing.T) {
 	if !foundCustom {
 		t.Fatalf("expected recovered custom_tool_result for custom_evt_1, got %+v", sent)
 	}
-	if calls := c.listEventCalls(); calls != 1 {
-		t.Fatalf("expected 1 session-history fetch, got %d", calls)
-	}
 }
 
-func TestRequiresActionDoesNotGuessToolKindWhenRecoveryHistoryFails(t *testing.T) {
+func TestRequiresActionDoesNotGuessToolKindWhenPersistedKindMissing(t *testing.T) {
 	g := newFakeGateway()
 	g.statusByID["inv_recovered"] = invocation.StatusApproved
-	c := &fakeClient{historyErr: errors.New("history unavailable")}
+	c := &fakeClient{}
 	a := newFakeAudit()
 	key := "custom_evt_1"
 	if err := a.Create(context.Background(), invocation.Invocation{
@@ -431,6 +443,32 @@ func TestEveryEventAudited(t *testing.T) {
 	}
 	if g.submitCount() != 0 {
 		t.Fatalf("non-tool events should not create invocations, got %d", g.submitCount())
+	}
+}
+
+func TestToolUsePersistsKindForRecovery(t *testing.T) {
+	g := newFakeGateway()
+	a := newFakeAudit()
+	w := newTestWatcher(g, &fakeClient{}, a)
+
+	w.handleEvent(context.Background(), toolUseEvent("custom_evt_1", evtAgentCustomToolUse, "deploy", nil))
+
+	invID := ""
+	w.mu.Lock()
+	if pc, ok := w.pending["custom_evt_1"]; ok {
+		invID = pc.InvocationID
+	}
+	w.mu.Unlock()
+	if invID == "" {
+		t.Fatal("expected pending invocation")
+	}
+	events, _, err := a.ListEvents(context.Background(), invID, invocation.EventListFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	isCustom, ok := findPersistedToolUseKind(events, "custom_evt_1")
+	if !ok || !isCustom {
+		t.Fatalf("expected persisted custom tool kind, ok=%v isCustom=%v events=%+v", ok, isCustom, events)
 	}
 }
 

--- a/internal/managedagents/watcher_test.go
+++ b/internal/managedagents/watcher_test.go
@@ -3,6 +3,7 @@ package managedagents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"runtime"
 	"sync"
@@ -75,8 +76,11 @@ func (g *fakeGateway) setStatusForKey(key string, status invocation.Status) {
 func (g *fakeGateway) submitCount() int { g.mu.Lock(); defer g.mu.Unlock(); return len(g.submitted) }
 
 type fakeClient struct {
-	mu   sync.Mutex
-	sent []sentEvent
+	mu         sync.Mutex
+	sent       []sentEvent
+	history    []RawEvent
+	historyErr error
+	listCalls  int
 }
 
 type sentEvent struct {
@@ -85,7 +89,13 @@ type sentEvent struct {
 }
 
 func (c *fakeClient) ListEventsSince(ctx context.Context, sessionID, after string) ([]RawEvent, error) {
-	return nil, nil
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.listCalls++
+	if c.historyErr != nil {
+		return nil, c.historyErr
+	}
+	return append([]RawEvent(nil), c.history...), nil
 }
 func (c *fakeClient) StreamEvents(ctx context.Context, sessionID string) (EventStream, error) {
 	return nil, context.Canceled
@@ -97,6 +107,7 @@ func (c *fakeClient) SendEvents(ctx context.Context, sessionID string, events []
 	return nil
 }
 func (c *fakeClient) sentEvents() []sentEvent { c.mu.Lock(); defer c.mu.Unlock(); return c.sent }
+func (c *fakeClient) listEventCalls() int     { c.mu.Lock(); defer c.mu.Unlock(); return c.listCalls }
 
 type eofStreamClient struct{}
 
@@ -333,6 +344,79 @@ func TestCustomToolApprovedSendsCustomResult(t *testing.T) {
 	}
 }
 
+func TestRequiresActionRecoversPendingCallAfterRestart(t *testing.T) {
+	g := newFakeGateway()
+	g.statusByID["inv_recovered"] = invocation.StatusApproved
+	g.statusByID["inv_recovered_2"] = invocation.StatusApproved
+	toolEvent := toolUseEvent("custom_evt_1", evtAgentCustomToolUse, "deploy", map[string]any{"env": "prod"})
+	toolEvent2 := toolUseEvent("tool_evt_2", evtAgentToolUse, "Bash", map[string]any{"command": "ls"})
+	c := &fakeClient{history: []RawEvent{toolEvent, toolEvent2}}
+	a := newFakeAudit()
+	key := "custom_evt_1"
+	if err := a.Create(context.Background(), invocation.Invocation{
+		InvocationID:   "inv_recovered",
+		IdempotencyKey: &key,
+		Tool:           "deploy",
+		Status:         invocation.StatusApproved,
+	}); err != nil {
+		t.Fatalf("seed audit: %v", err)
+	}
+	key2 := "tool_evt_2"
+	if err := a.Create(context.Background(), invocation.Invocation{
+		InvocationID:   "inv_recovered_2",
+		IdempotencyKey: &key2,
+		Tool:           "Bash",
+		Status:         invocation.StatusApproved,
+	}); err != nil {
+		t.Fatalf("seed audit 2: %v", err)
+	}
+	w := newTestWatcher(g, c, a)
+	ctx := context.Background()
+
+	w.handleEvent(ctx, idleRequiresAction("idle_1", []string{"custom_evt_1", "tool_evt_2"}))
+
+	sent := c.sentEvents()
+	if len(sent) != 2 {
+		t.Fatalf("expected 2 outbound events, got %d", len(sent))
+	}
+	foundCustom := false
+	for _, sentEvent := range sent {
+		evt := sentEvent.Events[0]
+		if evt.Type == "user.custom_tool_result" && evt.Fields["custom_tool_use_id"] == "custom_evt_1" {
+			foundCustom = true
+		}
+	}
+	if !foundCustom {
+		t.Fatalf("expected recovered custom_tool_result for custom_evt_1, got %+v", sent)
+	}
+	if calls := c.listEventCalls(); calls != 1 {
+		t.Fatalf("expected 1 session-history fetch, got %d", calls)
+	}
+}
+
+func TestRequiresActionDoesNotGuessToolKindWhenRecoveryHistoryFails(t *testing.T) {
+	g := newFakeGateway()
+	g.statusByID["inv_recovered"] = invocation.StatusApproved
+	c := &fakeClient{historyErr: errors.New("history unavailable")}
+	a := newFakeAudit()
+	key := "custom_evt_1"
+	if err := a.Create(context.Background(), invocation.Invocation{
+		InvocationID:   "inv_recovered",
+		IdempotencyKey: &key,
+		Tool:           "deploy",
+		Status:         invocation.StatusApproved,
+	}); err != nil {
+		t.Fatalf("seed audit: %v", err)
+	}
+	w := newTestWatcher(g, c, a)
+
+	w.handleEvent(context.Background(), idleRequiresAction("idle_1", []string{"custom_evt_1"}))
+
+	if sent := c.sentEvents(); len(sent) != 0 {
+		t.Fatalf("expected no guessed outbound events, got %+v", sent)
+	}
+}
+
 func TestEveryEventAudited(t *testing.T) {
 	g := newFakeGateway()
 	a := newFakeAudit()
@@ -388,6 +472,35 @@ func TestToolResultRecordsExecution(t *testing.T) {
 	}
 	if !foundCompleted {
 		t.Fatalf("expected a completed RecordExecution, got %+v", g.executions)
+	}
+}
+
+func TestToolResultRecoversPendingCallAfterRestart(t *testing.T) {
+	g := newFakeGateway()
+	c := &fakeClient{}
+	a := newFakeAudit()
+	key := "t1"
+	if err := a.Create(context.Background(), invocation.Invocation{
+		InvocationID:   "inv_recovered",
+		IdempotencyKey: &key,
+		Tool:           "Bash",
+		Status:         invocation.StatusExecuting,
+	}); err != nil {
+		t.Fatalf("seed audit: %v", err)
+	}
+	w := newTestWatcher(g, c, a)
+	ctx := context.Background()
+
+	resultBody, _ := json.Marshal(map[string]any{"id": "r1", "type": "agent.tool_result", "tool_use_id": "t1", "content": "done"})
+	w.handleEvent(ctx, RawEvent{ID: "r1", Type: "agent.tool_result", Raw: resultBody, ProcessedAt: time.Now()})
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.executions) != 1 {
+		t.Fatalf("expected 1 recovered execution update, got %+v", g.executions)
+	}
+	if g.executions[0].ID != "inv_recovered" || g.executions[0].Update.ExecutionStatus != "completed" {
+		t.Fatalf("unexpected recovered execution update: %+v", g.executions[0])
 	}
 }
 

--- a/internal/managedagents/watcher_test.go
+++ b/internal/managedagents/watcher_test.go
@@ -3,6 +3,7 @@ package managedagents
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"runtime"
 	"sync"
@@ -78,6 +79,7 @@ type fakeClient struct {
 	mu      sync.Mutex
 	sent    []sentEvent
 	history []RawEvent
+	sendErr error
 }
 
 type sentEvent struct {
@@ -96,6 +98,9 @@ func (c *fakeClient) StreamEvents(ctx context.Context, sessionID string) (EventS
 func (c *fakeClient) SendEvents(ctx context.Context, sessionID string, events []OutboundEvent) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.sendErr != nil {
+		return c.sendErr
+	}
 	c.sent = append(c.sent, sentEvent{SessionID: sessionID, Events: events})
 	return nil
 }
@@ -136,6 +141,11 @@ func (s *fakeSessionStore) UpdateCursor(ctx context.Context, id, lastEventID str
 	}
 	s.cursors[id] = lastEventID
 	return nil
+}
+func (s *fakeSessionStore) cursor(id string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cursors[id]
 }
 
 type fakeAudit struct {
@@ -205,6 +215,16 @@ func itoa(n int) string {
 func newTestWatcher(g InvocationGateway, c AnthropicClient, a InvocationAuditStore) *watcher {
 	cfg := Config{PollInterval: time.Millisecond}.withDefaults()
 	svc, err := NewService(g, &fakeSessionStore{}, a, []Account{{Client: c, Config: cfg}})
+	if err != nil {
+		panic(err)
+	}
+	acct := svc.accounts[cfg.Name]
+	return &watcher{svc: svc, acct: acct, reg: SessionRegistration{SessionID: "sess_1", Account: cfg.Name, AgentID: "agent-1"}, pending: map[string]pendingCall{}}
+}
+
+func newTestWatcherWithStore(g InvocationGateway, c AnthropicClient, a InvocationAuditStore, store *fakeSessionStore) *watcher {
+	cfg := Config{PollInterval: time.Millisecond}.withDefaults()
+	svc, err := NewService(g, store, a, []Account{{Client: c, Config: cfg}})
 	if err != nil {
 		panic(err)
 	}
@@ -426,6 +446,26 @@ func TestRequiresActionDoesNotGuessToolKindWhenPersistedKindMissing(t *testing.T
 
 	if sent := c.sentEvents(); len(sent) != 0 {
 		t.Fatalf("expected no guessed outbound events, got %+v", sent)
+	}
+}
+
+func TestRequiresActionDoesNotAdvanceCursorWhenSendFails(t *testing.T) {
+	g := newFakeGateway()
+	g.statusByID["tool_evt_1"] = invocation.StatusApproved
+	c := &fakeClient{sendErr: errors.New("anthropic unavailable")}
+	a := newFakeAudit()
+	store := &fakeSessionStore{}
+	w := newTestWatcherWithStore(g, c, a, store)
+	ctx := context.Background()
+
+	w.handleEvent(ctx, toolUseEvent("tool_evt_1", evtAgentToolUse, "Bash", nil))
+	w.handleEvent(ctx, idleRequiresAction("idle_1", []string{"tool_evt_1"}))
+
+	if got := store.cursor("sess_1"); got != "tool_evt_1" {
+		t.Fatalf("cursor advanced past failed requires_action: got %q", got)
+	}
+	if sent := c.sentEvents(); len(sent) != 0 {
+		t.Fatalf("expected no successful outbound events, got %+v", sent)
 	}
 }
 

--- a/internal/managedagents/watcher_test.go
+++ b/internal/managedagents/watcher_test.go
@@ -170,8 +170,10 @@ func itoa(n int) string {
 // --- helpers ---
 
 func newTestWatcher(g InvocationGateway, c AnthropicClient, a InvocationAuditStore) *watcher {
-	svc := NewService(c, g, &fakeSessionStore{}, a, Config{PollInterval: time.Millisecond})
-	return &watcher{svc: svc, reg: SessionRegistration{SessionID: "sess_1", AgentID: "agent-1"}, pending: map[string]pendingCall{}}
+	cfg := Config{PollInterval: time.Millisecond}.withDefaults()
+	svc := NewService(g, &fakeSessionStore{}, a, []Account{{Client: c, Config: cfg}})
+	acct := svc.accounts[cfg.Name]
+	return &watcher{svc: svc, acct: acct, reg: SessionRegistration{SessionID: "sess_1", Account: cfg.Name, AgentID: "agent-1"}, pending: map[string]pendingCall{}}
 }
 
 func toolUseEvent(id, eventType, name string, input map[string]any) RawEvent {

--- a/internal/managedagents/watcher_test.go
+++ b/internal/managedagents/watcher_test.go
@@ -3,6 +3,8 @@ package managedagents
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -95,6 +97,23 @@ func (c *fakeClient) SendEvents(ctx context.Context, sessionID string, events []
 	return nil
 }
 func (c *fakeClient) sentEvents() []sentEvent { c.mu.Lock(); defer c.mu.Unlock(); return c.sent }
+
+type eofStreamClient struct{}
+
+func (c eofStreamClient) ListEventsSince(ctx context.Context, sessionID, after string) ([]RawEvent, error) {
+	return nil, nil
+}
+func (c eofStreamClient) StreamEvents(ctx context.Context, sessionID string) (EventStream, error) {
+	return eofStream{}, nil
+}
+func (c eofStreamClient) SendEvents(ctx context.Context, sessionID string, events []OutboundEvent) error {
+	return nil
+}
+
+type eofStream struct{}
+
+func (s eofStream) Next(ctx context.Context) (RawEvent, error) { return RawEvent{}, io.EOF }
+func (s eofStream) Close() error                               { return nil }
 
 type fakeSessionStore struct {
 	mu      sync.Mutex
@@ -195,6 +214,29 @@ func TestNewServiceRejectsDuplicateAccountNames(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected duplicate default account name error")
 	}
+}
+
+func TestFollowDoesNotLeakCloseGoroutineAfterEOF(t *testing.T) {
+	w := newTestWatcher(newFakeGateway(), eofStreamClient{}, newFakeAudit())
+	ctx := context.Background()
+
+	runtime.GC()
+	before := runtime.NumGoroutine()
+	for i := 0; i < 100; i++ {
+		if err := w.follow(ctx); err != nil {
+			t.Fatalf("follow %d: %v", i, err)
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		if runtime.NumGoroutine() <= before+5 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("possible close goroutine leak: before=%d after=%d", before, runtime.NumGoroutine())
 }
 
 func toolUseEvent(id, eventType, name string, input map[string]any) RawEvent {

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 19 {
+	if len(migrations) != 20 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -71,7 +71,8 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{16, "016_llm_configs"},
 		{17, "017_agent_constitution"},
 		{18, "018_rule_llm_config"},
-		{19, "019_settings_summary_llm"},,
+		{19, "019_settings_summary_llm"},
+		{20, "020_managed_agent_sessions"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -82,10 +83,10 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 17 {
+	if len(pending) != 19 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}
+	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
 	for i, want := range wantVersions {
 		if pending[i].Version != want {
 			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)

--- a/internal/store/managed_agent_sessions.go
+++ b/internal/store/managed_agent_sessions.go
@@ -1,0 +1,120 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	sq "github.com/Masterminds/squirrel"
+)
+
+// ManagedAgentSession is the store-level representation of a Claude Managed
+// Agents session that Atryum is watching. last_event_id is the cursor of the
+// most recently processed Anthropic event so the watcher can resume after a
+// stream drop or restart.
+type ManagedAgentSession struct {
+	SessionID   string
+	AgentID     string
+	Description string
+	LastEventID string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// ManagedAgentSessionRepo provides upsert and query operations for the
+// managed_agent_sessions table.
+type ManagedAgentSessionRepo struct {
+	db *sql.DB
+	sb sq.StatementBuilderType
+}
+
+func NewManagedAgentSessionRepo(db *sql.DB) *ManagedAgentSessionRepo {
+	return NewManagedAgentSessionRepoWithDialect(db, DialectSQLite)
+}
+
+func NewManagedAgentSessionRepoWithDialect(db *sql.DB, dialect Dialect) *ManagedAgentSessionRepo {
+	return &ManagedAgentSessionRepo{db: db, sb: statementBuilderForDialect(dialect)}
+}
+
+// Upsert inserts a new watched session or updates the agent_id/description of
+// an existing one. The last_event_id cursor is preserved on update so a
+// re-registration does not rewind the watcher.
+func (r *ManagedAgentSessionRepo) Upsert(ctx context.Context, s ManagedAgentSession) error {
+	now := time.Now().UTC()
+	if s.CreatedAt.IsZero() {
+		s.CreatedAt = now
+	}
+	query, args, err := r.sb.Insert("managed_agent_sessions").
+		Columns("session_id", "agent_id", "description", "last_event_id", "created_at", "updated_at").
+		Values(s.SessionID, s.AgentID, s.Description, s.LastEventID, s.CreatedAt, now).
+		Suffix(`ON CONFLICT (session_id) DO UPDATE SET
+			agent_id    = excluded.agent_id,
+			description = excluded.description,
+			updated_at  = excluded.updated_at`).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = r.db.ExecContext(ctx, query, args...)
+	return err
+}
+
+func (r *ManagedAgentSessionRepo) Get(ctx context.Context, sessionID string) (ManagedAgentSession, error) {
+	query, args, err := r.sb.
+		Select("session_id", "agent_id", "description", "last_event_id", "created_at", "updated_at").
+		From("managed_agent_sessions").
+		Where(sq.Eq{"session_id": sessionID}).
+		ToSql()
+	if err != nil {
+		return ManagedAgentSession{}, err
+	}
+	row := r.db.QueryRowContext(ctx, query, args...)
+	return scanManagedAgentSession(row)
+}
+
+func (r *ManagedAgentSessionRepo) List(ctx context.Context) ([]ManagedAgentSession, error) {
+	query, args, err := r.sb.
+		Select("session_id", "agent_id", "description", "last_event_id", "created_at", "updated_at").
+		From("managed_agent_sessions").
+		OrderBy("created_at ASC").
+		ToSql()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ManagedAgentSession
+	for rows.Next() {
+		s, err := scanManagedAgentSession(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// UpdateCursor advances the last_event_id watermark for a session.
+func (r *ManagedAgentSessionRepo) UpdateCursor(ctx context.Context, sessionID, lastEventID string) error {
+	query, args, err := r.sb.Update("managed_agent_sessions").
+		Set("last_event_id", lastEventID).
+		Set("updated_at", time.Now().UTC()).
+		Where(sq.Eq{"session_id": sessionID}).
+		ToSql()
+	if err != nil {
+		return err
+	}
+	_, err = r.db.ExecContext(ctx, query, args...)
+	return err
+}
+
+func scanManagedAgentSession(row interface{ Scan(dest ...any) error }) (ManagedAgentSession, error) {
+	var s ManagedAgentSession
+	if err := row.Scan(&s.SessionID, &s.AgentID, &s.Description, &s.LastEventID, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		return ManagedAgentSession{}, err
+	}
+	return s, nil
+}

--- a/internal/store/managed_agent_sessions.go
+++ b/internal/store/managed_agent_sessions.go
@@ -14,6 +14,7 @@ import (
 // stream drop or restart.
 type ManagedAgentSession struct {
 	SessionID   string
+	Account     string
 	AgentID     string
 	Description string
 	LastEventID string
@@ -44,10 +45,14 @@ func (r *ManagedAgentSessionRepo) Upsert(ctx context.Context, s ManagedAgentSess
 	if s.CreatedAt.IsZero() {
 		s.CreatedAt = now
 	}
+	if s.Account == "" {
+		s.Account = "default"
+	}
 	query, args, err := r.sb.Insert("managed_agent_sessions").
-		Columns("session_id", "agent_id", "description", "last_event_id", "created_at", "updated_at").
-		Values(s.SessionID, s.AgentID, s.Description, s.LastEventID, s.CreatedAt, now).
+		Columns("session_id", "account", "agent_id", "description", "last_event_id", "created_at", "updated_at").
+		Values(s.SessionID, s.Account, s.AgentID, s.Description, s.LastEventID, s.CreatedAt, now).
 		Suffix(`ON CONFLICT (session_id) DO UPDATE SET
+			account     = excluded.account,
 			agent_id    = excluded.agent_id,
 			description = excluded.description,
 			updated_at  = excluded.updated_at`).
@@ -61,7 +66,7 @@ func (r *ManagedAgentSessionRepo) Upsert(ctx context.Context, s ManagedAgentSess
 
 func (r *ManagedAgentSessionRepo) Get(ctx context.Context, sessionID string) (ManagedAgentSession, error) {
 	query, args, err := r.sb.
-		Select("session_id", "agent_id", "description", "last_event_id", "created_at", "updated_at").
+		Select("session_id", "account", "agent_id", "description", "last_event_id", "created_at", "updated_at").
 		From("managed_agent_sessions").
 		Where(sq.Eq{"session_id": sessionID}).
 		ToSql()
@@ -74,7 +79,7 @@ func (r *ManagedAgentSessionRepo) Get(ctx context.Context, sessionID string) (Ma
 
 func (r *ManagedAgentSessionRepo) List(ctx context.Context) ([]ManagedAgentSession, error) {
 	query, args, err := r.sb.
-		Select("session_id", "agent_id", "description", "last_event_id", "created_at", "updated_at").
+		Select("session_id", "account", "agent_id", "description", "last_event_id", "created_at", "updated_at").
 		From("managed_agent_sessions").
 		OrderBy("created_at ASC").
 		ToSql()
@@ -113,7 +118,7 @@ func (r *ManagedAgentSessionRepo) UpdateCursor(ctx context.Context, sessionID, l
 
 func scanManagedAgentSession(row interface{ Scan(dest ...any) error }) (ManagedAgentSession, error) {
 	var s ManagedAgentSession
-	if err := row.Scan(&s.SessionID, &s.AgentID, &s.Description, &s.LastEventID, &s.CreatedAt, &s.UpdatedAt); err != nil {
+	if err := row.Scan(&s.SessionID, &s.Account, &s.AgentID, &s.Description, &s.LastEventID, &s.CreatedAt, &s.UpdatedAt); err != nil {
 		return ManagedAgentSession{}, err
 	}
 	return s, nil

--- a/internal/store/migrations/020_managed_agent_sessions.go
+++ b/internal/store/migrations/020_managed_agent_sessions.go
@@ -1,0 +1,29 @@
+package migrations
+
+func migration020() Definition {
+	return Definition{
+		Version: 20,
+		Name:    "020_managed_agent_sessions",
+		Steps: []Step{
+			RawDialect("create managed_agent_sessions table", `
+				CREATE TABLE IF NOT EXISTS managed_agent_sessions (
+					session_id    TEXT      PRIMARY KEY,
+					agent_id      TEXT      NOT NULL DEFAULT '',
+					description   TEXT      NOT NULL DEFAULT '',
+					last_event_id TEXT      NOT NULL DEFAULT '',
+					created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					updated_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)
+			`, `
+				CREATE TABLE IF NOT EXISTS managed_agent_sessions (
+					session_id    TEXT        PRIMARY KEY,
+					agent_id      TEXT        NOT NULL DEFAULT '',
+					description   TEXT        NOT NULL DEFAULT '',
+					last_event_id TEXT        NOT NULL DEFAULT '',
+					created_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					updated_at    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)
+			`),
+		},
+	}
+}

--- a/internal/store/migrations/020_managed_agent_sessions.go
+++ b/internal/store/migrations/020_managed_agent_sessions.go
@@ -8,6 +8,7 @@ func migration020() Definition {
 			RawDialect("create managed_agent_sessions table", `
 				CREATE TABLE IF NOT EXISTS managed_agent_sessions (
 					session_id    TEXT      PRIMARY KEY,
+					account       TEXT      NOT NULL DEFAULT 'default',
 					agent_id      TEXT      NOT NULL DEFAULT '',
 					description   TEXT      NOT NULL DEFAULT '',
 					last_event_id TEXT      NOT NULL DEFAULT '',
@@ -17,6 +18,7 @@ func migration020() Definition {
 			`, `
 				CREATE TABLE IF NOT EXISTS managed_agent_sessions (
 					session_id    TEXT        PRIMARY KEY,
+					account       TEXT        NOT NULL DEFAULT 'default',
 					agent_id      TEXT        NOT NULL DEFAULT '',
 					description   TEXT        NOT NULL DEFAULT '',
 					last_event_id TEXT        NOT NULL DEFAULT '',

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -53,5 +53,6 @@ func All() []Definition {
 		migration017(),
 		migration018(),
 		migration019(),
+		migration020(),
 	}
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -41,12 +41,12 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 19 {
-		t.Fatalf("expected 19 migrations, got %d", count)
+	if count != 20 {
+		t.Fatalf("expected 20 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
-	tables := []string{"invocations", "invocation_events", "mcp_servers", "oauth_credentials", "oauth_connect_sessions", "approval_rules"}
+	tables := []string{"invocations", "invocation_events", "mcp_servers", "oauth_credentials", "oauth_connect_sessions", "approval_rules", "managed_agent_sessions"}
 	for _, table := range tables {
 		var name string
 		if err := db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, table).Scan(&name); err != nil {
@@ -70,8 +70,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 19 {
-		t.Fatalf("expected 19 migrations after double init, got %d", count)
+	if count != 20 {
+		t.Fatalf("expected 20 migrations after double init, got %d", count)
 	}
 }
 


### PR DESCRIPTION
We would like to add support for claude managed agents via polling. When configuring the agent within claude it needs to be given "always ask" for tool permissions that we want atryum to decide.

Adding ui support for adding managed agents can be done as a followup.

How to test:
in the toml add
```
[[managed_agents]]
name    = "claude-managed-agent"
api_key = "$ANTHROPIC_API_KEY"
```

then tell atryum about the agent
```bash
curl -sS -X POST http://localhost:8080/api/v1/admin/managed-agents/sessions \
    -H "content-type: application/json" \
    -d '{
      "session_id": "sesn_01HFMUm2Q1iLMksTikNhnfuk",
      "account": "claude-managed-agent",
      "agent_id": "agent_013popGjeyhH8qPYqziHxdLk",
      "description": "Claude managed agent"
    }'
```


Then have the agent do something
```bash
 curl -sS -X POST https://api.anthropic.com/v1/sessions/sesn_01HFMUm2Q1iLMksTikNhnfuk/events \
    -H "x-api-key: $ANTHROPIC_API_KEY" \
    -H "anthropic-version: 2023-06-01" \
    -H "anthropic-beta: managed-agents-2026-04-01" \
    -H "content-type: application/json" \
    -d '{
      "events": [
        {
          "type": "user.message",
          "content": [
            {
              "type": "text",
              "text": "Run pwd, then list the files in the current directory."
            }
          ]
        }
      ]
    }'
```