### PR TITLE
Tell agents to read in their rules to reduce the number of denied calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The frontend fetches `/api/v1/admin-auth/config`, shows a sign-in screen, redire
 
 Public (auth-protected when `[[auth]]` is configured):
 
-- `POST /mcp/{server}` — MCP JSON-RPC. `tools/list` annotates each tool with its policy disposition for the calling agent; a synthetic `atryum.rules.get` tool lets an agent inspect its applicable rules before deciding what to call.
+- `POST /mcp/{server}` — MCP JSON-RPC. `tools/list` annotates each tool with its policy disposition for the calling agent; a synthetic `atryum_rules_get` tool lets an agent inspect its applicable rules before deciding what to call. The underscore name is intentional: dotted MCP tool names are spec-compliant, but some common harness implementations reject them.
 - `GET /mcp/{server}` — Streamable HTTP / legacy SSE channel for MCP clients that need a long-lived event stream.
 - `POST /api/v1/invocations` — direct invocation (Atryum executes).
 - `POST /api/v1/external/invocations`, `PATCH /api/v1/external/invocations/{id}` — hook path (harness executes, Atryum gates and records).

--- a/examples/amp-plugin/atryum.ts
+++ b/examples/amp-plugin/atryum.ts
@@ -360,12 +360,63 @@ function describe(input: Record<string, unknown>): string {
   return parts.join(" | ") || "(no string params)";
 }
 
