### PR TITLE
fix(mcp): populate custom headers in server edit form

### DIFF
--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -89,8 +89,8 @@ type OAuthToken struct {
 }
 
 type AuthHeader struct {
-	Name  string
-	Value string
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 type Upstream struct {


### PR DESCRIPTION
## Problem

When a server has custom headers configured, the edit form rendered the right *number* of header rows but left every key and value blank — making it look like no custom headers were set (despite the **CUSTOM HEADERS** badge).

## Cause

`mcp.AuthHeader` (`internal/mcp/client.go`) had no JSON struct tags, so it marshaled as `{"Name","Value"}` (capitalized). The UI reads `header.name`/`header.value` (lowercase), so both came back `undefined` → one blank row per stored header.

Saving worked only because Go's `encoding/json` unmarshal is case-insensitive; reading (marshal) uses the exact field names.

## Fix

Add `json:"name"` / `json:"value"` tags. Keys now populate, and values land in the existing `type="password"` field (shown as dots — obscured).

Note: the real header value still travels to the admin UI, same as `auth_token` already does. Server-side redaction (a `has_value` flag + save-time merge, like the OAuth client secret) is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)