### PR TITLE
mv /api/v1/admin/oauth/callback to /api/v1/mcp/oauth/callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The Settings UI can also select a default ValidMind agent record. AI Evaluation 
 
 ## Admin authentication
 
-Admin UI and admin API authentication is optional. When no `[[auth]]` block has `admin_enabled = true`, the admin UI/API behave as before and remain open. When one or more blocks are admin-enabled, Atryum requires a browser OIDC access token for admin API calls and accepts tokens from any admin-enabled issuer. The upstream MCP OAuth callback at `/api/v1/admin/oauth/callback` remains public so external identity providers can complete browser redirects.
+Admin UI and admin API authentication is optional. When no `[[auth]]` block has `admin_enabled = true`, the admin UI/API behave as before and remain open. When one or more blocks are admin-enabled, Atryum requires a browser OIDC access token for admin API calls and accepts tokens from any admin-enabled issuer. The upstream MCP OAuth callback at `/api/v1/mcp/oauth/callback` remains public so external identity providers can complete browser redirects.
 
 Admin auth reuses the same issuer/audience/JWKS validation as agent auth, then checks the admin claim configured on the matched `[[auth]]` block. This means different IdPs can use different admin claims at the same time.
 
@@ -145,7 +145,7 @@ Admin (UI and operators):
 - `/api/v1/admin/settings`, `/api/v1/admin/policy`
 - `/api/v1/admin/managed-agents/accounts`, `/managed-agents/agents` — discover configured Anthropic accounts and Claude agents for UI linking
 - `/api/v1/admin/managed-agents/sessions` — manually register a Claude Managed Agents session for the events bridge to watch; kept as a debugging escape hatch
