### PR TITLE
fix(pi): Add judge reject reason in pi agent hook

### DIFF
--- a/examples/pi-extension/index.ts
+++ b/examples/pi-extension/index.ts
@@ -24,6 +24,9 @@ type InvocationStatus =
 type InvocationResponse = {
   invocation_id: string;
   status: InvocationStatus;
+  approval?: {
+    reason?: string;
+  };
   error?: unknown;
 };
 
@@ -156,9 +159,12 @@ export default function (pi: ExtensionAPI) {
 
       invocationMap.delete(event.toolCallId);
       ctx.ui.setStatus("atryum", `blocked ${event.toolName}`);
+      const reviewerReason = decided.approval?.reason
+        ? ` Reason: ${decided.approval.reason}`
+        : "";
       return {
         block: true,
-        reason: `atryum: tool call '${event.toolName}' was ${decided.status} by reviewer.`,
+        reason: `atryum: tool call '${event.toolName}' was ${decided.status} by reviewer.${reviewerReason}`,
       };
     } catch (err) {
       ctx.ui.setStatus("atryum", "gate failed");


### PR DESCRIPTION
The llm judge returns a reject reason, but `pi` only ever saw ` atryum: tool call 'bash' was denied by reviewer.` This exposes the reason back to the agent to adjust their behavior.