### PR TITLE
fix(sync): persist ValidMind agent charter on sync

### DIFF
--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -136,9 +136,20 @@ func runServer(args []string) error {
 		}
 		log.Printf("agent sync: fetched %d agent(s) for org=%s (%s) record_type=%s", agentsResp.Total, agentsResp.OrgCUID, agentsResp.OrgName, settings.AgentRecordTypeSlug)
 		syncedAt := time.Now().UTC()
+		charterKey := settings.CharterFieldKey
 		for _, a := range agentsResp.Results {
 			description, _ := a.CustomFields["description"].(string)
-			log.Printf("  agent cuid=%s name=%q description=%q", a.CUID, a.Name, description)
+			// Pull the charter from the configured custom field. Tolerate both a
+			// flat custom_fields map and one nested under "model".
+			charter := ""
+			if charterKey != "" {
+				if v, ok := a.CustomFields[charterKey].(string); ok {
+					charter = v
+				} else if model, ok := a.CustomFields["model"].(map[string]any); ok {
+					charter, _ = model[charterKey].(string)
+				}
+			}
+			log.Printf("  agent cuid=%s name=%q description=%q charter_key=%q charter_len=%d", a.CUID, a.Name, description, charterKey, len(charter))
 			if upsertErr := agentsRepo.Upsert(ctx, store.AgentRecord{
 				ID:                 uuid.NewString(),
 				VMOrganizationCUID: agentsResp.OrgCUID,
@@ -146,6 +157,7 @@ func runServer(args []string) error {
 				VMCUID:             a.CUID,
 				VMName:             a.Name,
 				VMDescription:      description,
+				Charter:            charter,
 				Enabled:            true,
 				SyncedAt:           syncedAt,
 			}); upsertErr != nil {

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -83,10 +83,11 @@ func (r *AgentsRepo) Upsert(ctx context.Context, agent AgentRecord) error {
 			vm_organization_name = excluded.vm_organization_name,
 			vm_name              = excluded.vm_name,
 			vm_description       = excluded.vm_description,
+			charter              = excluded.charter,
 			synced_at            = excluded.synced_at`).
 		ToSql()
-	// Note: charter is intentionally NOT updated on upsert — it is a
-	// manually-maintained field and must survive agent re-syncs.
+	// Note: charter is sourced from the ValidMind charter custom field and
+	// refreshed on every re-sync (the UI shows it read-only, "managed by sync").
 	if err != nil {
 		return fmt.Errorf("build agent upsert: %w", err)
 	}


### PR DESCRIPTION
## Summary

The agent **Charter** is shown in the UI as read-only, *"managed by ValidMind sync,"* and the local LLM-as-judge evaluator requires it — but the sync never fetched the charter and the agents-store upsert never persisted it. Synced agents therefore always had an empty charter, and every tool call routed to the local evaluation path was denied with *"no charter configured."*

This is a half-finished migration: the UI and the evaluator were updated to treat the charter as ValidMind-managed, but the **sync** and **persistence** layers were never updated to carry it.

## Impact

- **Local LLM eval path** (`ApprovalRule.AtryumLLMConfigID` set): `internal/invocation/service.go` denies outright when `agentRec.Charter == ""`. With an empty charter, **every** call to a synced agent is denied — even ones the charter would explicitly allow.
- **VM-backend eval path** (`ApprovalRule.ModelConfigCUID` set): unaffected. It sends `charter_field_key` + `agent_vm_cuid` to the backend, which fetches the charter live and never reads the stored copy. This likely masked the bug — testing that leaned on the VM evaluator would never hit it.

## Root cause (two defects)

1. **Sync never read the charter custom field.** `cmd/atryum/main.go` (`syncAgents`) only read `custom_fields["description"]`; the configured `charter_field_key` from `agent_sync_settings` was never consulted, so `AgentRecord.Charter` was never set — even on first insert.
2. **Upsert intentionally skipped charter on update.** `internal/store/agents.go` (`AgentsRepo.Upsert`) omitted `charter` from the `ON CONFLICT (vm_cuid) DO UPDATE SET` clause, with a comment describing the *older* design where the charter was hand-entered in Atryum. Because rows are first synced before any charter exists, only the UPDATE path runs on re-sync — so the charter was dropped even once extraction worked.

## Fix

- `cmd/atryum/main.go`: read the charter from `settings.CharterFieldKey` (tolerating a flat `custom_fields` map or one nested under `model`), write it to the upserted `AgentRecord`, and log `charter_key` / `charter_len` for diagnosis.
- `internal/store/agents.go`: add `charter = excluded.charter` to the upsert so it refreshes on every re-sync; update the stale comment.

## Why it's safe

The upsert is only used by the sync path, which only touches ValidMind-synced agents. Synced agents' charter is read-only in the UI, so there is no hand-edited value to clobber. Non-synced agents are created/edited through separate write paths and don't flow through this upsert.

## Testing

- `gofmt -e` clean on both files.
- Verified end to end against a live ValidMind org: sync log now shows `charter_key="agentCharter" charter_len=398`, the charter renders in the agent UI instead of the placeholder, and the local eval path correctly allows charter-permitted reads.

## Follow-ups (not in this PR)

- Confirm the shape `FetchAgents` returns `custom_fields` in and drop the `model.` fallback if it's always flat.
- Add regression tests: a store test asserting `Upsert` updates `charter` on conflict, and a sync test asserting the charter is read from `CharterFieldKey` (extend `internal/store/sqlite_test.go`).
- Decide whether a synced-but-empty charter should hard-deny (current) or fall back to `human_approval` during onboarding before a charter is filled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
