### PR TITLE
ci: publish atryum image to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,65 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to push (defaults to 'latest')"
+        required: false
+        default: latest
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-push:
+    name: Build and push to Docker Hub
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: validmind/atryum
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.prod
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds the production atryum image from `Dockerfile.prod` and publishes it to Docker Hub under `validmind/atryum`.

## Changes

- New workflow `.github/workflows/docker-publish.yml`
- Multi-arch builds (`linux/amd64`, `linux/arm64`) via QEMU + Buildx
- Tags derived with `docker/metadata-action`:
  - push to `main` → `latest`, `main`, `sha-<short>`
  - `v*` tags → semver (`1.2.3`, `1.2`) + `sha-<short>`
  - manual `workflow_dispatch` → custom tag input (defaults to `latest`)
- GitHub Actions build cache to speed up rebuilds

## Notes

The org `gha-workflows` reusable build/push workflows target AWS ECR only, so a standalone workflow is used here to reach the Docker Hub destination.

## Requirements

Repo/org secrets must be set: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`.