### PR TITLE
feat(judge): Add tool call tool description to judge context

### DIFF
--- a/internal/invocation/local_evaluator.go
+++ b/internal/invocation/local_evaluator.go
@@ -100,10 +100,14 @@ func (e *LocalEvaluatorClient) EvaluateToolCall(ctx context.Context, req Evaluat
 
 func (e *LocalEvaluatorClient) buildUserMessage(req EvaluateRequest) string {
 	toolArgsJSON, _ := json.Marshal(req.ToolArgs)
-	return fmt.Sprintf(
+	msg := fmt.Sprintf(
 		"Tool call to evaluate:\n- Server: %s\n- Tool: %s\n- Arguments: %s",
 		req.ServerName, req.ToolName, string(toolArgsJSON),
 	)
+	if ctx := strings.TrimSpace(req.Context); ctx != "" {
+		msg += "\n\nAdditional context:\n" + ctx
+	}
+	return msg
 }
 
 // callOpenAI calls the OpenAI chat completions API (or any compatible endpoint).

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -163,6 +163,13 @@ type upstreamClient interface {
 	ForwardEnvelope(ctx context.Context, upstream mcp.Upstream, envelope mcp.Envelope, protocolVersion string) (mcp.ForwardResult, error)
 }
 
+const toolCatalogTTL = 5 * time.Minute
+
+type toolCatalogEntry struct {
+	tools     map[string]mcp.Tool
+	fetchedAt time.Time
+}
+
 type Service struct {
 	invocations      invocationRepo
 	events           eventRepo
@@ -177,6 +184,9 @@ type Service struct {
 	defaultTimeout   time.Duration
 	mu               sync.Mutex
 	pendingApprovals map[string]chan approvalDecision
+
+	toolCatalogMu sync.Mutex
+	toolCatalog   map[string]toolCatalogEntry
 }
 
 func NewService(
@@ -203,6 +213,7 @@ func NewService(
 		syncSettings:     syncSettings,
 		defaultTimeout:   defaultTimeout,
 		pendingApprovals: make(map[string]chan approvalDecision),
+		toolCatalog:      make(map[string]toolCatalogEntry),
 	}
 }
 
@@ -389,6 +400,64 @@ func (s *Service) resolveAgentRecord(ctx context.Context, agentID string) AgentR
 	return rec
 }
 
+func (s *Service) lookupToolInfo(ctx context.Context, serverName, toolName string) (mcp.Tool, bool) {
+	if serverName == "" || toolName == "" || s.resolver == nil || s.client == nil {
+		return mcp.Tool{}, false
+	}
+
+	s.toolCatalogMu.Lock()
+	entry, ok := s.toolCatalog[serverName]
+	fresh := ok && time.Since(entry.fetchedAt) < toolCatalogTTL
+	s.toolCatalogMu.Unlock()
+
+	if fresh {
+		tool, found := entry.tools[toolName]
+		return tool, found
+	}
+
+	upstream, err := s.resolver.ResolveContext(ctx, serverName)
+	if err != nil {
+		return mcp.Tool{}, false
+	}
+
+	listCtx, cancel := context.WithTimeout(ctx, s.defaultTimeout)
+	defer cancel()
+	tools, err := s.client.ListTools(listCtx, upstream)
+	if err != nil {
+		slog.Warn("ai_evaluation: tools/list failed; judge will run without tool description",
+			"server", serverName, "tool", toolName, "error", err)
+		return mcp.Tool{}, false
+	}
+
+	byName := make(map[string]mcp.Tool, len(tools))
+	for _, t := range tools {
+		byName[t.Name] = t
+	}
+	s.toolCatalogMu.Lock()
+	s.toolCatalog[serverName] = toolCatalogEntry{tools: byName, fetchedAt: time.Now()}
+	s.toolCatalogMu.Unlock()
+
+	tool, found := byName[toolName]
+	return tool, found
+}
+
+func buildEvaluationContext(tool mcp.Tool) string {
+	var sb strings.Builder
+	desc := strings.TrimSpace(tool.Description)
+	if desc != "" {
+		sb.WriteString("Tool description: ")
+		sb.WriteString(desc)
+	}
+	if len(tool.InputSchema) > 0 {
+		if sb.Len() > 0 {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString("Tool input schema (JSON Schema):\n")
+		sb.Write(tool.InputSchema)
+	}
+	return sb.String()
+}
+
 // runAIEvaluation dispatches to either the VM backend evaluator (when
 // rule.ModelConfigCUID is set) or the local LLM evaluator (when
 // rule.AtryumLLMConfigID is set). Falls back to DispositionHuman on any error
@@ -398,6 +467,11 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 		slog.Warn("ai_evaluation rule matched but no evaluator configured; falling back to human_approval",
 			"rule_id", rule.ID, "tool", toolName, "server", serverName)
 		return policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: evaluator not configured (falling back to human_approval)"}, nil
+	}
+
+	evalContext := ""
+	if tool, ok := s.lookupToolInfo(ctx, serverName, toolName); ok {
+		evalContext = buildEvaluationContext(tool)
 	}
 
 	// --- Local LLM path ---
@@ -428,6 +502,7 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 			ServerName:        serverName,
 			ToolName:          toolName,
 			ToolArgs:          toolArgs,
+			Context:           evalContext,
 		})
 		if err != nil {
 			slog.Error("ai_evaluation (local): LLM call failed; falling back to human_approval",
@@ -494,6 +569,7 @@ func (s *Service) runAIEvaluation(ctx context.Context, rule *ApprovalRule, serve
 		ServerName:      serverName,
 		ToolName:        toolName,
 		ToolArgs:        toolArgs,
+		Context:         evalContext,
 	})
 	if err != nil {
 		slog.Error("ai_evaluation: LLM evaluation failed; falling back to human_approval",

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -387,6 +387,166 @@ func TestSubmitAIEvaluationUsesDefaultAgentRecordForUnmappedAgentID(t *testing.T
 	}
 }
 
+func TestInvokeAIEvaluationIncludesToolDescriptionInContext(t *testing.T) {
+	toolDescription := "Attach an external URL reference to a Shortcut story. Non-destructive."
+	toolSchema := `{"type":"object","properties":{"story_public_id":{"type":"integer"},"url":{"type":"string"}}}`
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		switch body["method"] {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": body["id"],
+				"result": map[string]any{
+					"serverInfo":   map[string]any{"name": "fake-shortcut", "version": "0.1.0"},
+					"capabilities": map[string]any{},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": body["id"],
+				"result": map[string]any{"tools": []map[string]any{{
+					"name":        "stories-add-external-link",
+					"description": toolDescription,
+					"inputSchema": json.RawMessage(toolSchema),
+				}}},
+			})
+		case "tools/call":
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": body["id"], "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+		default:
+			t.Errorf("unexpected method: %v", body["method"])
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer upstream.Close()
+
+	db := newSQLiteTestDB(t)
+	serverRepo := store.NewServerRepo(db)
+	resolver := mcp.NewResolver(serverRepo, config.Config{
+		Upstreams: []config.UpstreamConfig{{Name: "shortcut", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+	})
+	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	evaluator := &evaluateClientStub{
+		resp: invocation.EvaluateResponse{Verdict: "approved", Reason: "charter allows non-destructive link operations"},
+	}
+	defaultAgent := invocation.AgentRecord{
+		ID:                 "agent-local-default",
+		VMCUID:             "agent-vm-default",
+		VMOrganizationCUID: "org-default",
+		Charter:            "Deny destructive tool calls, otherwise approve.",
+	}
+
+	service := invocation.NewService(
+		store.NewInvocationRepo(db),
+		store.NewEventRepo(db),
+		resolver,
+		mcp.NewHTTPClient(),
+		nil,
+		5*time.Second,
+		rulesStoreStub{rules: []invocation.ApprovalRule{{
+			Action:          invocation.RuleActionAIEvaluation,
+			ServerPatterns:  []string{"shortcut"},
+			ToolPatterns:    []string{"stories-add-external-link"},
+			ModelConfigCUID: "model-ai",
+			Enabled:         true,
+		}}},
+		agentLookupStub{byVMCUID: map[string]invocation.AgentRecord{defaultAgent.VMCUID: defaultAgent}},
+		evaluator,
+		summarySettingsStub{
+			charterFieldKey:    "constitution",
+			defaultAgentVMCUID: defaultAgent.VMCUID,
+		},
+	)
+
+	resp, err := service.Invoke(context.Background(), invocation.CreateInvocationRequest{
+		Server: "shortcut",
+		Tool:   "stories-add-external-link",
+		Input:  map[string]any{"story_public_id": 16782, "url": "https://example.com"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusSucceeded {
+		t.Fatalf("status = %q, want succeeded", resp.Status)
+	}
+
+	req := evaluator.request()
+	if req.Context == "" {
+		t.Fatalf("EvaluateRequest.Context is empty; expected tool description")
+	}
+	if !strings.Contains(req.Context, toolDescription) {
+		t.Fatalf("EvaluateRequest.Context missing tool description; got %q", req.Context)
+	}
+	if !strings.Contains(req.Context, "story_public_id") {
+		t.Fatalf("EvaluateRequest.Context missing input schema; got %q", req.Context)
+	}
+}
+
+func TestInvokeAIEvaluationToleratesMissingToolDescription(t *testing.T) {
+	// When tools/list fails or omits the tool, evaluation must still run —
+	// just without the context enrichment.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		switch body["method"] {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": body["id"], "result": map[string]any{"serverInfo": map[string]any{"name": "fake", "version": "0.1.0"}, "capabilities": map[string]any{}}})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/list":
+			w.WriteHeader(http.StatusInternalServerError)
+		case "tools/call":
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": body["id"], "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+		}
+	}))
+	defer upstream.Close()
+
+	db := newSQLiteTestDB(t)
+	serverRepo := store.NewServerRepo(db)
+	resolver := mcp.NewResolver(serverRepo, config.Config{
+		Upstreams: []config.UpstreamConfig{{Name: "shortcut", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+	})
+	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	evaluator := &evaluateClientStub{resp: invocation.EvaluateResponse{Verdict: "approved", Reason: "ok"}}
+	defaultAgent := invocation.AgentRecord{ID: "a", VMCUID: "vm-a", VMOrganizationCUID: "org", Charter: "c"}
+	service := invocation.NewService(
+		store.NewInvocationRepo(db),
+		store.NewEventRepo(db),
+		resolver,
+		mcp.NewHTTPClient(),
+		nil,
+		5*time.Second,
+		rulesStoreStub{rules: []invocation.ApprovalRule{{Action: invocation.RuleActionAIEvaluation, ServerPatterns: []string{"shortcut"}, ToolPatterns: []string{"stories-search"}, ModelConfigCUID: "m", Enabled: true}}},
+		agentLookupStub{byVMCUID: map[string]invocation.AgentRecord{defaultAgent.VMCUID: defaultAgent}},
+		evaluator,
+		summarySettingsStub{charterFieldKey: "constitution", defaultAgentVMCUID: defaultAgent.VMCUID},
+	)
+
+	resp, err := service.Invoke(context.Background(), invocation.CreateInvocationRequest{Server: "shortcut", Tool: "stories-search", Input: map[string]any{"q": "x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusSucceeded {
+		t.Fatalf("status = %q", resp.Status)
+	}
+	if evaluator.request().Context != "" {
+		t.Fatalf("expected empty Context when tools/list fails, got %q", evaluator.request().Context)
+	}
+}
+
 func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 	t.Helper()
 	db := newSQLiteTestDB(t)


### PR DESCRIPTION
I observed behavior of the judge flapping on denying/approving the same tool calls due to ambiguity of the available context info about the tool call as it related to the constitution, because the judge didn't have enough information about the tool's purpose.

This PR adds the tool description to the context so the judge has more to go off of.