+const RULES_CACHE_TTL_MS = 5 * 60 * 1000;
+const rulesCache = new Map<string, { value: string; expiresAt: number }>();
+
+function formatRulesContext(rules: unknown): string {
+  if (!rules || typeof rules !== "object") return "";
+  const record = rules as Record<string, unknown>;
+  const lines = [
+    "Atryum advisory rules visible to this harness before the gated call:",
+    `- server: ${String(record.server || SOURCE)}`,
+    `- tool: ${String(record.tool || "unknown")}`,
+    `- effective action: ${String(record.action || record.default_action || "unknown")}`,
+  ];
+  if (record.matched_rule_id) lines.push(`- matched rule: ${String(record.matched_rule_id)}`);
+  if (record.generated_at) lines.push(`- as of: ${String(record.generated_at)}`);
+  if (Array.isArray(record.items) && record.items.length > 0) {
+    lines.push("- visible rules:");
+    for (const item of record.items.slice(0, 20)) {
+      const rule = item as Record<string, unknown>;
+      const guidance = rule.guidance ? ` (${String(rule.guidance)})` : "";
+      lines.push(`  - ${String(rule.id || "(unnamed)")}: ${String(rule.action)}${guidance}`);
+    }
+  }
+  lines.push("- advisory only; Atryum re-checks policy during the actual gated call.");
+  return lines.join("\n");
+}
+
+async function rulesContext(tool: string): Promise<string> {
+  const cacheKey = [SOURCE, tool, ACCESS_TOKEN ? "auth" : "no-auth", AGENT_ID].join("\x00");
+  const cached = rulesCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+  if (cached) rulesCache.delete(cacheKey);
+  const url = new URL("/api/v1/agent/rules", API);
+  url.searchParams.set("server", SOURCE);
+  url.searchParams.set("tool", tool);
+  if (AGENT_ID && !ACCESS_TOKEN) url.searchParams.set("agent_id", AGENT_ID);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
+  try {
+    const res = await atryumFetch(url.toString(), { signal: controller.signal });
+    if (!res.ok) return "";
+    const value = formatRulesContext(await res.json());
+    rulesCache.set(cacheKey, { value, expiresAt: Date.now() + RULES_CACHE_TTL_MS });
+    return value;
+  } catch {
+    return "";
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function submit(
   tool: string,
   toolUseID: string,
   input: Record<string, unknown>,
   sessionID: string | undefined,
 ): Promise<InvocationResponse> {
+  const context = await rulesContext(tool);
   const res = await atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
     contentType: true,
@@ -377,6 +428,8 @@ async function submit(
       request_id: toolUseID,
       thread_id: activeThreadID() || undefined,
       session_id: sessionID,
+      chat_context: context || undefined,
+      context: context || undefined,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,
       agent_id: AGENT_ID || undefined,

--- a/examples/amp-plugin/atryum.ts
+++ b/examples/amp-plugin/atryum.ts
@@ -360,54 +360,14 @@ function describe(input: Record<string, unknown>): string {
   return parts.join(" | ") || "(no string params)";
 }
 
-const RULES_CACHE_TTL_MS = 5 * 60 * 1000;
-const rulesCache = new Map<string, { value: string; expiresAt: number }>();
-
-function formatRulesContext(rules: unknown): string {
-  if (!rules || typeof rules !== "object") return "";
-  const record = rules as Record<string, unknown>;
-  const lines = [
-    "Atryum advisory rules visible to this harness before the gated call:",
-    `- server: ${String(record.server || SOURCE)}`,
-    `- tool: ${String(record.tool || "unknown")}`,
-    `- effective action: ${String(record.action || record.default_action || "unknown")}`,
-  ];
-  if (record.matched_rule_id) lines.push(`- matched rule: ${String(record.matched_rule_id)}`);
-  if (record.generated_at) lines.push(`- as of: ${String(record.generated_at)}`);
-  if (Array.isArray(record.items) && record.items.length > 0) {
-    lines.push("- visible rules:");
-    for (const item of record.items.slice(0, 20)) {
-      const rule = item as Record<string, unknown>;
-      const guidance = rule.guidance ? ` (${String(rule.guidance)})` : "";
-      lines.push(`  - ${String(rule.id || "(unnamed)")}: ${String(rule.action)}${guidance}`);
-    }
-  }
-  lines.push("- advisory only; Atryum re-checks policy during the actual gated call.");
-  return lines.join("\n");
-}
-
-async function rulesContext(tool: string): Promise<string> {
-  const cacheKey = [SOURCE, tool, ACCESS_TOKEN ? "auth" : "no-auth", AGENT_ID].join("\x00");
-  const cached = rulesCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) return cached.value;
-  if (cached) rulesCache.delete(cacheKey);
+// Points the agent at the rules endpoint rather than pre-fetching and
+// embedding rule content, so the model can query it directly when useful.
+function rulesEndpointHint(tool: string): string {
   const url = new URL("/api/v1/agent/rules", API);
   url.searchParams.set("server", SOURCE);
   url.searchParams.set("tool", tool);
   if (AGENT_ID && !ACCESS_TOKEN) url.searchParams.set("agent_id", AGENT_ID);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 3000);
-  try {
-    const res = await atryumFetch(url.toString(), { signal: controller.signal });
-    if (!res.ok) return "";
-    const value = formatRulesContext(await res.json());
-    rulesCache.set(cacheKey, { value, expiresAt: Date.now() + RULES_CACHE_TTL_MS });
-    return value;
-  } catch {
-    return "";
-  } finally {
-    clearTimeout(timer);
-  }
+  return `atryum: to see the approval rules that apply to this call, GET ${url.toString()} (advisory only; Atryum re-checks policy during the actual gated call).`;
 }
 
 async function submit(
@@ -416,7 +376,6 @@ async function submit(
   input: Record<string, unknown>,
   sessionID: string | undefined,
 ): Promise<InvocationResponse> {
-  const context = await rulesContext(tool);
   const res = await atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
     contentType: true,
@@ -428,8 +387,6 @@ async function submit(
       request_id: toolUseID,
       thread_id: activeThreadID() || undefined,
       session_id: sessionID,
-      chat_context: context || undefined,
-      context: context || undefined,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,
       agent_id: AGENT_ID || undefined,
@@ -524,7 +481,7 @@ export default function (amp: PluginAPI) {
       invocationMap.delete(event.toolUseID);
       return {
         action: "reject-and-continue",
-        message: `atryum: tool call '${event.tool}' was ${decided.status} by reviewer.`,
+        message: `atryum: tool call '${event.tool}' was ${decided.status} by reviewer. ${rulesEndpointHint(event.tool)}`,
       };
     } catch (err) {
       ctx.logger.log(`atryum error: ${err}`);

--- a/examples/pi-extension/index.ts
+++ b/examples/pi-extension/index.ts
@@ -246,6 +246,56 @@ function describe(input: ToolInput): string {
   return parts.join(" | ") || "(no string params)";
 }
 
+const RULES_CACHE_TTL_MS = 5 * 60 * 1000;
+const rulesCache = new Map<string, { value: string; expiresAt: number }>();
+
+function formatRulesContext(rules: unknown): string {
+  if (!rules || typeof rules !== "object") return "";
+  const record = rules as Record<string, unknown>;
+  const lines = [
+    "Atryum advisory rules visible to this harness before the gated call:",
+    `- server: ${String(record.server || SOURCE)}`,
+    `- tool: ${String(record.tool || "unknown")}`,
+    `- effective action: ${String(record.action || record.default_action || "unknown")}`,
+  ];
+  if (record.matched_rule_id) lines.push(`- matched rule: ${String(record.matched_rule_id)}`);
+  if (record.generated_at) lines.push(`- as of: ${String(record.generated_at)}`);
+  if (Array.isArray(record.items) && record.items.length > 0) {
+    lines.push("- visible rules:");
+    for (const item of record.items.slice(0, 20)) {
+      const rule = item as Record<string, unknown>;
+      const guidance = rule.guidance ? ` (${String(rule.guidance)})` : "";
+      lines.push(`  - ${String(rule.id || "(unnamed)")}: ${String(rule.action)}${guidance}`);
+    }
+  }
+  lines.push("- advisory only; Atryum re-checks policy during the actual gated call.");
+  return lines.join("\n");
+}
+
+async function rulesContext(tool: string): Promise<string> {
+  const cacheKey = [SOURCE, tool, ACCESS_TOKEN ? "auth" : "no-auth", AGENT_ID].join("\x00");
+  const cached = rulesCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+  if (cached) rulesCache.delete(cacheKey);
+  const url = new URL("/api/v1/agent/rules", API);
+  url.searchParams.set("server", SOURCE);
+  url.searchParams.set("tool", tool);
+  if (AGENT_ID && !ACCESS_TOKEN) url.searchParams.set("agent_id", AGENT_ID);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
+  try {
+    const res = await atryumFetch(url.toString(), { signal: controller.signal });
+    if (!res.ok) return "";
+    const value = formatRulesContext(await res.json());
+    rulesCache.set(cacheKey, { value, expiresAt: Date.now() + RULES_CACHE_TTL_MS });
+    return value;
+  } catch {
+    return "";
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // Pi's own session identifier, used only for cross-referencing (thread_id and
 // client_session_id). Atryum keys off the session_id it mints, not this.
 function piClientSessionID(ctx: unknown): string | undefined {
@@ -304,6 +354,7 @@ async function submit(
   threadID: string | undefined,
   sessionID: string | undefined,
 ): Promise<InvocationResponse> {
+  const context = await rulesContext(tool);
   const res = await atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
     contentType: true,
@@ -315,6 +366,8 @@ async function submit(
       request_id: toolCallID,
       thread_id: threadID,
       session_id: sessionID,
+      chat_context: context || undefined,
+      context: context || undefined,
       agent_id: AGENT_ID || undefined,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,

--- a/examples/pi-extension/index.ts
+++ b/examples/pi-extension/index.ts
@@ -246,54 +246,14 @@ function describe(input: ToolInput): string {
   return parts.join(" | ") || "(no string params)";
 }
 
-const RULES_CACHE_TTL_MS = 5 * 60 * 1000;
-const rulesCache = new Map<string, { value: string; expiresAt: number }>();
-
-function formatRulesContext(rules: unknown): string {
-  if (!rules || typeof rules !== "object") return "";
-  const record = rules as Record<string, unknown>;
-  const lines = [
-    "Atryum advisory rules visible to this harness before the gated call:",
-    `- server: ${String(record.server || SOURCE)}`,
-    `- tool: ${String(record.tool || "unknown")}`,
-    `- effective action: ${String(record.action || record.default_action || "unknown")}`,
-  ];
-  if (record.matched_rule_id) lines.push(`- matched rule: ${String(record.matched_rule_id)}`);
-  if (record.generated_at) lines.push(`- as of: ${String(record.generated_at)}`);
-  if (Array.isArray(record.items) && record.items.length > 0) {
-    lines.push("- visible rules:");
-    for (const item of record.items.slice(0, 20)) {
-      const rule = item as Record<string, unknown>;
-      const guidance = rule.guidance ? ` (${String(rule.guidance)})` : "";
-      lines.push(`  - ${String(rule.id || "(unnamed)")}: ${String(rule.action)}${guidance}`);
-    }
-  }
-  lines.push("- advisory only; Atryum re-checks policy during the actual gated call.");
-  return lines.join("\n");
-}
-
-async function rulesContext(tool: string): Promise<string> {
-  const cacheKey = [SOURCE, tool, ACCESS_TOKEN ? "auth" : "no-auth", AGENT_ID].join("\x00");
-  const cached = rulesCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) return cached.value;
-  if (cached) rulesCache.delete(cacheKey);
+// Points the agent at the rules endpoint rather than pre-fetching and
+// embedding rule content, so the model can query it directly when useful.
+function rulesEndpointHint(tool: string): string {
   const url = new URL("/api/v1/agent/rules", API);
   url.searchParams.set("server", SOURCE);
   url.searchParams.set("tool", tool);
   if (AGENT_ID && !ACCESS_TOKEN) url.searchParams.set("agent_id", AGENT_ID);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 3000);
-  try {
-    const res = await atryumFetch(url.toString(), { signal: controller.signal });
-    if (!res.ok) return "";
-    const value = formatRulesContext(await res.json());
-    rulesCache.set(cacheKey, { value, expiresAt: Date.now() + RULES_CACHE_TTL_MS });
-    return value;
-  } catch {
-    return "";
-  } finally {
-    clearTimeout(timer);
-  }
+  return `atryum: to see the approval rules that apply to this call, GET ${url.toString()} (advisory only; Atryum re-checks policy during the actual gated call).`;
 }
 
 // Pi's own session identifier, used only for cross-referencing (thread_id and
@@ -354,7 +314,6 @@ async function submit(
   threadID: string | undefined,
   sessionID: string | undefined,
 ): Promise<InvocationResponse> {
-  const context = await rulesContext(tool);
   const res = await atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
     contentType: true,
@@ -366,8 +325,6 @@ async function submit(
       request_id: toolCallID,
       thread_id: threadID,
       session_id: sessionID,
-      chat_context: context || undefined,
-      context: context || undefined,
       agent_id: AGENT_ID || undefined,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,
@@ -461,7 +418,7 @@ export default function (pi: ExtensionAPI) {
         : "";
       return {
         block: true,
-        reason: `atryum: tool call '${event.toolName}' was ${decided.status} by reviewer.${reviewerReason}`,
+        reason: `atryum: tool call '${event.toolName}' was ${decided.status} by reviewer.${reviewerReason} ${rulesEndpointHint(event.toolName)}`,
       };
     } catch (err) {
       ctx.ui.setStatus("atryum", "gate failed");

--- a/examples/shared-agent-hook/atryum-hook.mjs
+++ b/examples/shared-agent-hook/atryum-hook.mjs
@@ -290,52 +290,14 @@ function describe(input) {
   return parts.join(" | ") || "(no string params)";
 }
 
-const RULES_CACHE_TTL_MS = 5 * 60 * 1000;
-const rulesCache = new Map();
-
-function formatRulesContext(rules) {
-  if (!rules || typeof rules !== "object") return "";
-  const lines = [
-    "Atryum advisory rules visible to this harness before the gated call:",
-    `- server: ${rules.server || SOURCE}`,
-    `- tool: ${rules.tool || "unknown"}`,
-    `- effective action: ${rules.action || rules.default_action || "unknown"}`,
-  ];
-  if (rules.matched_rule_id) lines.push(`- matched rule: ${rules.matched_rule_id}`);
-  if (rules.generated_at) lines.push(`- as of: ${rules.generated_at}`);
-  if (Array.isArray(rules.items) && rules.items.length > 0) {
-    lines.push("- visible rules:");
-    for (const rule of rules.items.slice(0, 20)) {
-      const guidance = rule.guidance ? ` (${rule.guidance})` : "";
-      lines.push(`  - ${rule.id || "(unnamed)"}: ${rule.action}${guidance}`);
-    }
-  }
-  lines.push("- advisory only; Atryum re-checks policy during the actual gated call.");
-  return lines.join("\n");
-}
-
-async function rulesContext(tool) {
-  const cacheKey = [SOURCE, tool, ACCESS_TOKEN ? "auth" : "no-auth", AGENT_ID].join("\x00");
-  const cached = rulesCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) return cached.value;
-  if (cached) rulesCache.delete(cacheKey);
+// Points the agent at the rules endpoint rather than pre-fetching and
+// embedding rule content, so the model can query it directly when useful.
+function rulesEndpointHint(tool) {
   const url = new URL("/api/v1/agent/rules", API);
   url.searchParams.set("server", SOURCE);
   url.searchParams.set("tool", tool);
   if (AGENT_ID && !ACCESS_TOKEN) url.searchParams.set("agent_id", AGENT_ID);
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), 3000);
-  try {
-    const res = await atryumFetch(url.toString(), { signal: controller.signal });
-    if (!res.ok) return "";
-    const value = formatRulesContext(await res.json());
-    rulesCache.set(cacheKey, { value, expiresAt: Date.now() + RULES_CACHE_TTL_MS });
-    return value;
-  } catch {
-    return "";
-  } finally {
-    clearTimeout(timer);
-  }
+  return `atryum: to see the approval rules that apply to this call, GET ${url.toString()} (advisory only; Atryum re-checks policy during the actual gated call).`;
 }
 
 // The host's own session/thread identifier. Used only for cross-referencing:
@@ -448,7 +410,6 @@ async function submitOnce(event, sessionIDValue) {
   const name = toolName(event);
   const input = toolInput(event);
   const id = toolUseID(event);
-  const context = await rulesContext(name);
   return atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
     contentType: true,
@@ -460,8 +421,6 @@ async function submitOnce(event, sessionIDValue) {
       request_id: id,
       thread_id: sessionId(event) || undefined,
       session_id: sessionIDValue || undefined,
-      chat_context: context || undefined,
-      context: context || undefined,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,
       agent_id: AGENT_ID || undefined,
@@ -615,7 +574,7 @@ async function handlePreToolUse(event) {
   await deleteInvocation(id);
   jsonOut(
     denyOutput(
-      `atryum: tool call '${toolName(event)}' was ${decided.status} by reviewer.`,
+      `atryum: tool call '${toolName(event)}' was ${decided.status} by reviewer. ${rulesEndpointHint(toolName(event))}`,
     ),
   );
 }

--- a/examples/shared-agent-hook/atryum-hook.mjs
+++ b/examples/shared-agent-hook/atryum-hook.mjs
@@ -290,6 +290,54 @@ function describe(input) {
   return parts.join(" | ") || "(no string params)";
 }
 
+const RULES_CACHE_TTL_MS = 5 * 60 * 1000;
+const rulesCache = new Map();
+
+function formatRulesContext(rules) {
+  if (!rules || typeof rules !== "object") return "";
+  const lines = [
+    "Atryum advisory rules visible to this harness before the gated call:",
+    `- server: ${rules.server || SOURCE}`,
+    `- tool: ${rules.tool || "unknown"}`,
+    `- effective action: ${rules.action || rules.default_action || "unknown"}`,
+  ];
+  if (rules.matched_rule_id) lines.push(`- matched rule: ${rules.matched_rule_id}`);
+  if (rules.generated_at) lines.push(`- as of: ${rules.generated_at}`);
+  if (Array.isArray(rules.items) && rules.items.length > 0) {
+    lines.push("- visible rules:");
+    for (const rule of rules.items.slice(0, 20)) {
+      const guidance = rule.guidance ? ` (${rule.guidance})` : "";
+      lines.push(`  - ${rule.id || "(unnamed)"}: ${rule.action}${guidance}`);
+    }
+  }
+  lines.push("- advisory only; Atryum re-checks policy during the actual gated call.");
+  return lines.join("\n");
+}
+
+async function rulesContext(tool) {
+  const cacheKey = [SOURCE, tool, ACCESS_TOKEN ? "auth" : "no-auth", AGENT_ID].join("\x00");
+  const cached = rulesCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+  if (cached) rulesCache.delete(cacheKey);
+  const url = new URL("/api/v1/agent/rules", API);
+  url.searchParams.set("server", SOURCE);
+  url.searchParams.set("tool", tool);
+  if (AGENT_ID && !ACCESS_TOKEN) url.searchParams.set("agent_id", AGENT_ID);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
+  try {
+    const res = await atryumFetch(url.toString(), { signal: controller.signal });
+    if (!res.ok) return "";
+    const value = formatRulesContext(await res.json());
+    rulesCache.set(cacheKey, { value, expiresAt: Date.now() + RULES_CACHE_TTL_MS });
+    return value;
+  } catch {
+    return "";
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // The host's own session/thread identifier. Used only for cross-referencing:
 // it becomes the invocation `thread_id` and the session's `client_session_id`.
 // Atryum keys the judge's context off the session_id it mints, not this value.
@@ -400,6 +448,7 @@ async function submitOnce(event, sessionIDValue) {
   const name = toolName(event);
   const input = toolInput(event);
   const id = toolUseID(event);
+  const context = await rulesContext(name);
   return atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
     contentType: true,
@@ -411,6 +460,8 @@ async function submitOnce(event, sessionIDValue) {
       request_id: id,
       thread_id: sessionId(event) || undefined,
       session_id: sessionIDValue || undefined,
+      chat_context: context || undefined,
+      context: context || undefined,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,
       agent_id: AGENT_ID || undefined,

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -185,10 +185,14 @@ func TestMCPAcceptsValidTokenAndPlumbsAgentID(t *testing.T) {
 
 func TestAgentRulesRequiresAuthAndUsesTokenAgentID(t *testing.T) {
 	rig := newAuthTestRig(t)
+	tokenAgent := store.AgentRecord{ID: "agent-cuid-007", AgentIDs: `["agent-007"]`}
+	otherAgent := store.AgentRecord{ID: "agent-cuid-other", AgentIDs: `["other"]`}
 	rules := &stubRulesRepo{rules: []store.Rule{
-		{ID: "auto-rule", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, Enabled: true, Order: 0},
+		{ID: "other-deny", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentCUIDs: []string{otherAgent.ID}, Enabled: true, Order: 0},
+		{ID: "auto-rule", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentCUIDs: []string{tokenAgent.ID}, Enabled: true, Order: 1},
 	}}
-	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, nil, nil, nil, nil, nil, nil)
+	agents := &stubAgentsRepo{records: []store.AgentRecord{tokenAgent, otherAgent}}
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, agents, nil, nil, nil, nil, nil)
 	h.SetAuthValidator(rig.v)
 	handler := h.Routes()
 
@@ -216,6 +220,9 @@ func TestAgentRulesRequiresAuthAndUsesTokenAgentID(t *testing.T) {
 	}
 	if resp.Action != invocation.RuleActionAutoApprove {
 		t.Fatalf("expected auto_approve action, got %q", resp.Action)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].ID != "auto-rule" {
+		t.Fatalf("expected only token agent rule to be visible, got %#v", resp.Items)
 	}
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1621,7 +1621,7 @@ func (h *Handler) annotateToolsWithPolicy(ctx context.Context, agentID, server s
 var atryumRulesTool = mcp.Tool{
 	Name:        atryumRulesToolName,
 	Description: "Return the current static Atryum approval rules visible to this agent. Optional arguments: server/source and tool preview a specific disposition. The response is advisory only; AI evaluation and human approval are decided during the actual gated tool call.",
-	InputSchema: json.RawMessage(`{"type":"object","properties":{"server":{"type":"string","description":"MCP server name to preview."},"source":{"type":"string","description":"Alias for server, useful for non-MCP harness terminology."},"tool":{"type":"string","description":"Tool name to preview."},"agent_id":{"type":"string","description":"Agent identity for no-auth local development only; ignored when inbound auth is enabled."}},"additionalProperties":false}`),
+	InputSchema: json.RawMessage(`{"type":"object","properties":{"server":{"type":"string","description":"MCP server name to preview."},"source":{"type":"string","description":"Alias for server, useful for non-MCP harness terminology."},"tool":{"type":"string","description":"Tool name to preview."},"agent_id":{"type":"string","description":"Agent identity for no-auth local development only; ignored when inbound auth is enabled."},"request_id":{"type":"string","description":"Deprecated compatibility alias for agent_id in no-auth local development only; ignored when inbound auth is enabled."}},"additionalProperties":false}`),
 }
 
 // effectiveActionForTool returns the action of the first enabled rule that

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -157,6 +157,16 @@ type Handler struct {
 	clientInfoMu    sync.RWMutex
 	clientInfoCache map[string]clientInfoSnapshot
 
+	// rulesListMu / rulesListCache avoids redundant DB round-trips when
+	// multiple operations in the same request window need the full rule list.
+	// Entries expire after 10 s — rules are admin-configured and change rarely.
+	rulesListMu    sync.RWMutex
+	rulesListCache *rulesListCacheEntry
+
+	// agentCUIDCache avoids repeated DB lookups for agentID → CUID resolution
+	// on every tools/list. Entries expire after 30 s.
+	agentCUIDCache sync.Map
+
 	// managedAgents is the optional Claude Managed Agents events bridge.
 	// nil when not configured (no anthropic api key).
 	managedAgents managedAgentsAdmin
@@ -628,9 +638,13 @@ func parseAgentIDs(raw string) []string {
 const atryumInitializeInstructions = "This MCP server is gated by the Atryum harness. " +
 	"Atryum may approve, deny, or request human approval for tool calls according to configured rules. " +
 	"Those rules may change between conversation turns, so treat each tool call as subject to the current Atryum policy. " +
-	"To see the static approval rules that currently apply to you, issue an HTTP GET to /api/v1/agent/rules " +
+	"To see the static approval rules that currently apply to you, call the atryum_rules_get MCP tool or issue an HTTP GET to /api/v1/agent/rules " +
 	"(optionally with ?server={server}&tool={tool} to preview the disposition for a specific tool); " +
 	"the response is advisory only, as AI-evaluation and human-approval outcomes are decided during the actual gated call."
+
+// Dotted tool names are valid MCP names, but common harnesses have rejected
+// them in practice. Keep this synthetic helper underscore-only for compatibility.
+const atryumRulesToolName = "atryum_rules_get"
 
 type AgentRule struct {
 	ID             string   `json:"id"`
@@ -1017,11 +1031,6 @@ func (h *Handler) agentRules(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	if h.rulesRepo == nil {
-		writeJSON(w, http.StatusOK, newAgentRulesResponse("", "", ""))
-		return
-	}
-
 	agentID := auth.AgentIDFromContext(r.Context())
 	if agentID == "" && h.authValidator == nil {
 		agentID = normalizeNoAuthAgentID(r.URL.Query().Get("agent_id"))
@@ -1034,6 +1043,11 @@ func (h *Handler) agentRules(w http.ResponseWriter, r *http.Request) {
 		server = strings.TrimSpace(r.URL.Query().Get("source"))
 	}
 	tool := strings.TrimSpace(r.URL.Query().Get("tool"))
+
+	if h.rulesRepo == nil {
+		writeJSON(w, http.StatusOK, newAgentRulesResponse(agentID, server, tool))
+		return
+	}
 
 	resp, err := h.buildAgentRulesResponse(r.Context(), agentID, server, tool)
 	if err != nil {
@@ -1049,7 +1063,7 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 		return resp, nil
 	}
 
-	rules, err := h.rulesRepo.List(ctx)
+	rules, err := h.cachedRulesList(ctx)
 	if err != nil {
 		return AgentRulesResponse{}, err
 	}
@@ -1080,6 +1094,56 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 	return resp, nil
 }
 
+func (h *Handler) handleAtryumRulesToolCall(w http.ResponseWriter, r *http.Request, id json.RawMessage, mcpServer string, arguments map[string]any) {
+	if arguments == nil {
+		arguments = map[string]any{}
+	}
+	agentID := auth.AgentIDFromContext(r.Context())
+	if agentID == "" && h.authValidator == nil {
+		agentID = normalizeNoAuthAgentID(stringArgument(arguments, "agent_id"))
+	}
+	if agentID == "" && h.authValidator == nil {
+		agentID = strings.TrimSpace(stringArgument(arguments, "request_id"))
+	}
+	server := strings.TrimSpace(stringArgument(arguments, "server"))
+	if server == "" {
+		server = strings.TrimSpace(stringArgument(arguments, "source"))
+	}
+	if server == "" {
+		server = mcpServer
+	}
+	tool := strings.TrimSpace(stringArgument(arguments, "tool"))
+
+	resp, err := h.buildAgentRulesResponse(r.Context(), agentID, server, tool)
+	if err != nil {
+		h.writeRPCError(w, id, -32000, err.Error())
+		return
+	}
+	body, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		h.writeRPCError(w, id, -32000, err.Error())
+		return
+	}
+	h.writeRPCResult(w, id, map[string]any{
+		"content": []map[string]any{{
+			"type": "text",
+			"text": string(body),
+		}},
+	})
+}
+
+func stringArgument(arguments map[string]any, key string) string {
+	v, ok := arguments[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
 func newAgentRulesResponse(agentID, server, tool string) AgentRulesResponse {
 	return AgentRulesResponse{
 		AgentID:        agentID,
@@ -1094,10 +1158,55 @@ func newAgentRulesResponse(agentID, server, tool string) AgentRulesResponse {
 	}
 }
 
+type rulesListCacheEntry struct {
+	rules     []store.Rule
+	expiresAt time.Time
+}
+
+func (h *Handler) cachedRulesList(ctx context.Context) ([]store.Rule, error) {
+	h.rulesListMu.RLock()
+	if h.rulesListCache != nil && time.Now().Before(h.rulesListCache.expiresAt) {
+		rules := h.rulesListCache.rules
+		h.rulesListMu.RUnlock()
+		return rules, nil
+	}
+	h.rulesListMu.RUnlock()
+
+	rules, err := h.rulesRepo.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	h.rulesListMu.Lock()
+	defer h.rulesListMu.Unlock()
+	h.rulesListCache = &rulesListCacheEntry{rules: rules, expiresAt: time.Now().Add(10 * time.Second)}
+	return rules, nil
+}
+
+type agentCUIDCacheEntry struct {
+	cuid      string
+	expiresAt time.Time
+}
+
 func (h *Handler) resolveAgentRecordForRules(ctx context.Context, agentID string) string {
 	if h.agentsRepo == nil {
 		return ""
 	}
+	cacheKey := agentID
+	if cacheKey == "" {
+		cacheKey = "\x00default"
+	}
+	if v, ok := h.agentCUIDCache.Load(cacheKey); ok {
+		if e := v.(agentCUIDCacheEntry); time.Now().Before(e.expiresAt) {
+			return e.cuid
+		}
+	}
+	cuid := h.resolveAgentCUIDUncached(ctx, agentID)
+	h.agentCUIDCache.Store(cacheKey, agentCUIDCacheEntry{cuid: cuid, expiresAt: time.Now().Add(30 * time.Second)})
+	return cuid
+}
+
+func (h *Handler) resolveAgentCUIDUncached(ctx context.Context, agentID string) string {
 	if agentID != "" {
 		if rec, err := h.agentsRepo.GetByAgentID(ctx, agentID); err == nil {
 			return rec.ID
@@ -1233,6 +1342,10 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 		}
 		if err := json.Unmarshal(req.Params, &params); err != nil {
 			h.writeRPCError(w, req.ID, -32602, "invalid params")
+			return
+		}
+		if params.Name == atryumRulesToolName {
+			h.handleAtryumRulesToolCall(w, r, req.ID, server, params.Arguments)
 			return
 		}
 		toolReq := invocation.CreateInvocationRequest{Server: server, Tool: params.Name, Input: params.Arguments}
@@ -1478,9 +1591,9 @@ func apiMatchPatterns(patterns []string, value string) bool {
 func agentRuleGuidance(action string) string {
 	switch action {
 	case invocation.RuleActionAutoApprove:
-		return "Likely to pass if policy and rule inputs do not change."
+		return "Auto-approved by this rule."
 	case invocation.RuleActionAutoDeny:
-		return "Will be rejected by this matched rule."
+		return "Auto-denied by this rule."
 	case invocation.RuleActionHumanApproval:
 		return "Requires reviewer approval."
 	case invocation.RuleActionAIEvaluation:
@@ -1514,22 +1627,29 @@ type atryumToolPolicy struct {
 // disposition for the current agent so the model sees the policy at the moment
 // it picks a tool. Annotation requires both rulesRepo and a concrete server.
 func (h *Handler) annotateToolsWithPolicy(ctx context.Context, agentID, server string, tools []mcp.Tool) []any {
-	out := make([]any, len(tools))
+	out := make([]any, 0, len(tools)+1)
 	if h.rulesRepo == nil || strings.TrimSpace(server) == "" {
-		for i, t := range tools {
-			out[i] = t
+		for _, t := range tools {
+			if t.Name != atryumRulesToolName {
+				out = append(out, t)
+			}
 		}
-		return out
+		return append(out, atryumRulesTool)
 	}
-	rules, err := h.rulesRepo.List(ctx)
+	rules, err := h.cachedRulesList(ctx)
 	if err != nil {
-		for i, t := range tools {
-			out[i] = t
+		for _, t := range tools {
+			if t.Name != atryumRulesToolName {
+				out = append(out, t)
+			}
 		}
-		return out
+		return append(out, atryumRulesTool)
 	}
 	agentCUID := h.resolveAgentRecordForRules(ctx, agentID)
-	for i, t := range tools {
+	for _, t := range tools {
+		if t.Name == atryumRulesToolName {
+			continue
+		}
 		action, matched := effectiveActionForTool(rules, server, t.Name, agentCUID)
 		desc := t.Description
 		if action != "" {
@@ -1540,7 +1660,7 @@ func (h *Handler) annotateToolsWithPolicy(ctx context.Context, agentID, server s
 				desc = prefix + desc
 			}
 		}
-		out[i] = annotatedTool{
+		out = append(out, annotatedTool{
 			Name:        t.Name,
 			Description: desc,
 			InputSchema: t.InputSchema,
@@ -1548,9 +1668,15 @@ func (h *Handler) annotateToolsWithPolicy(ctx context.Context, agentID, server s
 				EffectiveAction: action,
 				MatchedRuleID:   matched,
 			}},
-		}
+		})
 	}
-	return out
+	return append(out, atryumRulesTool)
+}
+
+var atryumRulesTool = mcp.Tool{
+	Name:        atryumRulesToolName,
+	Description: "Return the current static Atryum approval rules visible to this agent. Optional arguments: server/source and tool preview a specific disposition. The response is advisory only; AI evaluation and human approval are decided during the actual gated tool call.",
+	InputSchema: json.RawMessage(`{"type":"object","properties":{"server":{"type":"string","description":"MCP server name to preview."},"source":{"type":"string","description":"Alias for server, useful for non-MCP harness terminology."},"tool":{"type":"string","description":"Tool name to preview."},"agent_id":{"type":"string","description":"Agent identity for no-auth local development only; ignored when inbound auth is enabled."}},"additionalProperties":false}`),
 }
 
 // effectiveActionForTool returns the action of the first enabled rule that

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -157,16 +157,6 @@ type Handler struct {
 	clientInfoMu    sync.RWMutex
 	clientInfoCache map[string]clientInfoSnapshot
 
-	// rulesListMu / rulesListCache avoids redundant DB round-trips when
-	// multiple operations in the same request window need the full rule list.
-	// Entries expire after 10 s — rules are admin-configured and change rarely.
-	rulesListMu    sync.RWMutex
-	rulesListCache *rulesListCacheEntry
-
-	// agentCUIDCache avoids repeated DB lookups for agentID → CUID resolution
-	// on every tools/list. Entries expire after 30 s.
-	agentCUIDCache sync.Map
-
 	// managedAgents is the optional Claude Managed Agents events bridge.
 	// nil when not configured (no anthropic api key).
 	managedAgents managedAgentsAdmin
@@ -1063,7 +1053,7 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 		return resp, nil
 	}
 
-	rules, err := h.cachedRulesList(ctx)
+	rules, err := h.rulesRepo.List(ctx)
 	if err != nil {
 		return AgentRulesResponse{}, err
 	}
@@ -1158,55 +1148,10 @@ func newAgentRulesResponse(agentID, server, tool string) AgentRulesResponse {
 	}
 }
 
-type rulesListCacheEntry struct {
-	rules     []store.Rule
-	expiresAt time.Time
-}
-
-func (h *Handler) cachedRulesList(ctx context.Context) ([]store.Rule, error) {
-	h.rulesListMu.RLock()
-	if h.rulesListCache != nil && time.Now().Before(h.rulesListCache.expiresAt) {
-		rules := h.rulesListCache.rules
-		h.rulesListMu.RUnlock()
-		return rules, nil
-	}
-	h.rulesListMu.RUnlock()
-
-	rules, err := h.rulesRepo.List(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	h.rulesListMu.Lock()
-	defer h.rulesListMu.Unlock()
-	h.rulesListCache = &rulesListCacheEntry{rules: rules, expiresAt: time.Now().Add(10 * time.Second)}
-	return rules, nil
-}
-
-type agentCUIDCacheEntry struct {
-	cuid      string
-	expiresAt time.Time
-}
-
 func (h *Handler) resolveAgentRecordForRules(ctx context.Context, agentID string) string {
 	if h.agentsRepo == nil {
 		return ""
 	}
-	cacheKey := agentID
-	if cacheKey == "" {
-		cacheKey = "\x00default"
-	}
-	if v, ok := h.agentCUIDCache.Load(cacheKey); ok {
-		if e := v.(agentCUIDCacheEntry); time.Now().Before(e.expiresAt) {
-			return e.cuid
-		}
-	}
-	cuid := h.resolveAgentCUIDUncached(ctx, agentID)
-	h.agentCUIDCache.Store(cacheKey, agentCUIDCacheEntry{cuid: cuid, expiresAt: time.Now().Add(30 * time.Second)})
-	return cuid
-}
-
-func (h *Handler) resolveAgentCUIDUncached(ctx context.Context, agentID string) string {
 	if agentID != "" {
 		if rec, err := h.agentsRepo.GetByAgentID(ctx, agentID); err == nil {
 			return rec.ID
@@ -1636,7 +1581,7 @@ func (h *Handler) annotateToolsWithPolicy(ctx context.Context, agentID, server s
 		}
 		return append(out, atryumRulesTool)
 	}
-	rules, err := h.cachedRulesList(ctx)
+	rules, err := h.rulesRepo.List(ctx)
 	if err != nil {
 		for _, t := range tools {
 			if t.Name != atryumRulesToolName {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1224,11 +1224,7 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 			return
 		}
 		_ = h.emitTraceEvent(r.Context(), server, "mcp.tools.list", map[string]any{"tool_count": len(tools), "request_id": requestID})
-		listAgentID := auth.AgentIDFromContext(r.Context())
-		if listAgentID == "" && h.authValidator == nil {
-			listAgentID = normalizeNoAuthRequestAgentID(requestID)
-		}
-		annotated := h.annotateToolsWithPolicy(r.Context(), listAgentID, server, tools)
+		annotated := h.annotateToolsWithPolicy(r.Context(), auth.AgentIDFromContext(r.Context()), server, tools)
 		h.writeRPCResult(w, req.ID, map[string]any{"tools": annotated})
 	case "tools/call":
 		var params struct {
@@ -1260,11 +1256,7 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 		if len(resp.Error) > 0 {
 			result := normalizeToolCallResult(resp.Error, true)
 			if resp.Status == invocation.StatusDenied {
-				agentID := auth.AgentIDFromContext(r.Context())
-				if agentID == "" && h.authValidator == nil {
-					agentID = normalizeNoAuthRequestAgentID(requestID)
-				}
-				result = h.appendRulesContextToToolResult(r.Context(), result, agentID, server, params.Name)
+				result = h.appendRulesContextToToolResult(r.Context(), result, auth.AgentIDFromContext(r.Context()), server, params.Name)
 			}
 			h.writeRPCResult(w, req.ID, result)
 			return
@@ -4013,16 +4005,6 @@ func compactRequestID(id json.RawMessage) string {
 		return ""
 	}
 	return string(id)
-}
-
-func normalizeNoAuthRequestAgentID(value string) string {
-	value = strings.TrimSpace(value)
-	if strings.HasPrefix(value, `"`) {
-		if unquoted, err := strconv.Unquote(value); err == nil {
-			value = unquoted
-		}
-	}
-	return normalizeNoAuthAgentID(value)
 }
 
 func stringPtr(v string) *string { return &v }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -627,7 +627,10 @@ func parseAgentIDs(raw string) []string {
 // MCP clients can surface it to the model as system-level guidance.
 const atryumInitializeInstructions = "This MCP server is gated by the Atryum harness. " +
 	"Atryum may approve, deny, or request human approval for tool calls according to configured rules. " +
-	"Those rules may change between conversation turns, so treat each tool call as subject to the current Atryum policy."
+	"Those rules may change between conversation turns, so treat each tool call as subject to the current Atryum policy. " +
+	"To see the static approval rules that currently apply to you, issue an HTTP GET to /api/v1/agent/rules " +
+	"(optionally with ?server={server}&tool={tool} to preview the disposition for a specific tool); " +
+	"the response is advisory only, as AI-evaluation and human-approval outcomes are decided during the actual gated call."
 
 type AgentRule struct {
 	ID             string   `json:"id"`
@@ -635,17 +638,21 @@ type AgentRule struct {
 	ServerPatterns []string `json:"server_patterns"`
 	ToolPatterns   []string `json:"tool_patterns"`
 	Description    string   `json:"description,omitempty"`
+	Guidance       string   `json:"guidance,omitempty"`
 	Order          int      `json:"order"`
 }
 
 type AgentRulesResponse struct {
-	AgentID       string      `json:"agent_id,omitempty"`
-	Server        string      `json:"server,omitempty"`
-	Tool          string      `json:"tool,omitempty"`
-	DefaultAction string      `json:"default_action"`
-	Action        string      `json:"action,omitempty"`
-	MatchedRuleID *string     `json:"matched_rule_id,omitempty"`
-	Items         []AgentRule `json:"items"`
+	AgentID        string      `json:"agent_id,omitempty"`
+	Server         string      `json:"server,omitempty"`
+	Tool           string      `json:"tool,omitempty"`
+	DefaultAction  string      `json:"default_action"`
+	Action         string      `json:"action,omitempty"`
+	MatchedRuleID  *string     `json:"matched_rule_id,omitempty"`
+	GeneratedAt    time.Time   `json:"generated_at"`
+	EvaluationMode string      `json:"evaluation_mode"`
+	Explanation    string      `json:"explanation"`
+	Items          []AgentRule `json:"items"`
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1011,7 +1018,7 @@ func (h *Handler) agentRules(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if h.rulesRepo == nil {
-		writeJSON(w, http.StatusOK, AgentRulesResponse{DefaultAction: invocation.RuleActionHumanApproval, Items: []AgentRule{}})
+		writeJSON(w, http.StatusOK, newAgentRulesResponse("", "", ""))
 		return
 	}
 
@@ -1037,13 +1044,7 @@ func (h *Handler) agentRules(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, tool string) (AgentRulesResponse, error) {
-	resp := AgentRulesResponse{
-		AgentID:       agentID,
-		Server:        server,
-		Tool:          tool,
-		DefaultAction: invocation.RuleActionHumanApproval,
-		Items:         []AgentRule{},
-	}
+	resp := newAgentRulesResponse(agentID, server, tool)
 	if h.rulesRepo == nil {
 		return resp, nil
 	}
@@ -1055,7 +1056,7 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 	agentCUID := h.resolveAgentRecordForRules(ctx, agentID)
 
 	for _, rule := range rules {
-		if !apiRuleMatches(rule, server, tool, agentCUID, false) {
+		if !apiRuleVisibleToAgent(rule, agentCUID) {
 			continue
 		}
 		resp.Items = append(resp.Items, AgentRule{
@@ -1064,6 +1065,7 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 			ServerPatterns: rule.ServerPatterns,
 			ToolPatterns:   rule.ToolPatterns,
 			Description:    rule.Description,
+			Guidance:       agentRuleGuidance(rule.Action),
 			Order:          rule.Order,
 		})
 		if resp.Action == "" && server != "" && tool != "" &&
@@ -1076,6 +1078,20 @@ func (h *Handler) buildAgentRulesResponse(ctx context.Context, agentID, server, 
 		}
 	}
 	return resp, nil
+}
+
+func newAgentRulesResponse(agentID, server, tool string) AgentRulesResponse {
+	return AgentRulesResponse{
+		AgentID:        agentID,
+		Server:         server,
+		Tool:           tool,
+		DefaultAction:  invocation.RuleActionHumanApproval,
+		GeneratedAt:    time.Now().UTC(),
+		EvaluationMode: "static_only",
+		Explanation: "This advisory response is based on the current static approval rules visible to the resolved Atryum agent. " +
+			"AI evaluation rules are decided only during the actual gated tool call.",
+		Items: []AgentRule{},
+	}
 }
 
 func (h *Handler) resolveAgentRecordForRules(ctx context.Context, agentID string) string {
@@ -1105,8 +1121,15 @@ func (h *Handler) resolveAgentRecordForRules(ctx context.Context, agentID string
 	return rec.ID
 }
 
-func apiRuleMatches(rule store.Rule, server, tool, agentCUID string, includeServerTool bool) bool {
+func apiRuleVisibleToAgent(rule store.Rule, agentCUID string) bool {
 	if !rule.Enabled {
+		return false
+	}
+	return apiMatchAgentCUIDs(rule.AgentCUIDs, agentCUID)
+}
+
+func apiRuleMatches(rule store.Rule, server, tool, agentCUID string, includeServerTool bool) bool {
+	if !apiRuleVisibleToAgent(rule, agentCUID) {
 		return false
 	}
 	if includeServerTool {
@@ -1117,7 +1140,7 @@ func apiRuleMatches(rule store.Rule, server, tool, agentCUID string, includeServ
 			return false
 		}
 	}
-	return apiMatchAgentCUIDs(rule.AgentCUIDs, agentCUID)
+	return true
 }
 
 func apiMatchAgentCUIDs(cuids []string, agentCUID string) bool {
@@ -1233,7 +1256,11 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 		if len(resp.Error) > 0 {
 			result := normalizeToolCallResult(resp.Error, true)
 			if resp.Status == invocation.StatusDenied {
-				result = h.appendRulesContextToToolResult(r.Context(), result, server, params.Name)
+				agentID := auth.AgentIDFromContext(r.Context())
+				if agentID == "" && h.authValidator == nil {
+					agentID = normalizeNoAuthRequestAgentID(requestID)
+				}
+				result = h.appendRulesContextToToolResult(r.Context(), result, agentID, server, params.Name)
 			}
 			h.writeRPCResult(w, req.ID, result)
 			return
@@ -1452,6 +1479,21 @@ func apiMatchPatterns(patterns []string, value string) bool {
 	return false
 }
 
+func agentRuleGuidance(action string) string {
+	switch action {
+	case invocation.RuleActionAutoApprove:
+		return "Likely to pass if policy and rule inputs do not change."
+	case invocation.RuleActionAutoDeny:
+		return "Will be rejected by this matched rule."
+	case invocation.RuleActionHumanApproval:
+		return "Requires reviewer approval."
+	case invocation.RuleActionAIEvaluation:
+		return "Evaluated only during the real gated call; advisory cannot guarantee the outcome."
+	default:
+		return ""
+	}
+}
+
 // annotatedTool is the on-the-wire shape used for tools/list when atryum is
 // able to compute a per-tool policy disposition. It mirrors mcp.Tool but adds
 // an `annotations` block plus a description prefix so models that ignore
@@ -1531,11 +1573,11 @@ func effectiveActionForTool(rules []store.Rule, server, tool, agentCUID string) 
 
 // appendRulesContextToToolResult adds an extra text content block to a denied
 // tool call result describing the applicable rules and effective action.
-func (h *Handler) appendRulesContextToToolResult(ctx context.Context, result any, server, tool string) any {
+func (h *Handler) appendRulesContextToToolResult(ctx context.Context, result any, agentID, server, tool string) any {
 	if h.rulesRepo == nil {
 		return result
 	}
-	rulesResp, err := h.buildAgentRulesResponse(ctx, auth.AgentIDFromContext(ctx), server, tool)
+	rulesResp, err := h.buildAgentRulesResponse(ctx, agentID, server, tool)
 	if err != nil {
 		return result
 	}
@@ -3968,6 +4010,16 @@ func compactRequestID(id json.RawMessage) string {
 		return ""
 	}
 	return string(id)
+}
+
+func normalizeNoAuthRequestAgentID(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, `"`) {
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			value = unquoted
+		}
+	}
+	return normalizeNoAuthAgentID(value)
 }
 
 func stringPtr(v string) *string { return &v }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1224,7 +1224,11 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 			return
 		}
 		_ = h.emitTraceEvent(r.Context(), server, "mcp.tools.list", map[string]any{"tool_count": len(tools), "request_id": requestID})
-		annotated := h.annotateToolsWithPolicy(r.Context(), server, tools)
+		listAgentID := auth.AgentIDFromContext(r.Context())
+		if listAgentID == "" && h.authValidator == nil {
+			listAgentID = normalizeNoAuthRequestAgentID(requestID)
+		}
+		annotated := h.annotateToolsWithPolicy(r.Context(), listAgentID, server, tools)
 		h.writeRPCResult(w, req.ID, map[string]any{"tools": annotated})
 	case "tools/call":
 		var params struct {
@@ -1517,7 +1521,7 @@ type atryumToolPolicy struct {
 // annotateToolsWithPolicy decorates each tool with its effective approval
 // disposition for the current agent so the model sees the policy at the moment
 // it picks a tool. Annotation requires both rulesRepo and a concrete server.
-func (h *Handler) annotateToolsWithPolicy(ctx context.Context, server string, tools []mcp.Tool) []any {
+func (h *Handler) annotateToolsWithPolicy(ctx context.Context, agentID, server string, tools []mcp.Tool) []any {
 	out := make([]any, len(tools))
 	if h.rulesRepo == nil || strings.TrimSpace(server) == "" {
 		for i, t := range tools {
@@ -1532,7 +1536,6 @@ func (h *Handler) annotateToolsWithPolicy(ctx context.Context, server string, to
 		}
 		return out
 	}
-	agentID := auth.AgentIDFromContext(ctx)
 	agentCUID := h.resolveAgentRecordForRules(ctx, agentID)
 	for i, t := range tools {
 		action, matched := effectiveActionForTool(rules, server, t.Name, agentCUID)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1503,6 +1503,52 @@ func TestMCPToolsListAnnotationsUseDefaultAgentScopedRules(t *testing.T) {
 	}
 }
 
+func TestMCPToolsListAnnotationsIgnoreJSONRPCIDForNoAuthAgent(t *testing.T) {
+	agent := store.AgentRecord{ID: "agent-cuid-007", AgentIDs: `["agent-007"]`}
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "agent-auto", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Bash"}, AgentCUIDs: []string{agent.ID}, Enabled: true, Order: 0},
+	}}
+	svc := &stubService{tools: []mcp.Tool{{Name: "Bash", Description: "run a shell command"}}}
+	agents := &stubAgentsRepo{records: []store.AgentRecord{agent}}
+	h := NewHandler(svc, stubServerService{}, nil, rules, agents, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":"agent-007","method":"tools/list","params":{}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var rpcResp struct {
+		Result struct {
+			Tools []struct {
+				Annotations *struct {
+					Atryum struct {
+						EffectiveAction string `json:"effective_action"`
+						MatchedRuleID   string `json:"matched_rule_id"`
+					} `json:"atryum"`
+				} `json:"annotations"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &rpcResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rpcResp.Result.Tools) != 1 {
+		t.Fatalf("expected one tool, got %#v", rpcResp.Result.Tools)
+	}
+	got := rpcResp.Result.Tools[0].Annotations
+	if got == nil {
+		t.Fatal("expected annotation")
+	}
+	if got.Atryum.EffectiveAction != invocation.RuleActionHumanApproval {
+		t.Fatalf("expected anonymous/default policy, got %#v", got.Atryum)
+	}
+	if got.Atryum.MatchedRuleID != "" {
+		t.Fatalf("json-rpc id should not match agent-scoped rule, got %q", got.Atryum.MatchedRuleID)
+	}
+}
+
 func TestMCPToolsCallDenialIncludesRulesContext(t *testing.T) {
 	now := time.Now().UTC()
 	rules := &stubRulesRepo{rules: []store.Rule{
@@ -1560,7 +1606,7 @@ func TestMCPToolsCallDenialRulesContextFiltersAgentScopedRules(t *testing.T) {
 	}}
 	agents := &stubAgentsRepo{records: []store.AgentRecord{agent, other}}
 	h := NewHandler(svc, stubServerService{}, nil, rules, agents, nil, nil, nil, nil, nil)
-	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":"agent-007","method":"tools/call","params":{"name":"Bash","arguments":{"cmd":"ls"}}}`))
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo?agent_id=agent-007", strings.NewReader(`{"jsonrpc":"2.0","id":"request-1","method":"tools/call","params":{"name":"Bash","arguments":{"cmd":"ls"}}}`))
 	w := httptest.NewRecorder()
 
 	h.Routes().ServeHTTP(w, req)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1117,7 +1117,10 @@ func TestMCPToolsList(t *testing.T) {
 		t.Fatalf("expected tools list, got %s", w.Body.String())
 	}
 	if strings.Contains(w.Body.String(), `"atryum.rules.get"`) {
-		t.Fatalf("did not expect synthetic rules tool, got %s", w.Body.String())
+		t.Fatalf("did not expect dotted synthetic rules tool, got %s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"`+atryumRulesToolName+`"`) {
+		t.Fatalf("expected compatible synthetic rules tool, got %s", w.Body.String())
 	}
 }
 
@@ -1141,6 +1144,48 @@ func TestMCPToolsCallInterceptsInvocation(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), `"text":"ok"`) {
 		t.Fatalf("expected tool result, got %s", w.Body.String())
+	}
+}
+
+func TestMCPRulesToolReturnsAgentRulesWithoutInvocation(t *testing.T) {
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "read-auto", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Read"}, Enabled: true, Order: 0},
+	}}
+	svc := &stubService{}
+	h := NewHandler(svc, stubServerService{}, nil, rules, nil, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"atryum_rules_get","arguments":{"tool":"Read"}}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if svc.invokedReq != nil {
+		t.Fatalf("rules helper should not create a gated invocation, got %#v", svc.invokedReq)
+	}
+	var rpcResp struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &rpcResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rpcResp.Result.Content) != 1 {
+		t.Fatalf("expected one content block, got %#v", rpcResp.Result.Content)
+	}
+	var rulesResp AgentRulesResponse
+	if err := json.Unmarshal([]byte(rpcResp.Result.Content[0].Text), &rulesResp); err != nil {
+		t.Fatal(err)
+	}
+	if rulesResp.Server != "demo" || rulesResp.Tool != "Read" {
+		t.Fatalf("expected demo/Read preview, got %#v", rulesResp)
+	}
+	if rulesResp.Action != invocation.RuleActionAutoApprove {
+		t.Fatalf("expected auto approve disposition, got %q", rulesResp.Action)
+	}
+	if rulesResp.MatchedRuleID == nil || *rulesResp.MatchedRuleID != "read-auto" {
+		t.Fatalf("expected read-auto match, got %#v", rulesResp.MatchedRuleID)
 	}
 }
 
@@ -1382,8 +1427,8 @@ func TestAgentRulesGuidanceForEachAction(t *testing.T) {
 		byID[item.ID] = item.Guidance
 	}
 	for id, want := range map[string]string{
-		"auto-approve": "Likely to pass",
-		"auto-deny":    "Will be rejected",
+		"auto-approve": "Auto-approved",
+		"auto-deny":    "Auto-denied",
 		"human":        "Requires reviewer approval",
 		"ai":           "real gated call",
 	} {
@@ -1445,7 +1490,10 @@ func TestMCPToolsListAnnotatesEffectiveAction(t *testing.T) {
 		t.Fatalf("Other tool annotations: %#v", otherTool.Annotations)
 	}
 	if _, ok := byName["atryum.rules.get"]; ok {
-		t.Fatalf("did not expect synthetic rules tool in tools/list")
+		t.Fatalf("did not expect dotted synthetic rules tool in tools/list")
+	}
+	if _, ok := byName[atryumRulesToolName]; !ok {
+		t.Fatalf("expected compatible synthetic rules tool in tools/list")
 	}
 }
 
@@ -1522,6 +1570,7 @@ func TestMCPToolsListAnnotationsIgnoreJSONRPCIDForNoAuthAgent(t *testing.T) {
 	var rpcResp struct {
 		Result struct {
 			Tools []struct {
+				Name        string `json:"name"`
 				Annotations *struct {
 					Atryum struct {
 						EffectiveAction string `json:"effective_action"`
@@ -1534,10 +1583,25 @@ func TestMCPToolsListAnnotationsIgnoreJSONRPCIDForNoAuthAgent(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &rpcResp); err != nil {
 		t.Fatal(err)
 	}
-	if len(rpcResp.Result.Tools) != 1 {
-		t.Fatalf("expected one tool, got %#v", rpcResp.Result.Tools)
+	var bashTool *struct {
+		Name        string `json:"name"`
+		Annotations *struct {
+			Atryum struct {
+				EffectiveAction string `json:"effective_action"`
+				MatchedRuleID   string `json:"matched_rule_id"`
+			} `json:"atryum"`
+		} `json:"annotations"`
 	}
-	got := rpcResp.Result.Tools[0].Annotations
+	for i := range rpcResp.Result.Tools {
+		if rpcResp.Result.Tools[i].Name == "Bash" {
+			bashTool = &rpcResp.Result.Tools[i]
+			break
+		}
+	}
+	if bashTool == nil {
+		t.Fatalf("expected Bash tool, got %#v", rpcResp.Result.Tools)
+	}
+	got := bashTool.Annotations
 	if got == nil {
 		t.Fatal("expected annotation")
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1235,11 +1235,61 @@ func TestAgentRulesListsApplicableRulesAndDisposition(t *testing.T) {
 	if resp.MatchedRuleID == nil || *resp.MatchedRuleID != "read-auto" {
 		t.Fatalf("expected matched rule read-auto, got %#v", resp.MatchedRuleID)
 	}
+	if resp.GeneratedAt.IsZero() {
+		t.Fatal("expected generated_at to be populated")
+	}
+	if resp.EvaluationMode != "static_only" {
+		t.Fatalf("expected static_only evaluation mode, got %q", resp.EvaluationMode)
+	}
+	if !strings.Contains(resp.Explanation, "advisory") {
+		t.Fatalf("expected advisory explanation, got %q", resp.Explanation)
+	}
 	if len(resp.Items) != 3 {
 		t.Fatalf("expected three applicable rules, got %#v", resp.Items)
 	}
 	if resp.Items[0].ID != "bash-deny" || resp.Items[1].ID != "read-auto" || resp.Items[2].ID != "fallback-human" {
 		t.Fatalf("unexpected applicable rules order: %#v", resp.Items)
+	}
+	if resp.Items[1].Guidance == "" {
+		t.Fatalf("expected rule guidance, got %#v", resp.Items[1])
+	}
+}
+
+func TestAgentRulesFiltersOutRulesScopedToOtherAgents(t *testing.T) {
+	agent := store.AgentRecord{ID: "agent-cuid-007", AgentIDs: `["agent-007"]`}
+	other := store.AgentRecord{ID: "agent-cuid-other", AgentIDs: `["other-agent"]`}
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "other-agent", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentCUIDs: []string{other.ID}, Enabled: true, Order: 0},
+		{ID: "this-agent", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentCUIDs: []string{agent.ID}, Enabled: true, Order: 1},
+		{ID: "unscoped", Action: invocation.RuleActionHumanApproval, ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"}, Enabled: true, Order: 2},
+	}}
+	agents := &stubAgentsRepo{records: []store.AgentRecord{agent, other}}
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, agents, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/rules?agent_id=agent-007&source=amp&tool=Read", nil)
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AgentRulesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Action != invocation.RuleActionAutoApprove {
+		t.Fatalf("expected this-agent auto approve disposition, got %q", resp.Action)
+	}
+	if resp.MatchedRuleID == nil || *resp.MatchedRuleID != "this-agent" {
+		t.Fatalf("expected matched rule this-agent, got %#v", resp.MatchedRuleID)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected two visible rules, got %#v", resp.Items)
+	}
+	for _, item := range resp.Items {
+		if item.ID == "other-agent" {
+			t.Fatalf("other-agent scoped rule leaked into response: %#v", resp.Items)
+		}
 	}
 }
 
@@ -1276,6 +1326,70 @@ func TestAgentRulesUsesDefaultAgentRecordForAgentScopedRules(t *testing.T) {
 	}
 	if resp.Items[0].ID != "default-agent" || resp.Items[1].ID != "fallback-human" {
 		t.Fatalf("unexpected applicable rules order: %#v", resp.Items)
+	}
+}
+
+func TestAgentRulesNoAuthAgentIDFiltering(t *testing.T) {
+	agent := store.AgentRecord{ID: "agent-cuid-007", AgentIDs: `["agent-007"]`}
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "scoped", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentCUIDs: []string{agent.ID}, Enabled: true, Order: 0},
+		{ID: "other", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, AgentCUIDs: []string{"agent-other"}, Enabled: true, Order: 1},
+	}}
+	agents := &stubAgentsRepo{records: []store.AgentRecord{agent}}
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, agents, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/rules?agent_id=agent-007&source=amp&tool=Read", nil)
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AgentRulesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Action != invocation.RuleActionAutoApprove {
+		t.Fatalf("expected scoped auto approve disposition, got %q", resp.Action)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].ID != "scoped" {
+		t.Fatalf("expected only scoped visible rule, got %#v", resp.Items)
+	}
+}
+
+func TestAgentRulesGuidanceForEachAction(t *testing.T) {
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "auto-approve", Action: invocation.RuleActionAutoApprove, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Read"}, Enabled: true, Order: 0},
+		{ID: "auto-deny", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Bash"}, Enabled: true, Order: 1},
+		{ID: "human", Action: invocation.RuleActionHumanApproval, ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"}, Enabled: true, Order: 2},
+		{ID: "ai", Action: invocation.RuleActionAIEvaluation, ServerPatterns: []string{"amp"}, ToolPatterns: []string{"Search"}, Enabled: true, Order: 3},
+	}}
+	h := NewHandler(&stubService{}, stubServerService{}, nil, rules, nil, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agent/rules", nil)
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp AgentRulesResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]string{}
+	for _, item := range resp.Items {
+		byID[item.ID] = item.Guidance
+	}
+	for id, want := range map[string]string{
+		"auto-approve": "Likely to pass",
+		"auto-deny":    "Will be rejected",
+		"human":        "Requires reviewer approval",
+		"ai":           "real gated call",
+	} {
+		if !strings.Contains(byID[id], want) {
+			t.Fatalf("expected %s guidance to contain %q, got %q", id, want, byID[id])
+		}
 	}
 }
 
@@ -1427,6 +1541,49 @@ func TestMCPToolsCallDenialIncludesRulesContext(t *testing.T) {
 	last := rpcResp.Result.Content[len(rpcResp.Result.Content)-1].Text
 	if !strings.Contains(last, "Atryum approval rules") || !strings.Contains(last, "bash-deny") {
 		t.Fatalf("expected rules context in denial result, got %q", last)
+	}
+}
+
+func TestMCPToolsCallDenialRulesContextFiltersAgentScopedRules(t *testing.T) {
+	now := time.Now().UTC()
+	agent := store.AgentRecord{ID: "agent-cuid-007", AgentIDs: `["agent-007"]`}
+	other := store.AgentRecord{ID: "agent-cuid-other", AgentIDs: `["other-agent"]`}
+	rules := &stubRulesRepo{rules: []store.Rule{
+		{ID: "other-deny", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Bash"}, AgentCUIDs: []string{other.ID}, Enabled: true, Order: 0},
+		{ID: "agent-deny", Action: invocation.RuleActionAutoDeny, ServerPatterns: []string{"demo"}, ToolPatterns: []string{"Bash"}, AgentCUIDs: []string{agent.ID}, Enabled: true, Order: 1},
+	}}
+	svc := &stubService{invoke: invocation.InvocationResponse{
+		InvocationID: "inv_denied", ServerName: "demo", ToolName: "Bash",
+		Status:      invocation.StatusDenied,
+		SubmittedAt: now, CompletedAt: &now,
+		Error: json.RawMessage(`{"content":[{"type":"text","text":"Tool call denied by approval rule (auto_deny)."}],"isError":true}`),
+	}}
+	agents := &stubAgentsRepo{records: []store.AgentRecord{agent, other}}
+	h := NewHandler(svc, stubServerService{}, nil, rules, agents, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":"agent-007","method":"tools/call","params":{"name":"Bash","arguments":{"cmd":"ls"}}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	var rpcResp struct {
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &rpcResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rpcResp.Result.Content) < 2 {
+		t.Fatalf("expected denial text plus rules context, got %#v", rpcResp.Result.Content)
+	}
+	last := rpcResp.Result.Content[len(rpcResp.Result.Content)-1].Text
+	if !strings.Contains(last, "agent-deny") {
+		t.Fatalf("expected agent scoped rule in denial context, got %q", last)
+	}
+	if strings.Contains(last, "other-deny") {
+		t.Fatalf("other agent rule leaked into denial context: %q", last)
 	}
 }
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1124,6 +1124,38 @@ func TestMCPToolsList(t *testing.T) {
 	}
 }
 
+func TestMCPRulesToolSchemaIncludesRequestIDFallback(t *testing.T) {
+	h := NewHandler(&stubService{tools: []mcp.Tool{{Name: "demo_tool"}}}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/demo", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	var rpcResp struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				InputSchema struct {
+					Properties map[string]json.RawMessage `json:"properties"`
+				} `json:"inputSchema"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &rpcResp); err != nil {
+		t.Fatal(err)
+	}
+	for _, tool := range rpcResp.Result.Tools {
+		if tool.Name != atryumRulesToolName {
+			continue
+		}
+		if _, ok := tool.InputSchema.Properties["request_id"]; !ok {
+			t.Fatalf("expected request_id in %s schema properties, got %#v", atryumRulesToolName, tool.InputSchema.Properties)
+		}
+		return
+	}
+	t.Fatalf("expected %s in tools/list, got %#v", atryumRulesToolName, rpcResp.Result.Tools)
+}
+
 func TestMCPToolsCallInterceptsInvocation(t *testing.T) {
 	now := time.Now().UTC()
 	svc := &stubService{invoke: invocation.InvocationResponse{InvocationID: "inv_123", ServerName: "demo", ToolName: "demo_tool", Status: invocation.StatusSucceeded, Input: json.RawMessage(`{"a":1}`), SubmittedAt: now, CompletedAt: &now, Result: json.RawMessage(`{"content":[{"type":"text","text":"ok"}]}`)}}


### PR DESCRIPTION
We would like agents to be able to read in their rules to reduce the number of denied calls.
A previous version of this pr added a mcp tool for this but it was useless for the agent harnesses. This time around, we have the harnesses hit the rules endpoint every 5 minutes to get their rules. The mcp rule call also got readded.

https://github.com/validmind/atryum/issues/91

Open question:
Currently, i only expose static tools to the agent. Should we also expose llm as judge rules? I wonder if an agent knowing about llm as judge rules could make it act differently hmmmmm


<img width="1610" height="530" alt="Screenshot 2026-06-26 at 16 05 08" src="https://github.com/user-attachments/assets/d540b444-153d-4e08-9076-d00bfc344a7b" />
