### PR TITLE
Fixes dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ COPY . .
 COPY --from=ui-builder /ui/dist ./internal/api/web
 RUN CGO_ENABLED=0 go build -o /atryum ./cmd/atryum
 
-FROM alpine:3.20
-RUN apk add --no-cache ca-certificates
+FROM node:22-alpine 
 COPY --from=builder /atryum /usr/local/bin/atryum
 WORKDIR /app
 ENTRYPOINT ["atryum", "run", "-config", "/app/atryum.toml"]


### PR DESCRIPTION
Update Dockerfile to use Node 22-alpine as the base image, enabling the inclusion of UI assets during the build process. This change replaces the previous alpine:3.20 image and ensures that the Go application can access the necessary web assets from the Node build stage.