### PR TITLE
Always have temperature as zero when talking to the llm

### DIFF
--- a/internal/invocation/local_evaluator.go
+++ b/internal/invocation/local_evaluator.go
@@ -217,7 +217,7 @@ func (e *LocalEvaluatorClient) callAnthropic(ctx context.Context, cfg LocalLLMCo
 }
 
 // parseVerdict extracts verdict/confidence/reason from the LLM JSON output.
-// Falls back to "next_rule" on any parse error so no invocation is silently lost.
+// Falls back to "denied" on any parse error so no invocation is silently approved.
 func (e *LocalEvaluatorClient) parseVerdict(raw string) (verdict string, confidence float64, reason string) {
 	raw = strings.TrimSpace(raw)
 	// Strip markdown fences if the model wrapped the JSON anyway.

--- a/internal/invocation/local_evaluator.go
+++ b/internal/invocation/local_evaluator.go
@@ -60,7 +60,7 @@ func NewLocalEvaluatorClient(store LLMConfigProvider) *LocalEvaluatorClient {
 }
 
 // EvaluateToolCall calls the locally-configured LLM to judge the tool call.
-// Falls back to next_rule on unparseable output; returns an error on HTTP failure.
+// Falls back to denied on unparseable output; returns an error on HTTP failure.
 func (e *LocalEvaluatorClient) EvaluateToolCall(ctx context.Context, req EvaluateRequest) (EvaluateResponse, error) {
 	cfg, err := e.store.GetLLMConfig(ctx, req.AtryumLLMConfigID)
 	if err != nil {
@@ -119,13 +119,15 @@ func (e *LocalEvaluatorClient) callOpenAI(ctx context.Context, cfg LocalLLMConfi
 	baseURL = strings.TrimRight(baseURL, "/")
 	endpoint := baseURL + "/v1/chat/completions"
 
-	body, _ := json.Marshal(map[string]any{
-		"model": cfg.Model,
+	payload := map[string]any{
+		"model":       cfg.Model,
+		"temperature": 0.0,
 		"messages": []map[string]any{
 			{"role": "system", "content": system},
 			{"role": "user", "content": user},
 		},
-	})
+	}
+	body, _ := json.Marshal(payload)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
@@ -166,14 +168,16 @@ func (e *LocalEvaluatorClient) callOpenAI(ctx context.Context, cfg LocalLLMConfi
 func (e *LocalEvaluatorClient) callAnthropic(ctx context.Context, cfg LocalLLMConfig, system, user string) (string, error) {
 	endpoint := "https://api.anthropic.com/v1/messages"
 
-	body, _ := json.Marshal(map[string]any{
-		"model":      cfg.Model,
-		"max_tokens": 512,
-		"system":     system,
+	payload := map[string]any{
+		"model":       cfg.Model,
+		"max_tokens":  512,
+		"temperature": 0.0,
+		"system":      system,
 		"messages": []map[string]any{
 			{"role": "user", "content": user},
 		},
-	})
+	}
+	body, _ := json.Marshal(payload)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {

--- a/internal/invocation/local_evaluator_test.go
+++ b/internal/invocation/local_evaluator_test.go
@@ -1,0 +1,137 @@
+package invocation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type localLLMConfigStoreStub struct {
+	cfg LocalLLMConfig
+}
+
+func (s localLLMConfigStoreStub) GetLLMConfig(_ context.Context, _ string) (LocalLLMConfig, error) {
+	return s.cfg, nil
+}
+
+func TestLocalEvaluatorJudgeOpenAISendsTemperatureZero(t *testing.T) {
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{
+				"message": map[string]any{"content": `{"verdict":"approved","confidence":1,"reason":"ok"}`},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	evaluator := NewLocalEvaluatorClient(localLLMConfigStoreStub{cfg: LocalLLMConfig{
+		ID:       "llm-openai",
+		Provider: "openai_compatible",
+		Model:    "judge-model",
+		BaseURL:  server.URL,
+	}})
+
+	_, err := evaluator.EvaluateToolCall(context.Background(), EvaluateRequest{
+		AtryumLLMConfigID: "llm-openai",
+		Charter:           "Approve harmless calls.",
+		ServerName:        "github",
+		ToolName:          "search",
+		ToolArgs:          map[string]any{"q": "x"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, ok := payload["temperature"].(float64); !ok || got != 0 {
+		t.Fatalf("temperature = %#v, want 0", payload["temperature"])
+	}
+}
+
+func TestLocalEvaluatorJudgeAnthropicSendsTemperatureZero(t *testing.T) {
+	transport := &captureTransport{
+		responseBody: `{"content":[{"type":"text","text":"{\"verdict\":\"approved\",\"confidence\":1,\"reason\":\"ok\"}"}]}`,
+	}
+	evaluator := NewLocalEvaluatorClient(localLLMConfigStoreStub{cfg: LocalLLMConfig{
+		ID:       "llm-anthropic",
+		Provider: "anthropic",
+		Model:    "judge-model",
+		APIKey:   "key",
+	}})
+	evaluator.httpClient = &http.Client{Transport: transport}
+
+	_, err := evaluator.EvaluateToolCall(context.Background(), EvaluateRequest{
+		AtryumLLMConfigID: "llm-anthropic",
+		Charter:           "Approve harmless calls.",
+		ServerName:        "github",
+		ToolName:          "search",
+		ToolArgs:          map[string]any{"q": "x"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, ok := transport.payload["temperature"].(float64); !ok || got != 0 {
+		t.Fatalf("temperature = %#v, want 0", transport.payload["temperature"])
+	}
+}
+
+func TestLocalSummarizerSendsTemperatureZero(t *testing.T) {
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{
+				"message": map[string]any{"content": "summary"},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	evaluator := NewLocalEvaluatorClient(localLLMConfigStoreStub{cfg: LocalLLMConfig{
+		ID:       "llm-openai",
+		Provider: "openai_compatible",
+		Model:    "summary-model",
+		BaseURL:  server.URL,
+	}})
+
+	_, err := evaluator.SummarizeInvocation(context.Background(), "llm-openai", map[string]any{"status": "ok"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, ok := payload["temperature"].(float64); !ok || got != 0 {
+		t.Fatalf("temperature = %#v, want 0", payload["temperature"])
+	}
+}
+
+type captureTransport struct {
+	payload      map[string]any
+	responseBody string
+}
+
+func (t *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	defer req.Body.Close()
+	if err := json.NewDecoder(req.Body).Decode(&t.payload); err != nil {
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(bytes.NewBufferString(t.responseBody)),
+		Request:    req,
+	}, nil
+}


### PR DESCRIPTION

Sets temperature to 0.0 on every request the local evaluator sends to an LLM — both the tool-call judge and the invocation summarizer

Why

The judge and summarizer are deterministic decision-making tasks: a given charter + tool call should yield the same verdict every time, and summaries shouldn't vary run-to-run. Previously no temperature was specified, so we inherited each provider's default (typically 1.0), introducing avoidable nondeterminism into safety verdicts and audit summaries.

Some models might not like us sending a temperature parameter so we may want to over complicate this change in the future by adding a temperature column to LLMConfig table but it's probably worth waiting until we notice a model not working with temperature 0.0.