### PR TITLE
Guard against duplicate agent_ids across agents

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -2694,6 +2694,15 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "invalid json")
 			return
 		}
+		if req.AgentIDs != nil && len(req.AgentIDs) > 0 {
+			if conflictID, ownerName, err := h.agentsRepo.CheckAgentIDConflict(r.Context(), id, req.AgentIDs); err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to check agent ID conflicts")
+				return
+			} else if conflictID != "" {
+				writeError(w, http.StatusConflict, fmt.Sprintf("agent ID %q is already claimed by agent %q", conflictID, ownerName))
+				return
+			}
+		}
 		if err := h.agentsRepo.UpdateEnabled(r.Context(), id, req.Enabled); err != nil {
 			status := http.StatusInternalServerError
 			if err == sql.ErrNoRows {
@@ -2703,15 +2712,6 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if req.AgentIDs != nil {
-			if len(req.AgentIDs) > 0 {
-				if conflictID, ownerName, err := h.agentsRepo.CheckAgentIDConflict(r.Context(), id, req.AgentIDs); err != nil {
-					writeError(w, http.StatusInternalServerError, "failed to check agent ID conflicts")
-					return
-				} else if conflictID != "" {
-					writeError(w, http.StatusConflict, fmt.Sprintf("agent ID %q is already claimed by agent %q", conflictID, ownerName))
-					return
-				}
-			}
 			idsJSON, err := json.Marshal(req.AgentIDs)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "failed to encode agent_ids")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -90,6 +90,7 @@ type agentsRepo interface {
 	Get(ctx context.Context, id string) (store.AgentRecord, error)
 	GetByAgentID(ctx context.Context, agentID string) (store.AgentRecord, error)
 	GetByVMCUID(ctx context.Context, vmCUID string) (store.AgentRecord, error)
+	CheckAgentIDConflict(ctx context.Context, excludeID string, agentIDs []string) (conflictID, ownerName string, err error)
 	UpdateEnabled(ctx context.Context, id string, enabled bool) error
 	UpdateAgentIDs(ctx context.Context, id string, agentIDs string) error
 	UpdateMeta(ctx context.Context, id, name, description, charter string) error
@@ -399,7 +400,16 @@ func parseAgentIDs(raw string) []string {
 	if ids == nil {
 		return []string{}
 	}
-	return ids
+	// Deduplicate while preserving order.
+	seen := make(map[string]struct{}, len(ids))
+	out := ids[:0]
+	for _, id := range ids {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 const agentRulesToolName = "atryum.rules.get"
@@ -2582,6 +2592,15 @@ func (h *Handler) adminAgents(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "name is required")
 			return
 		}
+		if len(req.AgentIDs) > 0 {
+			if conflictID, ownerName, err := h.agentsRepo.CheckAgentIDConflict(r.Context(), "", req.AgentIDs); err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to check agent ID conflicts")
+				return
+			} else if conflictID != "" {
+				writeError(w, http.StatusConflict, fmt.Sprintf("agent ID %q is already claimed by agent %q", conflictID, ownerName))
+				return
+			}
+		}
 		id := uuid.New().String()
 		agentIDsJSON := "[]"
 		if len(req.AgentIDs) > 0 {
@@ -2684,6 +2703,15 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if req.AgentIDs != nil {
+			if len(req.AgentIDs) > 0 {
+				if conflictID, ownerName, err := h.agentsRepo.CheckAgentIDConflict(r.Context(), id, req.AgentIDs); err != nil {
+					writeError(w, http.StatusInternalServerError, "failed to check agent ID conflicts")
+					return
+				} else if conflictID != "" {
+					writeError(w, http.StatusConflict, fmt.Sprintf("agent ID %q is already claimed by agent %q", conflictID, ownerName))
+					return
+				}
+			}
 			idsJSON, err := json.Marshal(req.AgentIDs)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "failed to encode agent_ids")

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -312,6 +312,21 @@ func (s *stubAgentsRepo) UpdateAgentIDs(context.Context, string, string) error {
 func (s *stubAgentsRepo) UpdateMeta(context.Context, string, string, string, string) error {
 	return nil
 }
+func (s *stubAgentsRepo) CheckAgentIDConflict(_ context.Context, excludeID string, agentIDs []string) (string, string, error) {
+	for _, id := range agentIDs {
+		for _, r := range s.records {
+			if r.ID == excludeID {
+				continue
+			}
+			for _, rid := range parseAgentIDs(r.AgentIDs) {
+				if rid == id {
+					return id, r.VMName, nil
+				}
+			}
+		}
+	}
+	return "", "", nil
+}
 func (s *stubAgentsRepo) Create(_ context.Context, _ store.AgentRecord) error { return nil }
 func (s *stubAgentsRepo) Delete(context.Context, string) error                { return nil }
 func (s *stubAgentsRepo) DeleteSynced(context.Context) error                  { return nil }

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -162,17 +162,39 @@ func (r *AgentsRepo) GetByVMCUID(ctx context.Context, vmCUID string) (AgentRecor
 
 // GetByAgentID returns the agent record whose agent_ids JSON array contains the
 // given agentID string. Returns sql.ErrNoRows when no match is found.
+// ORDER BY id ensures deterministic results when multiple agents share the same
+// agent_id (which is a misconfiguration, but we handle it gracefully).
 func (r *AgentsRepo) GetByAgentID(ctx context.Context, agentID string) (AgentRecord, error) {
 	cols := strings.Join(agentColumns, ", ")
 	var query string
 	if r.dialect == DialectPostgres {
 		// PostgreSQL: use the @> containment operator on JSONB.
-		query = `SELECT ` + cols + ` FROM agents WHERE agent_ids @> to_jsonb($1::text)::jsonb LIMIT 1`
+		query = `SELECT ` + cols + ` FROM agents WHERE agent_ids @> to_jsonb($1::text)::jsonb ORDER BY id LIMIT 1`
 	} else {
 		// SQLite: use json_each to expand the array and match the value.
-		query = `SELECT ` + cols + ` FROM agents WHERE EXISTS (SELECT 1 FROM json_each(agent_ids) WHERE value = ?) LIMIT 1`
+		query = `SELECT ` + cols + ` FROM agents WHERE EXISTS (SELECT 1 FROM json_each(agent_ids) WHERE value = ?) ORDER BY id LIMIT 1`
 	}
 	return scanAgent(r.db.QueryRowContext(ctx, query, agentID))
+}
+
+// CheckAgentIDConflict checks whether any of the given agentIDs are already
+// claimed by an agent other than the one with excludeID. It returns the first
+// conflicting agentID and the name of the owning agent, or empty strings when
+// no conflict exists. Pass an empty excludeID when creating a new agent.
+func (r *AgentsRepo) CheckAgentIDConflict(ctx context.Context, excludeID string, agentIDs []string) (conflictID, ownerName string, err error) {
+	for _, id := range agentIDs {
+		record, rerr := r.GetByAgentID(ctx, id)
+		if rerr == sql.ErrNoRows {
+			continue
+		}
+		if rerr != nil {
+			return "", "", rerr
+		}
+		if record.ID != excludeID {
+			return id, record.VMName, nil
+		}
+	}
+	return "", "", nil
 }
 
 // Create inserts a new manually-created agent record. The caller is responsible

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -61,6 +61,12 @@ const formatDate = (iso: string): string => {
 };
 
 const errorMessage = (err: unknown, fallback: string): string => {
+  // Prefer the API response body: { error: { message: "..." } }
+  if (typeof err === 'object' && err !== null) {
+    const apiMsg = (err as { response?: { data?: { error?: { message?: unknown } } } }).response
+      ?.data?.error?.message;
+    if (typeof apiMsg === 'string' && apiMsg) return apiMsg;
+  }
   if (err instanceof Error) return err.message;
   if (typeof err === 'object' && err !== null && 'message' in err) {
     const msg = (err as { message: unknown }).message;
@@ -76,6 +82,8 @@ type CreateAgentModalProps = {
   onClose: () => void;
 };
 
+type StatusMsg = { text: string; isError: boolean; lines?: string[] };
+
 const CreateAgentModal: React.FC<CreateAgentModalProps> = ({ isOpen, onClose }) => {
   const [form, setForm] = useState<AgentCreateInput>({
     name: '',
@@ -84,8 +92,9 @@ const CreateAgentModal: React.FC<CreateAgentModalProps> = ({ isOpen, onClose }) 
     enabled: true,
     agent_ids: [],
   });
-  const [statusMsg, setStatusMsg] = useState<{ text: string; isError: boolean } | null>(null);
+  const [statusMsg, setStatusMsg] = useState<StatusMsg | null>(null);
   const createMutation = useCreateAgent();
+  const { data: agentsData } = useAgents();
   const noOptionsMessage = useCallback(() => null, []);
 
   const handleClose = () => {
@@ -97,6 +106,18 @@ const CreateAgentModal: React.FC<CreateAgentModalProps> = ({ isOpen, onClose }) 
   const handleCreate = async () => {
     if (!form.name.trim()) {
       setStatusMsg({ text: 'Name is required.', isError: true });
+      return;
+    }
+    const conflicts = (form.agent_ids ?? []).flatMap((id) => {
+      const owner = agentsData?.items.find((a) => a.agent_ids.includes(id));
+      return owner ? [`${id} is already in use by "${owner.name}"`] : [];
+    });
+    if (conflicts.length > 0) {
+      setStatusMsg({
+        text: 'Agent ID(s) already in use by another agent:',
+        lines: conflicts,
+        isError: true,
+      });
       return;
     }
     try {
@@ -118,7 +139,18 @@ const CreateAgentModal: React.FC<CreateAgentModalProps> = ({ isOpen, onClose }) 
             {statusMsg && (
               <Alert status={statusMsg.isError ? 'error' : 'success'} borderRadius="md" py={2}>
                 <AlertIcon />
-                <AlertDescription fontSize="sm">{statusMsg.text}</AlertDescription>
+                <AlertDescription fontSize="sm">
+                  <Text>{statusMsg.text}</Text>
+                  {statusMsg.lines && (
+                    <Stack as="ul" mt={1} gap={0} pl={4} listStyleType="disc">
+                      {statusMsg.lines.map((line) => (
+                        <Text as="li" key={line} fontSize="sm">
+                          {line}
+                        </Text>
+                      ))}
+                    </Stack>
+                  )}
+                </AlertDescription>
               </Alert>
             )}
             <FormControl isRequired>
@@ -209,14 +241,27 @@ const EditAgentModal: React.FC<EditAgentModalProps> = ({ agent, isOpen, onClose 
   const [charter, setCharter] = useState(agent.charter ?? '');
   const [enabled, setEnabled] = useState(agent.enabled);
   const [agentIDs, setAgentIDs] = useState<string[]>(agent.agent_ids);
-  const [statusMsg, setStatusMsg] = useState<{ text: string; isError: boolean } | null>(null);
+  const [statusMsg, setStatusMsg] = useState<StatusMsg | null>(null);
 
   const updateMutation = useUpdateAgent();
   const deleteMutation = useDeleteAgent();
+  const { data: agentsData } = useAgents();
 
   const handleUpdate = async () => {
     if (!name.trim()) {
       setStatusMsg({ text: 'Name is required.', isError: true });
+      return;
+    }
+    const conflicts = agentIDs.flatMap((id) => {
+      const owner = agentsData?.items.find((a) => a.cuid !== agent.cuid && a.agent_ids.includes(id));
+      return owner ? [`${id} is already in use by "${owner.name}"`] : [];
+    });
+    if (conflicts.length > 0) {
+      setStatusMsg({
+        text: 'Agent ID(s) already in use by another agent:',
+        lines: conflicts,
+        isError: true,
+      });
       return;
     }
     const input: AgentUpdateInput = { name, description, enabled, agent_ids: agentIDs, charter };
@@ -254,7 +299,18 @@ const EditAgentModal: React.FC<EditAgentModalProps> = ({ agent, isOpen, onClose 
             {statusMsg && (
               <Alert status={statusMsg.isError ? 'error' : 'success'} borderRadius="md" py={2}>
                 <AlertIcon />
-                <AlertDescription fontSize="sm">{statusMsg.text}</AlertDescription>
+                <AlertDescription fontSize="sm">
+                  <Text>{statusMsg.text}</Text>
+                  {statusMsg.lines && (
+                    <Stack as="ul" mt={1} gap={0} pl={4} listStyleType="disc">
+                      {statusMsg.lines.map((line) => (
+                        <Text as="li" key={line} fontSize="sm">
+                          {line}
+                        </Text>
+                      ))}
+                    </Stack>
+                  )}
+                </AlertDescription>
               </Alert>
             )}
 

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -276,6 +276,11 @@ const Invocations: React.FC = () => {
     const map = new Map<string, { cuid: string; name: string }>();
     for (const agent of agentsData?.items ?? []) {
       for (const id of agent.agent_ids) {
+        if (map.has(id)) {
+          console.warn(
+            `[Atryum] Duplicate agent_id "${id}" found on agent "${agent.name}" — already claimed by "${map.get(id)!.name}". This is a misconfiguration; only one agent should own each agent_id.`,
+          );
+        }
         map.set(id, { cuid: agent.cuid, name: agent.name });
       }
     }


### PR DESCRIPTION
## Summary

- **Backend conflict check**: `CheckAgentIDConflict` added to `AgentsRepo`; called in both `POST` and `PATCH /api/v1/admin/agents` before writing — returns `409 Conflict` with a message naming the conflicting ID and its owner agent.
- **Deterministic fallback**: `GetByAgentID` now includes `ORDER BY id` so behaviour is consistent if duplicates somehow reach the DB.
- **Intra-record dedup**: `parseAgentIDs` deduplicates within a single agent's array, preventing badge-count inflation.
- **UI validation**: `CreateAgentModal` and `EditAgentModal` check the cached agent list before submitting; on conflict the error alert lists each duplicate ID and the agent that owns it (e.g. _vmclient is already in use by "AMP"_).
- **Better error extraction**: `errorMessage` helper now prefers `err.response.data.error.message` (the API body) over the raw axios status line, so backend errors like `409` surface their human-readable text.
- **Observability**: `agentByAgentID` in `Invocations.tsx` logs a `console.warn` when a collision is detected.

## Test plan

- [ ] Create two agents; add the same agent ID to both — confirm the second save is blocked with the descriptive error in the UI
- [ ] Verify the same ID can be re-saved on the agent that already owns it (edit modal excludes self from the check)
- [ ] Confirm `go test ./internal/...` passes
- [ ] Confirm the Invocations page still resolves agent badges correctly with non-duplicate data

Made with [Cursor](https://cursor.com)