### PR TITLE
[SC-16888] Reconcile stale agents on sync to prune archived/deleted VM records

### DIFF
--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -137,6 +137,7 @@ func runServer(args []string) error {
 		log.Printf("agent sync: fetched %d agent(s) for org=%s (%s) record_type=%s", agentsResp.Total, agentsResp.OrgCUID, agentsResp.OrgName, settings.AgentRecordTypeSlug)
 		syncedAt := time.Now().UTC()
 		charterKey := settings.CharterFieldKey
+		activeCUIDs := make([]string, 0, len(agentsResp.Results))
 		for _, a := range agentsResp.Results {
 			description, _ := a.CustomFields["description"].(string)
 			// Pull the charter from the configured custom field. Tolerate both a
@@ -162,6 +163,20 @@ func runServer(args []string) error {
 				SyncedAt:           syncedAt,
 			}); upsertErr != nil {
 				log.Printf("  agent sync upsert failed for cuid=%s: %v", a.CUID, upsertErr)
+			} else {
+				activeCUIDs = append(activeCUIDs, a.CUID)
+			}
+		}
+		// Prune agents that are no longer present in ValidMind (archived or deleted).
+		// Agents with managed agent bindings are never pruned: deleting them would
+		// cascade-delete their binding configuration (ON DELETE CASCADE FK).
+		boundCUIDs, err := agentsRepo.ListVMCUIDsWithBindings(ctx)
+		if err != nil {
+			log.Printf("agent sync: could not list agents with bindings, skipping stale prune: %v", err)
+		} else {
+			keepCUIDs := append(activeCUIDs, boundCUIDs...)
+			if err := agentsRepo.DeleteSyncedStaleForOrg(ctx, agentsResp.OrgCUID, keepCUIDs); err != nil {
+				log.Printf("agent sync: failed to prune stale agents for org=%s: %v", agentsResp.OrgCUID, err)
 			}
 		}
 		return nil

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -301,6 +301,48 @@ func (r *AgentsRepo) DeleteSynced(ctx context.Context) error {
 	return err
 }
 
