### PR TITLE
fix(oauth): Refresh OAuth tokens for MCP upstreams

### DIFF
--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -162,11 +162,11 @@ func runServer(args []string) error {
 			}
 		}
 	}
-	resolver := mcp.NewResolver(serverRepo, cfg).WithCredentials(credentialAdapter{repo: oauthRepo})
+	client := mcp.NewHTTPClient()
+	resolver := mcp.NewResolver(serverRepo, cfg).WithCredentials(store.NewRefreshingOAuthCredentialStore(oauthRepo, client))
 	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
 		return fmt.Errorf("bootstrap servers: %w", err)
 	}
-	client := mcp.NewHTTPClient()
 
 	manualApproval := policy.ManualApprovalProvider{}
 	policyRegistry := policy.NewRegistry(
@@ -622,19 +622,4 @@ func emptyDefault(value, fallback string) string {
 		return fallback
 	}
 	return value
-}
-
-// credentialAdapter bridges store.OAuthRepo into the narrow
-// mcp.CredentialStore interface the resolver consumes. Keeps the mcp
-// package independent of the concrete OAuthRepo/OAuthCredential types.
-type credentialAdapter struct {
-	repo *store.OAuthRepo
-}
-
-func (a credentialAdapter) GetCredential(ctx context.Context, serverName string) (mcp.AccessTokenView, error) {
-	cred, err := a.repo.GetCredential(ctx, serverName)
-	if err != nil {
-		return mcp.AccessTokenView{}, err
-	}
-	return mcp.AccessTokenView{AccessToken: cred.AccessToken}, nil
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3139,7 +3139,7 @@ func (s *ServerAdminService) Test(ctx context.Context, name string) (ServerTestR
 	if err != nil {
 		return ServerTestResponse{}, err
 	}
-	if token, tokenErr := s.oauthRepo.GetCredential(ctx, name); tokenErr == nil {
+	if token, tokenErr := store.NewRefreshingOAuthCredentialStore(s.oauthRepo, s.client).GetCredential(ctx, upstream); tokenErr == nil {
 		upstream.AuthToken = token.AccessToken
 	}
 	testCtx, cancel := context.WithTimeout(ctx, s.timeout)

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -203,9 +203,10 @@ type ServerFilter struct {
 // requests (tools/list, tools/call, forward) get the live access token
 // attached. The interface is intentionally narrow — the resolver does not
 // need to know about refresh tokens or expiry; that's the credential
-// store's problem.
+// store's problem. The upstream is passed so the store can refresh with the
+// correct token endpoint/client credentials when needed.
 type CredentialStore interface {
-	GetCredential(ctx context.Context, serverName string) (AccessTokenView, error)
+	GetCredential(ctx context.Context, upstream Upstream) (AccessTokenView, error)
 }
 
 type AccessTokenView struct {
@@ -326,7 +327,7 @@ func (r *Resolver) overlayCredential(ctx context.Context, upstream Upstream) Ups
 	if r.credentials == nil {
 		return upstream
 	}
-	cred, err := r.credentials.GetCredential(ctx, upstream.Name)
+	cred, err := r.credentials.GetCredential(ctx, upstream)
 	if err != nil || strings.TrimSpace(cred.AccessToken) == "" {
 		return upstream
 	}
@@ -457,6 +458,45 @@ func (c *Client) ExchangeOAuthCode(ctx context.Context, upstream Upstream, code 
 	defer resp.Body.Close()
 	bodyBytes, _ := io.ReadAll(resp.Body)
 	c.debugf("oauth token exchange response server=%s status=%d body=%s", upstream.Name, resp.StatusCode, truncateForLog(bodyBytes, 600))
+	return parseOAuthTokenResponse(resp.StatusCode, bodyBytes, "oauth token exchange")
+}
+
+func (c *Client) RefreshOAuthToken(ctx context.Context, upstream Upstream, refreshToken string) (OAuthToken, error) {
+	if strings.TrimSpace(upstream.OAuthTokenURL) == "" {
+		return OAuthToken{}, fmt.Errorf("oauth_token_url is required")
+	}
+	if strings.TrimSpace(upstream.OAuthClientID) == "" {
+		return OAuthToken{}, fmt.Errorf("oauth client id is required")
+	}
+	if strings.TrimSpace(refreshToken) == "" {
+		return OAuthToken{}, fmt.Errorf("oauth refresh token is required")
+	}
+	values := url.Values{}
+	values.Set("grant_type", "refresh_token")
+	values.Set("refresh_token", refreshToken)
+	values.Set("client_id", upstream.OAuthClientID)
+	if strings.TrimSpace(upstream.OAuthClientSecret) != "" {
+		values.Set("client_secret", upstream.OAuthClientSecret)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, upstream.OAuthTokenURL, strings.NewReader(values.Encode()))
+	if err != nil {
+		return OAuthToken{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	c.debugf("oauth token refresh server=%s token_url=%s client_id=%s has_secret=%t", upstream.Name, upstream.OAuthTokenURL, upstream.OAuthClientID, strings.TrimSpace(upstream.OAuthClientSecret) != "")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.debugf("oauth token refresh transport error server=%s err=%v", upstream.Name, err)
+		return OAuthToken{}, err
+	}
+	defer resp.Body.Close()
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	c.debugf("oauth token refresh response server=%s status=%d body=%s", upstream.Name, resp.StatusCode, truncateForLog(bodyBytes, 600))
+	return parseOAuthTokenResponse(resp.StatusCode, bodyBytes, "oauth token refresh")
+}
+
+func parseOAuthTokenResponse(statusCode int, bodyBytes []byte, operation string) (OAuthToken, error) {
 	var payload struct {
 		AccessToken      string `json:"access_token"`
 		RefreshToken     string `json:"refresh_token"`
@@ -467,22 +507,22 @@ func (c *Client) ExchangeOAuthCode(ctx context.Context, upstream Upstream, code 
 		ErrorDescription string `json:"error_description"`
 	}
 	_ = json.Unmarshal(bodyBytes, &payload)
-	if resp.StatusCode >= http.StatusBadRequest || payload.Error != "" || payload.AccessToken == "" {
-		// Surface as much of the AS response as we can — the bare status is
-		// useless for diagnosing why an OAuth exchange failed.
+	if statusCode >= http.StatusBadRequest || payload.Error != "" || payload.AccessToken == "" {
+		// Surface as much of the AS response as we can; the bare status is
+		// useless for diagnosing why an OAuth token request failed.
 		snippet := strings.TrimSpace(string(bodyBytes))
 		if len(snippet) > 400 {
 			snippet = snippet[:400] + "…"
 		}
 		switch {
 		case payload.Error != "" && payload.ErrorDescription != "":
-			return OAuthToken{}, fmt.Errorf("oauth token exchange failed (status %d): %s — %s", resp.StatusCode, payload.Error, payload.ErrorDescription)
+			return OAuthToken{}, fmt.Errorf("%s failed (status %d): %s — %s", operation, statusCode, payload.Error, payload.ErrorDescription)
 		case payload.Error != "":
-			return OAuthToken{}, fmt.Errorf("oauth token exchange failed (status %d): %s", resp.StatusCode, payload.Error)
+			return OAuthToken{}, fmt.Errorf("%s failed (status %d): %s", operation, statusCode, payload.Error)
 		case snippet != "":
-			return OAuthToken{}, fmt.Errorf("oauth token exchange failed (status %d): %s", resp.StatusCode, snippet)
+			return OAuthToken{}, fmt.Errorf("%s failed (status %d): %s", operation, statusCode, snippet)
 		default:
-			return OAuthToken{}, fmt.Errorf("oauth token exchange failed with status %d (empty body)", resp.StatusCode)
+			return OAuthToken{}, fmt.Errorf("%s failed with status %d (empty body)", operation, statusCode)
 		}
 	}
 	var expiresAt *time.Time

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -66,6 +67,54 @@ func TestConnectionDebugLogsHTTPProbeWithoutSecrets(t *testing.T) {
 	for _, secret := range []string{"secret-token", "super-secret"} {
 		if strings.Contains(got, secret) {
 			t.Fatalf("expected logs to redact %q, got:\n%s", secret, got)
+		}
+	}
+}
+
+func TestRefreshOAuthTokenSendsRefreshGrant(t *testing.T) {
+	var form url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Fatalf("content-type = %q", got)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		form = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access-new","refresh_token":"refresh-new","token_type":"Bearer","scope":"openid","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient()
+	client.httpClient = server.Client()
+	token, err := client.RefreshOAuthToken(context.Background(), Upstream{
+		Name:              "shortcut",
+		OAuthTokenURL:     server.URL,
+		OAuthClientID:     "client-id",
+		OAuthClientSecret: "client-secret",
+	}, "refresh-old")
+	if err != nil {
+		t.Fatalf("RefreshOAuthToken: %v", err)
+	}
+	if token.AccessToken != "access-new" || token.RefreshToken != "refresh-new" {
+		t.Fatalf("unexpected token: %#v", token)
+	}
+	if token.ExpiresAt == nil {
+		t.Fatal("expected expires_at to be set")
+	}
+	want := map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": "refresh-old",
+		"client_id":     "client-id",
+		"client_secret": "client-secret",
+	}
+	for key, value := range want {
+		if got := form.Get(key); got != value {
+			t.Fatalf("form[%s] = %q, want %q; form=%v", key, got, value, form)
 		}
 	}
 }

--- a/internal/store/oauth_refresh.go
+++ b/internal/store/oauth_refresh.go
@@ -1,0 +1,121 @@
+package store
+
+import (
+	"context"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"atryum/internal/mcp"
+)
+
+const defaultOAuthRefreshSkew = 2 * time.Minute
+
+type OAuthTokenRefresher interface {
+	RefreshOAuthToken(ctx context.Context, upstream mcp.Upstream, refreshToken string) (mcp.OAuthToken, error)
+}
+
+type RefreshingOAuthCredentialStore struct {
+	repo      *OAuthRepo
+	refresher OAuthTokenRefresher
+	skew      time.Duration
+
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+func NewRefreshingOAuthCredentialStore(repo *OAuthRepo, refresher OAuthTokenRefresher) *RefreshingOAuthCredentialStore {
+	return NewRefreshingOAuthCredentialStoreWithSkew(repo, refresher, defaultOAuthRefreshSkew)
+}
+
+func NewRefreshingOAuthCredentialStoreWithSkew(repo *OAuthRepo, refresher OAuthTokenRefresher, skew time.Duration) *RefreshingOAuthCredentialStore {
+	if skew < 0 {
+		skew = 0
+	}
+	return &RefreshingOAuthCredentialStore{
+		repo:      repo,
+		refresher: refresher,
+		skew:      skew,
+		locks:     make(map[string]*sync.Mutex),
+	}
+}
+
+func (s *RefreshingOAuthCredentialStore) GetCredential(ctx context.Context, upstream mcp.Upstream) (mcp.AccessTokenView, error) {
+	if s == nil || s.repo == nil {
+		return mcp.AccessTokenView{}, nil
+	}
+	cred, err := s.repo.GetCredential(ctx, upstream.Name)
+	if err != nil {
+		return mcp.AccessTokenView{}, err
+	}
+	if !s.shouldRefresh(cred) {
+		return mcp.AccessTokenView{AccessToken: cred.AccessToken}, nil
+	}
+	if s.refresher == nil || strings.TrimSpace(cred.RefreshToken) == "" || !canRefresh(upstream) {
+		return mcp.AccessTokenView{AccessToken: cred.AccessToken}, nil
+	}
+
+	lock := s.lockFor(upstream.Name)
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Another goroutine may have refreshed while we waited.
+	cred, err = s.repo.GetCredential(ctx, upstream.Name)
+	if err != nil {
+		return mcp.AccessTokenView{}, err
+	}
+	if !s.shouldRefresh(cred) {
+		return mcp.AccessTokenView{AccessToken: cred.AccessToken}, nil
+	}
+
+	token, err := s.refresher.RefreshOAuthToken(ctx, upstream, cred.RefreshToken)
+	if err != nil {
+		log.Printf("[mcp-auth] oauth token refresh failed server=%s err=%v", upstream.Name, err)
+		return mcp.AccessTokenView{AccessToken: cred.AccessToken}, nil
+	}
+	if strings.TrimSpace(token.RefreshToken) == "" {
+		token.RefreshToken = cred.RefreshToken
+	}
+	if strings.TrimSpace(token.TokenType) == "" {
+		token.TokenType = cred.TokenType
+	}
+	if strings.TrimSpace(token.Scope) == "" {
+		token.Scope = cred.Scope
+	}
+	updated := OAuthCredential{
+		ServerName:   cred.ServerName,
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		TokenType:    token.TokenType,
+		Scope:        token.Scope,
+		ExpiresAt:    token.ExpiresAt,
+		CreatedAt:    cred.CreatedAt,
+	}
+	if err := s.repo.UpsertCredential(ctx, updated); err != nil {
+		return mcp.AccessTokenView{}, err
+	}
+	return mcp.AccessTokenView{AccessToken: token.AccessToken}, nil
+}
+
+func (s *RefreshingOAuthCredentialStore) shouldRefresh(cred OAuthCredential) bool {
+	if strings.TrimSpace(cred.AccessToken) == "" || cred.ExpiresAt == nil {
+		return false
+	}
+	return !cred.ExpiresAt.After(time.Now().UTC().Add(s.skew))
+}
+
+func (s *RefreshingOAuthCredentialStore) lockFor(serverName string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lock := s.locks[serverName]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		s.locks[serverName] = lock
+	}
+	return lock
+}
+
+func canRefresh(upstream mcp.Upstream) bool {
+	return strings.TrimSpace(upstream.OAuthTokenURL) != "" && strings.TrimSpace(upstream.OAuthClientID) != ""
+}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -3,6 +3,9 @@ package store
 import (
 	"context"
 	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -615,6 +618,92 @@ func TestOAuthRepo_CredentialCRUD(t *testing.T) {
 	_, err = oauthRepo.GetCredential(ctx, "oauth-srv")
 	if err == nil {
 		t.Error("expected error after delete")
+	}
+}
+
+func TestRefreshingOAuthCredentialStoreRefreshesExpiredCredential(t *testing.T) {
+	db, cleanup := openTestDB(t)
+	defer cleanup()
+	if err := InitDB(db); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+
+	var form url.Values
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		form = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access-new","token_type":"Bearer","scope":"openid","expires_in":3600}`))
+	}))
+	defer tokenServer.Close()
+
+	serverRepo := NewServerRepo(db)
+	oauthRepo := NewOAuthRepo(db)
+	ctx := context.Background()
+	upstream := mcp.Upstream{
+		Name:              "oauth-refresh-srv",
+		Mode:              mcp.UpstreamModeHTTP,
+		BaseURL:           "http://localhost",
+		OAuthTokenURL:     tokenServer.URL,
+		OAuthClientID:     "client-id",
+		OAuthClientSecret: "client-secret",
+		Timeout:           30 * time.Second,
+		Enabled:           true,
+		Status: mcp.ServerStatus{
+			AuthType:         mcp.AuthTypeHosted,
+			ConnectionStatus: mcp.ConnectionStatusUnknown,
+			AuthStatus:       mcp.AuthStatusUnknown,
+		},
+	}
+	if err := serverRepo.CreateServer(ctx, upstream); err != nil {
+		t.Fatalf("CreateServer: %v", err)
+	}
+	expired := time.Now().Add(-1 * time.Minute).UTC()
+	if err := oauthRepo.UpsertCredential(ctx, OAuthCredential{
+		ServerName:   upstream.Name,
+		AccessToken:  "access-old",
+		RefreshToken: "refresh-old",
+		TokenType:    "Bearer",
+		Scope:        "openid",
+		ExpiresAt:    &expired,
+	}); err != nil {
+		t.Fatalf("UpsertCredential: %v", err)
+	}
+
+	client := mcp.NewHTTPClient()
+	store := NewRefreshingOAuthCredentialStoreWithSkew(oauthRepo, client, 0)
+	view, err := store.GetCredential(ctx, upstream)
+	if err != nil {
+		t.Fatalf("GetCredential: %v", err)
+	}
+	if view.AccessToken != "access-new" {
+		t.Fatalf("access token = %q, want access-new", view.AccessToken)
+	}
+	for key, value := range map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": "refresh-old",
+		"client_id":     "client-id",
+		"client_secret": "client-secret",
+	} {
+		if got := form.Get(key); got != value {
+			t.Fatalf("form[%s] = %q, want %q; form=%v", key, got, value, form)
+		}
+	}
+
+	got, err := oauthRepo.GetCredential(ctx, upstream.Name)
+	if err != nil {
+		t.Fatalf("GetCredential after refresh: %v", err)
+	}
+	if got.AccessToken != "access-new" {
+		t.Fatalf("stored access token = %q, want access-new", got.AccessToken)
+	}
+	if got.RefreshToken != "refresh-old" {
+		t.Fatalf("stored refresh token = %q, want preserved refresh-old", got.RefreshToken)
+	}
+	if got.ExpiresAt == nil || !got.ExpiresAt.After(time.Now().UTC()) {
+		t.Fatalf("stored expires_at was not updated: %#v", got.ExpiresAt)
 	}
 }
 


### PR DESCRIPTION
Replace the non-refreshing oauth credential store with a refreshing one.