-- `/api/v1/admin/oauth/callback` — public OAuth callback for upstream MCP server connect flows
+- `/api/v1/mcp/oauth/callback` — public OAuth callback for upstream MCP server connect flows
 - `/api/v1/admin-auth/config` — public, non-secret OIDC metadata for the admin UI login screen
 
 ## Frontend

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -36,6 +36,8 @@ import (
 //go:embed web/*
 var webFS embed.FS
 
+const upstreamMCPOAuthCallbackPath = "/api/v1/mcp/oauth/callback"
+
 type service interface {
 	Invoke(ctx context.Context, req invocation.CreateInvocationRequest) (invocation.InvocationResponse, error)
 	ListTools(ctx context.Context, server string) ([]mcp.Tool, error)
@@ -786,7 +788,7 @@ func (h *Handler) Routes() http.Handler {
 	mux.Handle("/api/v1/admin/vm/organizations", admin(h.adminVMOrganizations))
 	mux.Handle("/api/v1/admin/vm/record-types", admin(h.adminVMRecordTypes))
 	mux.Handle("/api/v1/admin/vm/custom-fields", admin(h.adminVMCustomFields))
-	mux.HandleFunc("/api/v1/admin/oauth/callback", h.oauthCallback)
+	mux.HandleFunc(upstreamMCPOAuthCallbackPath, h.oauthCallback)
 	mux.Handle("/api/v1/admin/policy", admin(h.adminPolicy))
 	mux.Handle("/api/v1/admin/managed-agents/accounts", admin(h.adminManagedAgentAccounts))
 	mux.Handle("/api/v1/admin/managed-agents/agents", admin(h.adminManagedAgents))
@@ -3244,7 +3246,7 @@ func (s *ServerAdminService) StartConnect(ctx context.Context, name string, appB
 	if s.publicBaseURL != "" {
 		redirectBaseURL = s.publicBaseURL
 	}
-	redirectURI := redirectBaseURL + "/api/v1/admin/oauth/callback"
+	redirectURI := redirectBaseURL + upstreamMCPOAuthCallbackPath
 	connectReq, err := provider.BuildConnectRequest(ctx, upstream, redirectURI, stateToken)
 	if err != nil {
 		return OAuthConnectStartResponse{}, err

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -3,11 +3,13 @@ package api
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +20,8 @@ import (
 	"atryum/internal/managedagents"
 	"atryum/internal/mcp"
 	"atryum/internal/store"
+
+	_ "modernc.org/sqlite"
 )
 
 type stubService struct {
@@ -121,6 +125,21 @@ func (stubServerService) GetConnectStatus(context.Context, string) (OAuthConnect
 }
 func (stubServerService) CompleteConnect(context.Context, string, string, string) (OAuthConnectStatusResponse, error) {
 	return OAuthConnectStatusResponse{}, nil
+}
+
+type callbackServerService struct {
+	stubServerService
+	state     string
+	code      string
+	errorText string
+}
+
+func (s *callbackServerService) CompleteConnect(_ context.Context, state string, code string, errorText string) (OAuthConnectStatusResponse, error) {
+	s.state = state
+	s.code = code
+	s.errorText = errorText
+	message := "connected"
+	return OAuthConnectStatusResponse{Status: "succeeded", Message: &message}, nil
 }
 
 type stubRulesRepo struct {
@@ -229,6 +248,86 @@ func (s *stubAgentSyncSettingsRepo) Get(context.Context) (store.AgentSyncSetting
 func (s *stubAgentSyncSettingsRepo) Save(_ context.Context, settings store.AgentSyncSettings) error {
 	s.settings = settings
 	return nil
+}
+
+func TestUpstreamMCPOAuthCallbackRouteIsPublicMCPPath(t *testing.T) {
+	t.Run("new path serves callback", func(t *testing.T) {
+		serverSvc := &callbackServerService{}
+		h := NewHandler(&stubService{}, serverSvc, nil, nil, nil, nil, nil, nil, nil, nil)
+		req := httptest.NewRequest(http.MethodGet, upstreamMCPOAuthCallbackPath+"?state=state-123&code=code-456", nil)
+		w := httptest.NewRecorder()
+
+		h.Routes().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+		}
+		if serverSvc.state != "state-123" || serverSvc.code != "code-456" || serverSvc.errorText != "" {
+			t.Fatalf("callback args = state %q code %q error %q", serverSvc.state, serverSvc.code, serverSvc.errorText)
+		}
+	})
+
+	t.Run("old path is removed", func(t *testing.T) {
+		h := NewHandler(&stubService{}, &callbackServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/oauth/callback?state=old&code=old", nil)
+		w := httptest.NewRecorder()
+
+		h.Routes().ServeHTTP(w, req)
+
+		if w.Code == http.StatusOK {
+			t.Fatalf("expected old admin callback path not to succeed")
+		}
+	})
+}
+
+func TestStartConnectUsesUpstreamMCPOAuthCallbackRedirectURI(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+	if err := store.InitDB(db); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+
+	ctx := context.Background()
+	serverRepo := store.NewServerRepo(db)
+	oauthRepo := store.NewOAuthRepo(db)
+	if err := serverRepo.UpsertServer(ctx, mcp.Upstream{
+		Name:              "shortcut",
+		Mode:              mcp.UpstreamModeHTTP,
+		BaseURL:           "https://mcp.example.test",
+		Enabled:           true,
+		OAuthAuthorizeURL: "https://idp.example.test/authorize",
+		OAuthTokenURL:     "https://idp.example.test/token",
+		OAuthClientID:     "client-123",
+		OAuthScopes:       "read write",
+	}); err != nil {
+		t.Fatalf("UpsertServer: %v", err)
+	}
+
+	svc := NewServerAdminService(serverRepo, oauthRepo, nil, 5*time.Second, "")
+	resp, err := svc.StartConnect(ctx, "shortcut", "http://localhost:8080/")
+	if err != nil {
+		t.Fatalf("StartConnect: %v", err)
+	}
+
+	parsed, err := url.Parse(resp.ConnectURL)
+	if err != nil {
+		t.Fatalf("parse connect url: %v", err)
+	}
+	wantRedirectURI := "http://localhost:8080" + upstreamMCPOAuthCallbackPath
+	if got := parsed.Query().Get("redirect_uri"); got != wantRedirectURI {
+		t.Fatalf("redirect_uri = %q, want %q", got, wantRedirectURI)
+	}
+
+	session, err := oauthRepo.GetConnectSession(ctx, resp.State)
+	if err != nil {
+		t.Fatalf("GetConnectSession: %v", err)
+	}
+	if session.RedirectURI != wantRedirectURI {
+		t.Fatalf("saved redirect_uri = %q, want %q", session.RedirectURI, wantRedirectURI)
+	}
 }
 
 func TestAdminServerTestDebugLogsRequestContext(t *testing.T) {

--- a/website/md-drafts/1_integrations/2_connect-agents.md
+++ b/website/md-drafts/1_integrations/2_connect-agents.md
@@ -373,7 +373,7 @@ When auth mode is enabled, configure your agent to send a bearer token rather th
 
 ### Admin UI authentication
 
-Admin UI/API authentication is opt-in. If no configured `[[auth]]` block has `admin_enabled = true`, `/ui/` and the admin API remain open for local development. As soon as one or more blocks are admin-enabled, Atryum requires a valid browser OIDC access token for admin API calls. The upstream MCP OAuth callback at `/api/v1/admin/oauth/callback` remains public so external identity providers can complete browser redirects.
+Admin UI/API authentication is opt-in. If no configured `[[auth]]` block has `admin_enabled = true`, `/ui/` and the admin API remain open for local development. As soon as one or more blocks are admin-enabled, Atryum requires a valid browser OIDC access token for admin API calls. The upstream MCP OAuth callback at `/api/v1/mcp/oauth/callback` remains public so external identity providers can complete browser redirects.
 
 Admin auth reuses the same issuer, audience, expiry, signature, and JWKS validation as agent auth. After token verification, Atryum checks the admin claim from the matched `[[auth]]` block:
 

--- a/website/md-drafts/1_integrations/3_connect-mcp-servers.md
+++ b/website/md-drafts/1_integrations/3_connect-mcp-servers.md
@@ -116,11 +116,17 @@ Use manual registration when the upstream server does not support Dynamic Client
         - Leave **Use default scopes** checked to use whatever scopes the OAuth app declared with the provider.
         - Uncheck **Use default scopes** to define custom scopes, then enter them in **Scopes (requested)**.
 
-3. Make sure that **Enabled** is checked.
+3. Register Atryum's redirect URI with your OAuth provider. Add `<your-atryum-base-url>/api/v1/mcp/oauth/callback` (for example, `https://atryum.example.com/api/v1/mcp/oauth/callback`) to the allowed redirect/callback URLs of the OAuth app. The provider rejects the **Connect** flow if this exact URL is not registered.
 
-4. Click **Create Server** (or **Save** when editing an existing server), then click **Connect** (or **Reconnect**) to complete authorization.
+4. Make sure that **Enabled** is checked.
+
+5. Click **Create Server** (or **Save** when editing an existing server), then click **Connect** (or **Reconnect**) to complete authorization.
 
 When a server needs re-authentication, the auth status shows that action is required and the **Reconnect** button appears in the server detail panel.
+
+:::
+The upstream MCP OAuth callback path changed from `/api/v1/admin/oauth/callback` to `/api/v1/mcp/oauth/callback`. If you registered the old path with an external provider, update the redirect/callback URL to the new path, or the **Connect** flow will fail.
+:::
 
 :::
 Leave **Bearer Token** blank when using the OAuth **Connect** flow. Atryum hides the bearer field once OAuth credentials are in place.


### PR DESCRIPTION
the mcp oauth callback has nothing to do with the admin page so it should have a different route.

https://github.com/validmind/atryum/issues/120