+// ListVMCUIDsWithBindings returns the vm_cuid of every agent that has at least
+// one managed_agent_binding row. These agents must not be pruned during sync:
+// deleting them would cascade-delete their binding configuration.
+func (r *AgentsRepo) ListVMCUIDsWithBindings(ctx context.Context) ([]string, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT vm_cuid FROM agents WHERE id IN (SELECT DISTINCT agent_cuid FROM managed_agent_bindings)`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list agents with bindings: %w", err)
+	}
+	defer rows.Close()
+	var cuids []string
+	for rows.Next() {
+		var c string
+		if err := rows.Scan(&c); err != nil {
+			return nil, err
+		}
+		cuids = append(cuids, c)
+	}
+	return cuids, rows.Err()
+}
+
+// DeleteSyncedStaleForOrg removes synced agent records for the given org whose
+// vm_cuid is not in keepCUIDs. Called after each sync to prune agents that were
+// archived or deleted in ValidMind. Manually-created agents (empty
+// vm_organization_cuid) are never touched.
+//
+// If keepCUIDs is empty, all synced agents for the org are removed (the org has
+// no active records of the configured record type).
+func (r *AgentsRepo) DeleteSyncedStaleForOrg(ctx context.Context, orgCUID string, keepCUIDs []string) error {
+	q := r.sb.Delete("agents").Where(sq.Eq{"vm_organization_cuid": orgCUID})
+	if len(keepCUIDs) > 0 {
+		q = q.Where(sq.NotEq{"vm_cuid": keepCUIDs})
+	}
+	query, args, err := q.ToSql()
+	if err != nil {
+		return fmt.Errorf("build stale agent delete: %w", err)
+	}
+	_, err = r.db.ExecContext(ctx, query, args...)
+	return err
+}
+
 // List returns all agent records ordered by vm_name.
 func (r *AgentsRepo) List(ctx context.Context) ([]AgentRecord, error) {
 	return r.list(ctx, r.sb.Select(agentColumns...).From("agents").OrderBy("vm_name ASC"))

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -305,9 +305,15 @@ func (r *AgentsRepo) DeleteSynced(ctx context.Context) error {
 // one managed_agent_binding row. These agents must not be pruned during sync:
 // deleting them would cascade-delete their binding configuration.
 func (r *AgentsRepo) ListVMCUIDsWithBindings(ctx context.Context) ([]string, error) {
-	rows, err := r.db.QueryContext(ctx,
-		`SELECT vm_cuid FROM agents WHERE id IN (SELECT DISTINCT agent_cuid FROM managed_agent_bindings)`,
-	)
+	query, args, err := r.sb.
+		Select("DISTINCT a.vm_cuid").
+		From("agents a").
+		Join("managed_agent_bindings mab ON mab.agent_cuid = a.id").
+		ToSql()
+	if err != nil {
+		return nil, fmt.Errorf("build list agents with bindings: %w", err)
+	}
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list agents with bindings: %w", err)
 	}

--- a/internal/store/agents.go
+++ b/internal/store/agents.go
@@ -336,7 +336,13 @@ func (r *AgentsRepo) ListVMCUIDsWithBindings(ctx context.Context) ([]string, err
 //
 // If keepCUIDs is empty, all synced agents for the org are removed (the org has
 // no active records of the configured record type).
+//
+// Returns an error if orgCUID is empty: an empty orgCUID would match all
+// manually-created agents (which also store "" in vm_organization_cuid).
 func (r *AgentsRepo) DeleteSyncedStaleForOrg(ctx context.Context, orgCUID string, keepCUIDs []string) error {
+	if orgCUID == "" {
+		return fmt.Errorf("DeleteSyncedStaleForOrg: orgCUID must not be empty")
+	}
 	q := r.sb.Delete("agents").Where(sq.Eq{"vm_organization_cuid": orgCUID})
 	if len(keepCUIDs) > 0 {
 		q = q.Where(sq.NotEq{"vm_cuid": keepCUIDs})


### PR DESCRIPTION
## What and why?

Previously, archiving or deleting an inventory record in ValidMind left the corresponding agent row in Atryum's database indefinitely — the sync only upserted, never removed. The agent remained visible in the Atryum UI until a user changed the org or record type in Settings (which triggers `DeleteSynced`).

This PR adds reconciliation to every sync run: after upserting the active records returned from ValidMind, any synced agent for the configured org whose `vm_cuid` is no longer in the pull is deleted. This covers records archived or deleted in ValidMind.

**Safety:** agents with active managed agent bindings (`managed_agent_bindings` FK → `agents.id ON DELETE CASCADE`) are exempted from pruning — their `vm_cuid` is added to `keepCUIDs` before the delete so binding configuration is not accidentally destroyed.

**Companion PR in the backend repo** adds the CRUD-event triggers that fire the sync automatically: [validmind/backend#3330](https://github.com/validmind/backend/pull/3330)

## How to test

1. Configure Atryum with a ValidMind org and record type.
2. Ensure at least one inventory record is synced as an agent.
3. Archive or delete that record in ValidMind.
4. Trigger a sync (manually via the Sync button, or wait for startup).
5. Confirm the agent is removed from the Atryum Agents list.
6. Confirm that an agent with managed agent bindings is **not** removed even if its VM record is archived.

## What needs special review?

- `ListVMCUIDsWithBindings` uses a raw SQL query (`agents WHERE id IN (SELECT DISTINCT agent_cuid FROM managed_agent_bindings)`). This works for both SQLite and PostgreSQL dialects but bypasses the squirrel query builder — intentional for the subquery pattern.
- If `ListVMCUIDsWithBindings` errors, the entire prune step is skipped (logged). This is a safe degradation: stale agents linger until the next successful sync rather than risking accidental deletion.

## Dependencies, breaking changes, and deployment notes

- **Companion PR required in `validmind/backend`**: [validmind/backend#3330](https://github.com/validmind/backend/pull/3330) — adds the CRUD event triggers that call Atryum's sync endpoint automatically.
- No new migrations, no config changes, no API surface changes.
- Startup sync now also prunes stale agents, so deploying this binary alone (without the backend PR) is safe and beneficial.

## Release notes

Archived or deleted ValidMind inventory records are now automatically removed from Atryum's agent list on the next sync, keeping the two systems consistent without manual intervention.

Made with [Cursor](https://cursor.com)