### PR TITLE
fix(store): allow creating VM-path ai_evaluation rules (NOT NULL on atryum_llm_config_id)

### DIFF
--- a/internal/store/rules.go
+++ b/internal/store/rules.go
@@ -67,7 +67,7 @@ func (r *RulesRepo) Create(ctx context.Context, rule Rule) error {
 		Columns(ruleColumns...).
 		Values(
 			rule.ID, rule.Action, serverJSON, toolJSON, rule.AgentIDPattern,
-			emptyToNil(rule.ModelConfigCUID), emptyToNil(rule.AtryumLLMConfigID), agentCUIDsJSON,
+			emptyToNil(rule.ModelConfigCUID), rule.AtryumLLMConfigID, agentCUIDsJSON,
 			emptyToNil(rule.Description), boolToInt(rule.Enabled), rule.Order, now, now,
 		).ToSql()
 	if err != nil {
@@ -139,7 +139,7 @@ func (r *RulesRepo) Update(ctx context.Context, rule Rule) error {
 		Set("tool_pattern", toolJSON).
 		Set("agent_id_pattern", rule.AgentIDPattern).
 		Set("model_config_cuid", emptyToNil(rule.ModelConfigCUID)).
-		Set("atryum_llm_config_id", emptyToNil(rule.AtryumLLMConfigID)).
+		Set("atryum_llm_config_id", rule.AtryumLLMConfigID).
 		Set("agent_cuids", agentCUIDsJSON).
 		Set("description", emptyToNil(rule.Description)).
 		Set("enabled", boolToInt(rule.Enabled)).
@@ -386,7 +386,7 @@ func (r *RulesRepo) InsertBefore(ctx context.Context, anchorID string, rule Rule
 		Columns(ruleColumns...).
 		Values(
 			rule.ID, rule.Action, serverJSON, toolJSON, rule.AgentIDPattern,
-			emptyToNil(rule.ModelConfigCUID), emptyToNil(rule.AtryumLLMConfigID), agentCUIDsJSON,
+			emptyToNil(rule.ModelConfigCUID), rule.AtryumLLMConfigID, agentCUIDsJSON,
 			emptyToNil(rule.Description), boolToInt(rule.Enabled), rule.Order, now, now,
 		).ToSql()
 	if err != nil {

--- a/internal/store/rules_test.go
+++ b/internal/store/rules_test.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRulesRepo_CreateVMPathAIEvaluationRule is a regression test for the
+// VM-backend ai_evaluation rule path. Such rules set only ModelConfigCUID and
+// leave AtryumLLMConfigID empty. Migration 018 added atryum_llm_config_id as
+// TEXT NOT NULL DEFAULT '', so writing SQL NULL (the old emptyToNil behavior)
+// for an empty value violated the NOT NULL constraint and made VM-path rules
+// impossible to create. The empty string must be persisted directly instead.
+func TestRulesRepo_CreateVMPathAIEvaluationRule(t *testing.T) {
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+	if err := InitDB(db); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+
+	repo := NewRulesRepo(db)
+	ctx := context.Background()
+
+	rule := Rule{
+		ID:              "rule-vm-path",
+		Action:          "ai_evaluation",
+		ServerPatterns:  []string{},
+		ToolPatterns:    []string{},
+		AgentIDPattern:  "*",
+		ModelConfigCUID: "model-config-cuid-123",
+		// AtryumLLMConfigID intentionally left empty: VM backend path.
+		Enabled: true,
+		Order:   0,
+	}
+
+	if err := repo.Create(ctx, rule); err != nil {
+		t.Fatalf("Create VM-path ai_evaluation rule: %v", err)
+	}
+
+	got, err := repo.Get(ctx, "rule-vm-path")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Action != "ai_evaluation" {
+		t.Errorf("Action = %q, want ai_evaluation", got.Action)
+	}
+	if got.ModelConfigCUID != "model-config-cuid-123" {
+		t.Errorf("ModelConfigCUID = %q, want model-config-cuid-123", got.ModelConfigCUID)
+	}
+	if got.AtryumLLMConfigID != "" {
+		t.Errorf("AtryumLLMConfigID = %q, want empty string", got.AtryumLLMConfigID)
+	}
+}


### PR DESCRIPTION
## Symptom

Creating an `ai_evaluation` approval rule that uses the **VM backend path** (only `model_config_cuid` set, `atryum_llm_config_id` left empty) fails with:

```
NOT NULL constraint failed: approval_rules.atryum_llm_config_id
```

This makes VM-path rules impossible to create. There is no workaround by also setting `atryum_llm_config_id`, because the evaluation dispatcher in `internal/invocation/service.go` treats a non-empty `atryum_llm_config_id` as "use the local LLM path", which would ignore `model_config_cuid`.

## Root cause

Migration `internal/store/migrations/018_rule_llm_config.go` adds the column:

```sql
ALTER TABLE approval_rules ADD COLUMN atryum_llm_config_id TEXT NOT NULL DEFAULT ''
```

But `internal/store/rules.go` wrote this column via `emptyToNil(rule.AtryumLLMConfigID)`, which converts an empty string to SQL `NULL` — violating the `NOT NULL` constraint whenever the value is empty (the VM-path case).

## Fix

Pass `rule.AtryumLLMConfigID` directly at the three write sites — the `Create` insert, the `Update` set, and the `InsertBefore` transactional insert. The column is `NOT NULL DEFAULT ''`, so an empty string is the correct value. `model_config_cuid` is nullable and correctly stays wrapped in `emptyToNil`.

## Test

Adds `TestRulesRepo_CreateVMPathAIEvaluationRule` in `internal/store/rules_test.go`: it creates an `ai_evaluation` rule with only `ModelConfigCUID` set (empty `AtryumLLMConfigID`) and asserts `Create` succeeds and the rule round-trips on read.

Verified against the buggy code, the test reproduces the exact `NOT NULL constraint failed: approval_rules.atryum_llm_config_id` error; with the fix it passes (run in `golang:1.25-alpine` via Docker, matching `go.mod`).
