### PR TITLE
Add Go unit tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,44 @@
+name: Unit tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cmd/**"
+      - "internal/**"
+      - "go.mod"
+      - "go.sum"
+      - "Justfile"
+      - ".github/workflows/unit-tests.yml"
+  pull_request:
+    paths:
+      - "cmd/**"
+      - "internal/**"
+      - "go.mod"
+      - "go.sum"
+      - "Justfile"
+      - ".github/workflows/unit-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unit-tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    name: Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
+
+      - name: Run unit tests
+        run: go test ./...

--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -2,7 +2,6 @@ package invocation_test
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -36,14 +35,7 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	cfg := config.Config{
 		Defaults:  config.DefaultsConfig{RequestTimeoutSeconds: 5},
 		Upstreams: []config.UpstreamConfig{{Name: "demo", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
@@ -125,14 +117,7 @@ func TestInvokeWithoutAgentIDPersistsClientInfoFromRequest(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	cfg := config.Config{
 		Defaults:  config.DefaultsConfig{RequestTimeoutSeconds: 5},
 		Upstreams: []config.UpstreamConfig{{Name: "demo", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
@@ -179,14 +164,7 @@ func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	cfg := config.Config{
 		Defaults:  config.DefaultsConfig{RequestTimeoutSeconds: 5},
 		Upstreams: []config.UpstreamConfig{{Name: "demo", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
@@ -226,14 +204,7 @@ func TestInvokeWithoutAuthFallsBackToRequestIDForRules(t *testing.T) {
 // agents.agent_ids resolution / agent-scoped rule matching all light up.
 // A verified OAuth identity in context still wins when both are present.
 func TestExternalSubmitUsesSelfDeclaredAgentIDWhenNoAuthIdentity(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	svc := invocation.NewService(
 		store.NewInvocationRepo(db), store.NewEventRepo(db), nil,
 		nil, policy.AlwaysApproveProvider{},

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -121,14 +121,7 @@ func TestBusinessToolErrorMarksInvocationFailed(t *testing.T) {
 }
 
 func TestResolverBootstrapsServersFromConfigWhenDBEmpty(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	repo := store.NewServerRepo(db)
 	resolver := mcp.NewResolver(repo, config.Config{Upstreams: []config.UpstreamConfig{{Name: "bootstrap", Mode: "http", BaseURL: "http://example.com", Enabled: true, TimeoutSeconds: 7}}})
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
@@ -147,14 +140,7 @@ func TestResolverBootstrapsServersFromConfigWhenDBEmpty(t *testing.T) {
 }
 
 func TestServerStatusPersistsAfterUpdate(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	repo := store.NewServerRepo(db)
 	upstream := mcp.FromConfig(config.UpstreamConfig{Name: "status-demo", Mode: "http", BaseURL: "http://example.com", Enabled: true, TimeoutSeconds: 5})
 	if err := repo.CreateServer(context.Background(), upstream); err != nil {
@@ -195,14 +181,7 @@ func TestServerStatusPersistsAfterUpdate(t *testing.T) {
 }
 
 func TestSetSummaryPersistsSummaryAndRecordsEvent(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	invRepo := store.NewInvocationRepo(db)
 	eventRepo := store.NewEventRepo(db)
 	service := invocation.NewService(invRepo, eventRepo, nil, nil, policy.AlwaysApproveProvider{}, 5*time.Second, nil, nil, nil, nil)
@@ -251,14 +230,7 @@ func TestSetSummaryPersistsSummaryAndRecordsEvent(t *testing.T) {
 }
 
 func TestSubmitPendingApprovalAutomaticallySummarizesInvocation(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	invRepo := store.NewInvocationRepo(db)
 	eventRepo := store.NewEventRepo(db)
 	service := invocation.NewService(invRepo, eventRepo, nil, nil, nil, 5*time.Second, nil, nil, nil, summarySettingsStub{
@@ -312,14 +284,7 @@ func TestSubmitPendingApprovalAutomaticallySummarizesInvocation(t *testing.T) {
 }
 
 func TestSubmitAIEvaluationUsesDefaultAgentRecordForUnmappedAgentID(t *testing.T) {
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	invRepo := store.NewInvocationRepo(db)
 	eventRepo := store.NewEventRepo(db)
 	evaluator := &evaluateClientStub{
@@ -382,14 +347,7 @@ func TestSubmitAIEvaluationUsesDefaultAgentRecordForUnmappedAgentID(t *testing.T
 
 func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 	t.Helper()
-	db, err := sql.Open("sqlite", ":memory:")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-	if err := store.InitDB(db); err != nil {
-		t.Fatal(err)
-	}
+	db := newSQLiteTestDB(t)
 	serverRepo := store.NewServerRepo(db)
 	resolver := mcp.NewResolver(serverRepo, cfg)
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {

--- a/internal/invocation/testdb_test.go
+++ b/internal/invocation/testdb_test.go
@@ -1,0 +1,24 @@
+package invocation_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"atryum/internal/store"
+)
+
+func newSQLiteTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	if err := store.InitDB(db); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs `go test ./...` for Go unit tests
- share a SQLite test DB helper for invocation tests
- force one SQLite connection for in-memory invocation test DBs so schema state is stable

## Test
- `go test ./...`