### PR TITLE
Add Invocation Audit section to FOSS UI + audit event instrumentation

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -45,8 +45,8 @@ type service interface {
 	List(ctx context.Context, filter invocation.InvocationListFilter) (invocation.InvocationListResponse, error)
 	ListAgentIDs(ctx context.Context) ([]string, error)
 	Events(ctx context.Context, invocationID string, filter invocation.EventListFilter) (invocation.EventListResponse, error)
-	Approve(ctx context.Context, invocationID string) error
-	Deny(ctx context.Context, invocationID string, message string) error
+	Approve(ctx context.Context, invocationID string, actorID string) error
+	Deny(ctx context.Context, invocationID string, message string, actorID string) error
 	Submit(ctx context.Context, req invocation.ExternalSubmitRequest) (invocation.InvocationResponse, error)
 	RecordExecution(ctx context.Context, invocationID string, update invocation.ExternalExecutionUpdate) (invocation.InvocationResponse, error)
 	SetSummary(ctx context.Context, invocationID string, summary string) (invocation.InvocationResponse, error)
@@ -191,11 +191,17 @@ type PolicyUpdateRequest struct {
 
 type ApproveRequest struct {
 	CreateRule *AdminRuleInput `json:"create_rule,omitempty"`
+	// ActorID identifies the human reviewer who made the decision. Optional —
+	// when omitted no attribution is stored. The VM backend proxy injects this
+	// field from the authenticated user's identity before forwarding.
+	ActorID string `json:"actor_id,omitempty"`
 }
 
 type DenyRequest struct {
 	Message    string          `json:"message,omitempty"`
 	CreateRule *AdminRuleInput `json:"create_rule,omitempty"`
+	// ActorID identifies the human reviewer who made the decision. Optional.
+	ActorID string `json:"actor_id,omitempty"`
 }
 
 type AdminServer struct {
@@ -1673,7 +1679,7 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 		}
-		if err := h.svc.Approve(r.Context(), id); err != nil {
+		if err := h.svc.Approve(r.Context(), id, req.ActorID); err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
@@ -1732,7 +1738,7 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 				return
 			}
 		}
-		if err := h.svc.Deny(r.Context(), id, req.Message); err != nil {
+		if err := h.svc.Deny(r.Context(), id, req.Message, req.ActorID); err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -68,8 +68,8 @@ func (s *stubService) ListAgentIDs(context.Context) ([]string, error) {
 func (s *stubService) Events(context.Context, string, invocation.EventListFilter) (invocation.EventListResponse, error) {
 	return invocation.EventListResponse{}, nil
 }
-func (s *stubService) Approve(context.Context, string) error      { return nil }
-func (s *stubService) Deny(context.Context, string, string) error { return nil }
+func (s *stubService) Approve(context.Context, string, string) error      { return nil }
+func (s *stubService) Deny(context.Context, string, string, string) error { return nil }
 func (s *stubService) Submit(ctx context.Context, req invocation.ExternalSubmitRequest) (invocation.InvocationResponse, error) {
 	s.submitReq = &req
 	s.submitCtx = ctx

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -323,7 +323,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 		// If every matching ai_evaluation rule deferred, treat as human approval.
 		if ruleMatched && decision.Disposition == dispositionContinue {
 			decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
-			s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, "", string(policy.DispositionHuman), decision, nil)
+			s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, "", RuleActionAIEvaluation, decision, nil)
 		}
 		}
 	}

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -320,11 +320,11 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 					"rule_id", r.ID, "server", upstream.Name, "tool", req.Tool)
 				matchedRuleID = nil
 			}
-		// If every matching ai_evaluation rule deferred, treat as human approval.
-		if ruleMatched && decision.Disposition == dispositionContinue {
-			decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
-			s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, "", RuleActionAIEvaluation, decision, nil)
-		}
+			// If every matching ai_evaluation rule deferred, treat as human approval.
+			if ruleMatched && decision.Disposition == dispositionContinue {
+				decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
+				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, "", RuleActionAIEvaluation, decision, nil)
+			}
 		}
 	}
 	if !ruleMatched && s.policy != nil {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -1348,7 +1348,7 @@ func (s *Service) toResponse(inv Invocation) InvocationResponse {
 
 // emitRuleEvaluatedEvent records one entry in the per-invocation audit trail for
 // each rule that was evaluated during rule-iteration. disposition is the raw
-// policy disposition ("auto", "never", "human_approval", "continue", etc.).
+// policy disposition ("auto", "never", "human", "continue", etc.).
 // When skipped is true the rule returned "next_rule" / dispositionContinue and
 // rule iteration continued to the next candidate.
 func (s *Service) emitRuleEvaluatedEvent(ctx context.Context, invocationID, ruleID, action string, d policy.Decision, conf *float64) {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -137,6 +137,7 @@ type SummaryResponse struct {
 type approvalDecision struct {
 	approved bool
 	message  string
+	actorID  string
 }
 
 type invocationRepo interface {
@@ -297,25 +298,27 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 					id := r.ID
 					matchedRuleID = &id
 				}
+				var ruleConf *float64
 				switch r.Action {
 				case RuleActionAutoDeny:
 					decision = policy.Decision{Disposition: policy.DispositionNever, Reason: "matched approval rule (auto_deny)"}
 				case RuleActionAutoApprove:
 					decision = policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (auto_approve)"}
 				case RuleActionAIEvaluation:
-					var conf *float64
-					decision, conf = s.runAIEvaluation(ctx, &r, upstream.Name, req.Tool, req.Input, agentID, agentRec, "", 0)
+					decision, ruleConf = s.runAIEvaluation(ctx, &r, upstream.Name, req.Tool, req.Input, agentID, agentRec, "", 0)
 					if decision.Disposition != dispositionContinue {
-						aiConfidence = conf
+						aiConfidence = ruleConf
 					}
 				default:
 					decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (human_approval)"}
 				}
+				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, r.ID, r.Action, decision, ruleConf)
 				if decision.Disposition != dispositionContinue {
 					break
 				}
 				slog.Info("ai_evaluation: LLM deferred to next rule; continuing rule iteration",
 					"rule_id", r.ID, "server", upstream.Name, "tool", req.Tool)
+				matchedRuleID = nil
 			}
 			// If every matching ai_evaluation rule deferred, treat as human approval.
 			if ruleMatched && decision.Disposition == dispositionContinue {
@@ -710,27 +713,38 @@ func (s *Service) waitForHumanApproval(ctx context.Context, inv Invocation, upst
 	})
 	s.summarizePendingApproval(inv.InvocationID)
 
+	var approvedActorID string
 	select {
 	case d := <-ch:
 		if !d.approved {
 			completed := time.Now().UTC()
 			inv.Status = StatusDenied
 			inv.CompletedAt = &completed
-			inv.Approval = &Approval{Status: humanDecisionStatus(inv.Approval, false), Reason: stringPtr("human")}
+			inv.Approval = &Approval{
+				Status:     humanDecisionStatus(inv.Approval, false),
+				Reason:     stringPtr("human"),
+				ActorID:    stringPtrIfNotEmpty(d.actorID),
+				DecisionAt: timePtr(completed),
+			}
 			msg := "Tool call denied by the MCP permissions system."
 			if d.message != "" {
 				msg += "\n\nReason: " + d.message
 			}
 			inv.Error = mustJSON(map[string]any{"content": []map[string]any{{"type": "text", "text": msg}}, "isError": true})
 			_ = s.invocations.UpdateResult(context.Background(), inv)
+			deniedPayload := map[string]any{"message": d.message, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}
+			if d.actorID != "" {
+				deniedPayload["actor_id"] = d.actorID
+			}
 			_ = s.events.Create(context.Background(), Event{
 				InvocationID: inv.InvocationID,
 				EventType:    "invocation.denied",
-				Payload:      mustJSON(map[string]any{"message": d.message, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}),
+				Payload:      mustJSON(deniedPayload),
 				CreatedAt:    completed,
 			})
 			return s.toResponse(inv), nil
 		}
+		approvedActorID = d.actorID
 	case <-ctx.Done():
 		completed := time.Now().UTC()
 		inv.Status = StatusFailed
@@ -741,19 +755,39 @@ func (s *Service) waitForHumanApproval(ctx context.Context, inv Invocation, upst
 		return s.toResponse(inv), nil
 	}
 
+	approvedAt := time.Now().UTC()
 	inv.Status = StatusExecuting
-	inv.Approval = &Approval{Status: humanDecisionStatus(inv.Approval, true), Reason: stringPtr("human")}
+	inv.Approval = &Approval{
+		Status:     humanDecisionStatus(inv.Approval, true),
+		Reason:     stringPtr("human"),
+		ActorID:    stringPtrIfNotEmpty(approvedActorID),
+		DecisionAt: timePtr(approvedAt),
+	}
 	if err := s.invocations.UpdateResult(ctx, inv); err != nil {
 		return InvocationResponse{}, err
+	}
+	approvedEventPayload := map[string]any{}
+	if approvedActorID != "" {
+		approvedEventPayload["actor_id"] = approvedActorID
+	}
+	_ = s.events.Create(ctx, Event{
+		InvocationID: inv.InvocationID,
+		EventType:    "invocation.approved",
+		Payload:      mustJSON(approvedEventPayload),
+		CreatedAt:    approvedAt,
+	})
+	executingPayload := map[string]any{
+		"upstream": upstream.Name, "request_id": req.RequestID,
+		"input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input),
+	}
+	if approvedActorID != "" {
+		executingPayload["actor_id"] = approvedActorID
 	}
 	_ = s.events.Create(ctx, Event{
 		InvocationID: inv.InvocationID,
 		EventType:    "invocation.executing",
-		Payload: mustJSON(map[string]any{
-			"upstream": upstream.Name, "request_id": req.RequestID,
-			"input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input),
-		}),
-		CreatedAt: time.Now().UTC(),
+		Payload:      mustJSON(executingPayload),
+		CreatedAt:    approvedAt,
 	})
 	return s.finishExecution(ctx, inv, upstream, req)
 }
@@ -795,13 +829,13 @@ func (s *Service) finishExecution(ctx context.Context, inv Invocation, upstream 
 	return s.toResponse(inv), nil
 }
 
-func (s *Service) Approve(ctx context.Context, invocationID string) error {
+func (s *Service) Approve(ctx context.Context, invocationID string, actorID string) error {
 	s.mu.Lock()
 	ch, ok := s.pendingApprovals[invocationID]
 	s.mu.Unlock()
 	if ok {
 		select {
-		case ch <- approvalDecision{approved: true}:
+		case ch <- approvalDecision{approved: true, actorID: actorID}:
 			return nil
 		default:
 			return fmt.Errorf("invocation %s approval already decided", invocationID)
@@ -809,25 +843,25 @@ func (s *Service) Approve(ctx context.Context, invocationID string) error {
 	}
 	// External (mediated) invocation: no in-memory waiter. Update DB directly
 	// so the polling external executor can pick up the decision.
-	return s.recordExternalDecision(ctx, invocationID, true, "")
+	return s.recordExternalDecision(ctx, invocationID, true, "", actorID)
 }
 
-func (s *Service) Deny(ctx context.Context, invocationID string, message string) error {
+func (s *Service) Deny(ctx context.Context, invocationID string, message string, actorID string) error {
 	s.mu.Lock()
 	ch, ok := s.pendingApprovals[invocationID]
 	s.mu.Unlock()
 	if ok {
 		select {
-		case ch <- approvalDecision{approved: false, message: message}:
+		case ch <- approvalDecision{approved: false, message: message, actorID: actorID}:
 			return nil
 		default:
 			return fmt.Errorf("invocation %s approval already decided", invocationID)
 		}
 	}
-	return s.recordExternalDecision(ctx, invocationID, false, message)
+	return s.recordExternalDecision(ctx, invocationID, false, message, actorID)
 }
 
-func (s *Service) recordExternalDecision(ctx context.Context, invocationID string, approved bool, message string) error {
+func (s *Service) recordExternalDecision(ctx context.Context, invocationID string, approved bool, message string, actorID string) error {
 	inv, err := s.invocations.Get(ctx, invocationID)
 	if err != nil {
 		return err
@@ -838,16 +872,30 @@ func (s *Service) recordExternalDecision(ctx context.Context, invocationID strin
 	now := time.Now().UTC()
 	if approved {
 		inv.Status = StatusApproved
-		inv.Approval = &Approval{Status: humanDecisionStatus(inv.Approval, true), Reason: stringPtr("human")}
+		inv.Approval = &Approval{
+			Status:     humanDecisionStatus(inv.Approval, true),
+			Reason:     stringPtr("human"),
+			ActorID:    stringPtrIfNotEmpty(actorID),
+			DecisionAt: timePtr(now),
+		}
 		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
 			return err
 		}
-		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.approved", Payload: mustJSON(map[string]any{"input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}), CreatedAt: now})
+		approvedPayload := map[string]any{"input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}
+		if actorID != "" {
+			approvedPayload["actor_id"] = actorID
+		}
+		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.approved", Payload: mustJSON(approvedPayload), CreatedAt: now})
 		return nil
 	}
 	inv.Status = StatusDenied
 	inv.CompletedAt = &now
-	inv.Approval = &Approval{Status: humanDecisionStatus(inv.Approval, false), Reason: stringPtr("human")}
+	inv.Approval = &Approval{
+		Status:     humanDecisionStatus(inv.Approval, false),
+		Reason:     stringPtr("human"),
+		ActorID:    stringPtrIfNotEmpty(actorID),
+		DecisionAt: timePtr(now),
+	}
 	msg := "Tool call denied by the MCP permissions system."
 	if message != "" {
 		msg += "\n\nReason: " + message
@@ -856,7 +904,11 @@ func (s *Service) recordExternalDecision(ctx context.Context, invocationID strin
 	if err := s.invocations.UpdateResult(ctx, inv); err != nil {
 		return err
 	}
-	_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.denied", Payload: mustJSON(map[string]any{"message": message, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}), CreatedAt: now})
+	deniedPayload := map[string]any{"message": message, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input)}
+	if actorID != "" {
+		deniedPayload["actor_id"] = actorID
+	}
+	_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.denied", Payload: mustJSON(deniedPayload), CreatedAt: now})
 	return nil
 }
 
@@ -959,6 +1011,7 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 				}
 				if r.Action == RuleActionAIEvaluation {
 					d, conf := s.runAIEvaluation(ctx, &r, source, req.Tool, req.Input, agentID, agentRec, chatContext, chatContextMessages)
+					s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, r.ID, r.Action, d, conf)
 					if d.Disposition == dispositionContinue {
 						matchedRuleID = nil
 						slog.Info("ai_evaluation: LLM deferred to next rule; continuing rule iteration",
@@ -970,6 +1023,13 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 					resolvedAIConfidence = conf
 					break
 				}
+				nonAIDecision := policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (" + r.Action + ")"}
+				if r.Action == RuleActionAutoDeny {
+					nonAIDecision = policy.Decision{Disposition: policy.DispositionNever, Reason: "matched approval rule (auto_deny)"}
+				} else if r.Action == RuleActionHumanApproval {
+					nonAIDecision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (human_approval)"}
+				}
+				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, r.ID, r.Action, nonAIDecision, nil)
 				ruleAction = r.Action
 				break
 			}
@@ -1286,12 +1346,48 @@ func (s *Service) toResponse(inv Invocation) InvocationResponse {
 	return resp
 }
 
+// emitRuleEvaluatedEvent records one entry in the per-invocation audit trail for
+// each rule that was evaluated during rule-iteration. disposition is the raw
+// policy disposition ("auto", "never", "human_approval", "continue", etc.).
+// When skipped is true the rule returned "next_rule" / dispositionContinue and
+// rule iteration continued to the next candidate.
+func (s *Service) emitRuleEvaluatedEvent(ctx context.Context, invocationID, ruleID, action string, d policy.Decision, conf *float64) {
+	payload := map[string]any{
+		"rule_id":     ruleID,
+		"action":      action,
+		"disposition": string(d.Disposition),
+		"reason":      d.Reason,
+		"skipped":     d.Disposition == dispositionContinue,
+	}
+	if conf != nil {
+		payload["confidence"] = *conf
+	}
+	_ = s.events.Create(ctx, Event{
+		InvocationID: invocationID,
+		EventType:    "invocation.rule_evaluated",
+		Payload:      mustJSON(payload),
+		CreatedAt:    time.Now().UTC(),
+	})
+}
+
 func mustJSON(v any) []byte {
 	b, _ := json.Marshal(v)
 	return b
 }
 
 func stringPtr(v string) *string { return &v }
+
+func timePtr(t time.Time) *string {
+	s := t.UTC().Format(time.RFC3339Nano)
+	return &s
+}
+
+func stringPtrIfNotEmpty(v string) *string {
+	if v == "" {
+		return nil
+	}
+	return &v
+}
 
 func normalizedLimit(limit uint64, fallback uint64) uint64 {
 	if limit == 0 {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -320,10 +320,11 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 					"rule_id", r.ID, "server", upstream.Name, "tool", req.Tool)
 				matchedRuleID = nil
 			}
-			// If every matching ai_evaluation rule deferred, treat as human approval.
-			if ruleMatched && decision.Disposition == dispositionContinue {
-				decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
-			}
+		// If every matching ai_evaluation rule deferred, treat as human approval.
+		if ruleMatched && decision.Disposition == dispositionContinue {
+			decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
+			s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, "", string(policy.DispositionHuman), decision, nil)
+		}
 		}
 	}
 	if !ruleMatched && s.policy != nil {

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -999,6 +999,7 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 		return InvocationResponse{}, err
 	}
 	ruleAction := ""
+	ruleDeferred := false
 	var matchedRuleID *string
 	var resolvedAIDecision *policy.Decision
 	var resolvedAIConfidence *float64
@@ -1015,6 +1016,7 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 					s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, r.ID, r.Action, d, conf)
 					if d.Disposition == dispositionContinue {
 						matchedRuleID = nil
+						ruleDeferred = true
 						slog.Info("ai_evaluation: LLM deferred to next rule; continuing rule iteration",
 							"rule_id", r.ID, "server", source, "tool", req.Tool)
 						continue
@@ -1033,6 +1035,12 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, r.ID, r.Action, nonAIDecision, nil)
 				ruleAction = r.Action
 				break
+			}
+			// If every matching ai_evaluation rule deferred, the invocation falls
+			// back to human approval below; record that in the audit trail.
+			if ruleDeferred && ruleAction == "" {
+				fallback := policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
+				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, "", RuleActionAIEvaluation, fallback, nil)
 			}
 		}
 	}

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -299,18 +299,13 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 					matchedRuleID = &id
 				}
 				var ruleConf *float64
-				switch r.Action {
-				case RuleActionAutoDeny:
-					decision = policy.Decision{Disposition: policy.DispositionNever, Reason: "matched approval rule (auto_deny)"}
-				case RuleActionAutoApprove:
-					decision = policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (auto_approve)"}
-				case RuleActionAIEvaluation:
+				if r.Action == RuleActionAIEvaluation {
 					decision, ruleConf = s.runAIEvaluation(ctx, &r, upstream.Name, req.Tool, req.Input, agentID, agentRec, "", 0)
 					if decision.Disposition != dispositionContinue {
 						aiConfidence = ruleConf
 					}
-				default:
-					decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (human_approval)"}
+				} else {
+					decision = decisionForRuleAction(r.Action)
 				}
 				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, r.ID, r.Action, decision, ruleConf)
 				if decision.Disposition != dispositionContinue {
@@ -322,8 +317,7 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 			}
 			// If every matching ai_evaluation rule deferred, treat as human approval.
 			if ruleMatched && decision.Disposition == dispositionContinue {
-				decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
-				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, "", RuleActionAIEvaluation, decision, nil)
+				decision = s.emitAllDeferredFallback(ctx, inv.InvocationID)
 			}
 		}
 	}
@@ -1026,21 +1020,14 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 					resolvedAIConfidence = conf
 					break
 				}
-				nonAIDecision := policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (" + r.Action + ")"}
-				if r.Action == RuleActionAutoDeny {
-					nonAIDecision = policy.Decision{Disposition: policy.DispositionNever, Reason: "matched approval rule (auto_deny)"}
-				} else if r.Action == RuleActionHumanApproval {
-					nonAIDecision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (human_approval)"}
-				}
-				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, r.ID, r.Action, nonAIDecision, nil)
+				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, r.ID, r.Action, decisionForRuleAction(r.Action), nil)
 				ruleAction = r.Action
 				break
 			}
 			// If every matching ai_evaluation rule deferred, the invocation falls
 			// back to human approval below; record that in the audit trail.
 			if ruleDeferred && ruleAction == "" {
-				fallback := policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
-				s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, "", RuleActionAIEvaluation, fallback, nil)
+				s.emitAllDeferredFallback(ctx, inv.InvocationID)
 			}
 		}
 	}
@@ -1353,6 +1340,29 @@ func (s *Service) toResponse(inv Invocation) InvocationResponse {
 		resp.Error = json.RawMessage(inv.Error)
 	}
 	return resp
+}
+
+// decisionForRuleAction maps a non-AI approval rule action to the decision it
+// enforces. Unknown actions gate to human approval, matching the dispatch
+// behavior of both the Invoke and Submit flows.
+func decisionForRuleAction(action string) policy.Decision {
+	switch action {
+	case RuleActionAutoDeny:
+		return policy.Decision{Disposition: policy.DispositionNever, Reason: "matched approval rule (auto_deny)"}
+	case RuleActionAutoApprove:
+		return policy.Decision{Disposition: policy.DispositionAuto, Reason: "matched approval rule (auto_approve)"}
+	default:
+		return policy.Decision{Disposition: policy.DispositionHuman, Reason: "matched approval rule (human_approval)"}
+	}
+}
+
+// emitAllDeferredFallback records the audit event for an invocation whose
+// matching ai_evaluation rules all deferred, and returns the human-approval
+// decision that rule iteration falls back to.
+func (s *Service) emitAllDeferredFallback(ctx context.Context, invocationID string) policy.Decision {
+	d := policy.Decision{Disposition: policy.DispositionHuman, Reason: "ai_evaluation: all matching rules deferred; falling back to human_approval"}
+	s.emitRuleEvaluatedEvent(ctx, invocationID, "", RuleActionAIEvaluation, d, nil)
+	return d
 }
 
 // emitRuleEvaluatedEvent records one entry in the per-invocation audit trail for

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -663,7 +663,7 @@ func approveNextInvocation(t *testing.T, service *invocation.Service, delay time
 	if pending.Status != invocation.StatusPendingApproval {
 		return
 	}
-	if err := service.Approve(context.Background(), pending.InvocationID); err != nil {
+	if err := service.Approve(context.Background(), pending.InvocationID, ""); err != nil {
 		t.Errorf("approve invocation: %v", err)
 	}
 }

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -227,7 +227,7 @@ const InvocationAuditSection: React.FC<{ entries: AuditEntry[] }> = ({
       </Text>
       <VStack align="stretch" gap={2}>
         {entries.map((entry, i) => (
-          <AuditEntryRow key={entry.ruleName ?? i} entry={entry} />
+          <AuditEntryRow key={entry.ruleId ?? 'unmatched'} entry={entry} />
         ))}
       </VStack>
     </Box>

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -150,6 +150,7 @@ const AUDIT_STEP_ICON: Record<AuditStep["variant"], string> = {
   defer: "→",
   pending: "…",
   info: "→",
+  error: "✗",
 };
 
 const AuditEntryRow: React.FC<{ entry: AuditEntry }> = ({ entry }) => {

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -9,6 +9,7 @@ import {
   CloseButton,
   Code,
   Collapse,
+  Divider,
   Flex,
   FormControl,
   FormLabel,
@@ -67,7 +68,7 @@ import {
   useSummarizeInvocation,
 } from "../hooks/useInvocations";
 import { useSettings } from "../hooks/useSettings";
-import { useCreateRule } from "../hooks/useRules";
+import { useCreateRule, useRules } from "../hooks/useRules";
 import { useAgents } from "../hooks/useAgents";
 import { useInvocationStream } from "../hooks/useInvocationStream";
 import {
@@ -86,6 +87,9 @@ import {
   isAIEvaluated,
   getConfidenceColor,
   formatConfidence,
+  buildInvocationAudit,
+  type AuditEntry,
+  type AuditStep,
 } from "../utils/invocationDisplay";
 
 const STATUSES: InvocationStatus[] = [
@@ -136,6 +140,98 @@ const loadPendingInvocations = async (): Promise<Invocation[]> => {
     pendingInvocations.push(...page.items);
     if (page.items.length < limit) return pendingInvocations;
   }
+};
+
+const AUDIT_STEP_ICON: Record<AuditStep["variant"], string> = {
+  approve: "✓",
+  deny: "✗",
+  defer: "→",
+  pending: "…",
+  info: "→",
+};
+
+const AuditEntryRow: React.FC<{ entry: AuditEntry }> = ({ entry }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const badge = entry.isAIEvaluation ? (
+    <Badge colorScheme="purple" fontSize="xs">
+      AI Evaluation
+    </Badge>
+  ) : entry.ruleName !== null ? (
+    <Badge colorScheme="purple" fontSize="xs">
+      Rule
+    </Badge>
+  ) : null;
+
+  return (
+    <Box borderWidth={1} borderColor="border.base" borderRadius="md" overflow="hidden">
+      <Flex
+        justify="space-between"
+        align="center"
+        px={3}
+        py={2}
+        cursor="pointer"
+        _hover={{ bg: "background.container.subtle" }}
+        onClick={() => setIsOpen((v) => !v)}>
+        <HStack gap={2} flex={1} minW={0}>
+          <Icon
+            as={isOpen ? ChevronUpIcon : ChevronDownIcon}
+            boxSize={4}
+            color="text.subtle"
+            flexShrink={0}
+          />
+          <Text fontSize="sm" fontWeight="medium" noOfLines={1}>
+            {entry.ruleName ?? "No rule matched"}
+          </Text>
+          {badge}
+        </HStack>
+      </Flex>
+      <Collapse in={isOpen} animateOpacity>
+        <VStack align="stretch" gap={0} px={3} pb={2}>
+          {entry.steps.map((step, i) => (
+            <Box
+              key={i}
+              pt={2}
+              borderTopWidth={i > 0 ? 1 : 0}
+              borderColor="border.base">
+              <Text fontSize="xs" fontWeight="medium">
+                {AUDIT_STEP_ICON[step.variant]} {step.text}
+              </Text>
+              {step.timestamp && (
+                <Text fontSize="xs" color="text.subtle" mt={0.5}>
+                  {formatDate(step.timestamp)}
+                </Text>
+              )}
+            </Box>
+          ))}
+        </VStack>
+      </Collapse>
+    </Box>
+  );
+};
+
+const InvocationAuditSection: React.FC<{ entries: AuditEntry[] }> = ({
+  entries,
+}) => {
+  if (entries.length === 0) return null;
+  return (
+    <Box>
+      <Text
+        fontSize="xs"
+        fontWeight="semibold"
+        textTransform="uppercase"
+        color="text.subtle"
+        letterSpacing="wide"
+        mb={2}>
+        Matched {entries.length === 1 ? "Rule" : "Rules"}
+      </Text>
+      <VStack align="stretch" gap={2}>
+        {entries.map((entry, i) => (
+          <AuditEntryRow key={entry.ruleName ?? i} entry={entry} />
+        ))}
+      </VStack>
+    </Box>
+  );
 };
 
 const EventRow: React.FC<{ event: InvocationEvent }> = ({ event }) => {
@@ -318,7 +414,20 @@ const Invocations: React.FC = () => {
   const deny = useDenyInvocation();
   const summarize = useSummarizeInvocation();
   const createRule = useCreateRule();
+  const { data: rulesData } = useRules();
   const { data: settings } = useSettings();
+
+  const auditEntries = useMemo(
+    () =>
+      detail
+        ? buildInvocationAudit(
+            detail,
+            rulesData?.items ?? [],
+            eventsData?.items ?? [],
+          )
+        : [],
+    [detail, rulesData?.items, eventsData?.items],
+  );
   const summaryModelConfigCuid = settings?.summary_model_config_cuid ?? "";
   const hasSummaryModel = Boolean(
     summaryModelConfigCuid || (settings?.summary_atryum_llm_config_id ?? ""),
@@ -1044,6 +1153,13 @@ const Invocations: React.FC = () => {
                         data-testid="invocation-detail-close-button"
                       />
                     </Flex>
+
+                    {auditEntries.length > 0 && (
+                      <>
+                        <InvocationAuditSection entries={auditEntries} />
+                        <Divider />
+                      </>
+                    )}
 
                     <Box
                       p={3}

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -166,8 +166,9 @@ export function buildInvocationAudit(
       ? buildAuditFromEvents(inv, rules, events, ruleEvalEvents)
       : buildAuditFromApproval(inv, rules);
 
-  // If execution failed after approval, append a failure step to the last
-  // entry so it appears regardless of which rule/approval branch ran first.
+  // If the invocation failed, append a terminal failure step to the last entry
+  // so it appears regardless of whether failure happened during approval wait
+  // or after approval during execution.
   if (inv.status === 'failed') {
     const failStep: AuditStep = {
       text: 'Invocation failed',
@@ -330,7 +331,7 @@ function resolveDecisionSteps(
     }
     return [
       { text: 'Deferring to human approval as per charter', variant: 'defer' },
-      { text: 'Awaiting human', variant: 'pending' },
+      ...undecidedSteps(inv),
     ];
   }
   if (disposition === 'human' || disposition === 'workflow') {
@@ -360,7 +361,7 @@ function resolveDecisionSteps(
     }
     return [
       { text: deferText, variant: 'defer' },
-      { text: 'Awaiting human', variant: 'pending' },
+      ...undecidedSteps(inv),
     ];
   }
   if (disposition === 'approved') {
@@ -384,4 +385,23 @@ function resolveDecisionSteps(
     return [{ text: `Decision: ${disposition}`, variant: 'info' }];
   }
   return [];
+}
+
+/**
+ * Steps for an invocation that reached a human/workflow gate but has no
+ * recorded decision. Only render "Awaiting human" while a decision is still
+ * possible; on a terminal status show what actually ended the wait ('failed'
+ * returns nothing — buildInvocationAudit appends the failure step).
+ */
+function undecidedSteps(inv: InvocationAuditInput): AuditStep[] {
+  if (inv.status === 'failed') {
+    return [];
+  }
+  if (inv.status === 'expired') {
+    return [{ text: 'Expired without decision', variant: 'info' }];
+  }
+  if (inv.status === 'cancelled') {
+    return [{ text: 'Cancelled', variant: 'info' }];
+  }
+  return [{ text: 'Awaiting human', variant: 'pending' }];
 }

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -313,12 +313,15 @@ function resolveDecisionSteps(
     ];
   }
   if (disposition === 'human') {
+    const deferText = isAIEval
+      ? 'Deferring to human approval as per charter'
+      : 'Human approval required as per rule';
     if (
       approvalStatus === 'approved' ||
       approvalStatus === 'ai_escalated_approved'
     ) {
       return [
-        { text: 'Deferring to human approval as per charter', variant: 'defer' },
+        { text: deferText, variant: 'defer' },
         { text: 'Approved by human', variant: 'approve', actor },
       ];
     }
@@ -327,12 +330,12 @@ function resolveDecisionSteps(
       approvalStatus === 'ai_escalated_denied'
     ) {
       return [
-        { text: 'Deferring to human approval as per charter', variant: 'defer' },
+        { text: deferText, variant: 'defer' },
         { text: 'Denied by human', variant: 'deny', actor },
       ];
     }
     return [
-      { text: 'Deferring to human approval as per charter', variant: 'defer' },
+      { text: deferText, variant: 'defer' },
       { text: 'Awaiting human', variant: 'pending' },
     ];
   }

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -98,7 +98,8 @@ export type AuditStepVariant =
   | 'deny'
   | 'defer'
   | 'pending'
-  | 'info';
+  | 'info'
+  | 'error';
 
 export type AuditStep = {
   text: string;
@@ -120,6 +121,7 @@ export type AuditEntry = {
 
 type InvocationAuditInput = {
   status: string;
+  completed_at?: string | null;
   approval?: {
     status: string;
     reason?: string | null;
@@ -159,11 +161,35 @@ export function buildInvocationAudit(
     (e) => e.type === 'invocation.rule_evaluated',
   );
 
-  if (ruleEvalEvents.length > 0) {
-    return buildAuditFromEvents(inv, rules, events, ruleEvalEvents);
+  const entries =
+    ruleEvalEvents.length > 0
+      ? buildAuditFromEvents(inv, rules, events, ruleEvalEvents)
+      : buildAuditFromApproval(inv, rules);
+
+  // If execution failed after approval, append a failure step to the last
+  // entry so it appears regardless of which rule/approval branch ran first.
+  if (inv.status === 'failed') {
+    const failStep: AuditStep = {
+      text: 'Invocation failed',
+      variant: 'error',
+      timestamp: inv.completed_at ?? undefined,
+    };
+    if (entries.length > 0) {
+      const last = entries[entries.length - 1];
+      if (!last.steps.some((s) => s.variant === 'error')) {
+        last.steps.push(failStep);
+      }
+    } else {
+      entries.push({
+        ruleName: null,
+        ruleId: null,
+        isAIEvaluation: false,
+        steps: [failStep],
+      });
+    }
   }
 
-  return buildAuditFromApproval(inv, rules);
+  return entries;
 }
 
 function buildAuditFromEvents(

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -333,10 +333,13 @@ function resolveDecisionSteps(
       { text: 'Awaiting human', variant: 'pending' },
     ];
   }
-  if (disposition === 'human') {
-    const deferText = isAIEval
-      ? 'Deferring to human approval as per charter'
-      : 'Human approval required as per rule';
+  if (disposition === 'human' || disposition === 'workflow') {
+    const deferText =
+      disposition === 'workflow'
+        ? 'Deferring to approval workflow'
+        : isAIEval
+          ? 'Deferring to human approval as per charter'
+          : 'Human approval required as per rule';
     if (
       approvalStatus === 'approved' ||
       approvalStatus === 'ai_escalated_approved'
@@ -374,6 +377,11 @@ function resolveDecisionSteps(
   }
   if (inv.status === 'cancelled') {
     return [{ text: 'Cancelled', variant: 'info' }];
+  }
+  // Unknown disposition (e.g. a value added on the backend before this UI
+  // learns about it): render it raw rather than an empty step list.
+  if (disposition !== '') {
+    return [{ text: `Decision: ${disposition}`, variant: 'info' }];
   }
   return [];
 }

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -312,7 +312,7 @@ function resolveDecisionSteps(
       { text: 'Awaiting human', variant: 'pending' },
     ];
   }
-  if (disposition === 'human_approval') {
+  if (disposition === 'human') {
     if (
       approvalStatus === 'approved' ||
       approvalStatus === 'ai_escalated_approved'

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -1,4 +1,4 @@
-import type { Invocation } from '../api/AtryumAPI';
+import type { Invocation, Rule, InvocationEvent } from '../api/AtryumAPI';
 
 export const STATUS_COLOR: Record<string, string> = {
   pending_approval: 'orange',
@@ -90,3 +90,266 @@ export const formatDate = (dateStr: string | null | undefined): string => {
     timeStyle: 'short',
   });
 };
+
+// ─── Invocation Audit ─────────────────────────────────────────────────────────
+
+export type AuditStepVariant =
+  | 'approve'
+  | 'deny'
+  | 'defer'
+  | 'pending'
+  | 'info';
+
+export type AuditStep = {
+  text: string;
+  variant: AuditStepVariant;
+  /** ISO timestamp for this step, if known */
+  timestamp?: string;
+  /** Raw actor identifier for human decision steps */
+  actor?: string;
+};
+
+export type AuditEntry = {
+  /** null means no rule matched */
+  ruleName: string | null;
+  isAIEvaluation: boolean;
+  confidence?: number;
+  steps: AuditStep[];
+};
+
+type InvocationAuditInput = {
+  status: string;
+  approval?: {
+    status: string;
+    reason?: string | null;
+    confidence_score?: number | null;
+    actor_id?: string | null;
+  } | null;
+  matched_rule_id?: string | null;
+};
+
+type RuleEvaluatedEventData = {
+  rule_id?: string;
+  action?: string;
+  disposition?: string;
+  confidence?: number;
+  reason?: string;
+  skipped?: boolean;
+};
+
+type DecisionEventData = {
+  actor_id?: string;
+};
+
+/**
+ * Derives structured audit entries from an invocation + rules list + events.
+ *
+ * When `invocation.rule_evaluated` events are present the full evaluation
+ * chain — including skipped rules — is reconstructed from those events.
+ * Otherwise falls back to deriving a single entry from the invocation's
+ * final approval fields.
+ */
+export function buildInvocationAudit(
+  inv: InvocationAuditInput,
+  rules: Rule[],
+  events: InvocationEvent[] = [],
+): AuditEntry[] {
+  const ruleEvalEvents = events.filter(
+    (e) => e.type === 'invocation.rule_evaluated',
+  );
+
+  if (ruleEvalEvents.length > 0) {
+    return buildAuditFromEvents(inv, rules, events, ruleEvalEvents);
+  }
+
+  return buildAuditFromApproval(inv, rules);
+}
+
+function buildAuditFromEvents(
+  inv: InvocationAuditInput,
+  rules: Rule[],
+  allEvents: InvocationEvent[],
+  ruleEvalEvents: InvocationEvent[],
+): AuditEntry[] {
+  const decisionEvent = allEvents.find(
+    (e) =>
+      e.type === 'invocation.approved' ||
+      e.type === 'invocation.denied' ||
+      e.type === 'invocation.executing',
+  );
+  const actor = (decisionEvent?.data as DecisionEventData | undefined)
+    ?.actor_id;
+  const decisionTimestamp = decisionEvent?.timestamp;
+
+  return ruleEvalEvents.map((evt) => {
+    const d = (evt.data ?? {}) as RuleEvaluatedEventData;
+    const rule = d.rule_id
+      ? (rules.find((r) => r.id === d.rule_id) ?? null)
+      : null;
+    const ruleName =
+      rule?.description ?? (d.rule_id ? `Rule ${d.rule_id}` : null);
+    const isAIEval = d.action === 'ai_evaluation';
+    const confidence = d.confidence;
+
+    const steps: AuditStep[] = [];
+
+    if (d.skipped) {
+      steps.push({
+        text: 'Skipped this rule as per charter',
+        variant: 'info',
+        timestamp: evt.timestamp,
+      });
+    } else {
+      const resolved = resolveDecisionSteps(
+        d.disposition ?? '',
+        inv,
+        actor,
+        isAIEval,
+      );
+      steps.push(
+        ...resolved.map((step) => ({
+          ...step,
+          timestamp:
+            step.variant === 'approve' || step.variant === 'deny'
+              ? decisionTimestamp
+              : evt.timestamp,
+        })),
+      );
+    }
+
+    return { ruleName, isAIEvaluation: isAIEval, confidence, steps };
+  });
+}
+
+function buildAuditFromApproval(
+  inv: InvocationAuditInput,
+  rules: Rule[],
+): AuditEntry[] {
+  const ruleId = inv.matched_rule_id ?? null;
+  const rule = ruleId ? (rules.find((r) => r.id === ruleId) ?? null) : null;
+  const ruleName = rule?.description ?? (ruleId ? `Rule ${ruleId}` : null);
+
+  const approvalStatus = inv.approval?.status ?? null;
+  const reason = inv.approval?.reason ?? '';
+  const confidence = inv.approval?.confidence_score ?? undefined;
+  const actor = inv.approval?.actor_id ?? undefined;
+
+  const isAIEval =
+    (reason ?? '').startsWith('ai_evaluation') ||
+    approvalStatus === 'ai_escalated' ||
+    approvalStatus === 'ai_escalated_approved' ||
+    approvalStatus === 'ai_escalated_denied';
+
+  const steps = resolveDecisionSteps(
+    approvalStatus ?? '',
+    inv,
+    actor ?? undefined,
+  );
+
+  return [{ ruleName, isAIEvaluation: isAIEval, confidence, steps }];
+}
+
+function resolveDecisionSteps(
+  disposition: string,
+  inv: InvocationAuditInput,
+  actor?: string,
+  isAIEval?: boolean,
+): AuditStep[] {
+  const approvalStatus = inv.approval?.status ?? null;
+  const reason = inv.approval?.reason ?? '';
+
+  if (disposition === 'auto' || disposition === 'auto_approved') {
+    const byAI =
+      isAIEval ??
+      ((reason ?? '').startsWith('ai_evaluation') ||
+        approvalStatus === 'auto_approved');
+    return [
+      {
+        text: byAI
+          ? 'Invocation approved by AI'
+          : 'Invocation approved by rule',
+        variant: 'approve',
+      },
+    ];
+  }
+  if (disposition === 'never' || disposition === 'auto_denied') {
+    const byAI =
+      isAIEval ??
+      ((reason ?? '').startsWith('ai_evaluation') ||
+        approvalStatus === 'auto_denied');
+    return [
+      {
+        text: byAI ? 'Invocation denied by AI' : 'Invocation denied by rule',
+        variant: 'deny',
+      },
+    ];
+  }
+  if (
+    disposition === 'ai_escalated' ||
+    disposition === 'ai_escalated_approved' ||
+    disposition === 'ai_escalated_denied'
+  ) {
+    if (
+      approvalStatus === 'ai_escalated_approved' ||
+      approvalStatus === 'approved'
+    ) {
+      return [
+        { text: 'Deferring to human approval as per charter', variant: 'defer' },
+        { text: 'Invocation approved by human', variant: 'approve', actor },
+      ];
+    }
+    if (
+      approvalStatus === 'ai_escalated_denied' ||
+      approvalStatus === 'denied'
+    ) {
+      return [
+        { text: 'Deferring to human approval as per charter', variant: 'defer' },
+        { text: 'Invocation denied by human', variant: 'deny', actor },
+      ];
+    }
+    return [
+      { text: 'Deferring to human approval as per charter', variant: 'defer' },
+      { text: 'Awaiting human', variant: 'pending' },
+    ];
+  }
+  if (disposition === 'human_approval') {
+    if (
+      approvalStatus === 'approved' ||
+      approvalStatus === 'ai_escalated_approved'
+    ) {
+      return [
+        { text: 'Deferring to human approval as per charter', variant: 'defer' },
+        { text: 'Approved by human', variant: 'approve', actor },
+      ];
+    }
+    if (
+      approvalStatus === 'denied' ||
+      approvalStatus === 'ai_escalated_denied'
+    ) {
+      return [
+        { text: 'Deferring to human approval as per charter', variant: 'defer' },
+        { text: 'Denied by human', variant: 'deny', actor },
+      ];
+    }
+    return [
+      { text: 'Deferring to human approval as per charter', variant: 'defer' },
+      { text: 'Awaiting human', variant: 'pending' },
+    ];
+  }
+  if (disposition === 'approved') {
+    return [{ text: 'Approved by human', variant: 'approve', actor }];
+  }
+  if (disposition === 'denied') {
+    return [{ text: 'Denied by human', variant: 'deny', actor }];
+  }
+  if (inv.status === 'pending_approval') {
+    return [{ text: 'Awaiting human approval', variant: 'pending' }];
+  }
+  if (inv.status === 'expired') {
+    return [{ text: 'Expired without decision', variant: 'info' }];
+  }
+  if (inv.status === 'cancelled') {
+    return [{ text: 'Cancelled', variant: 'info' }];
+  }
+  return [];
+}

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -244,6 +244,7 @@ function buildAuditFromApproval(
     approvalStatus ?? '',
     inv,
     actor ?? undefined,
+    isAIEval,
   );
 
   return [{ ruleName, ruleId, isAIEvaluation: isAIEval, confidence, steps }];
@@ -259,10 +260,7 @@ function resolveDecisionSteps(
   const reason = inv.approval?.reason ?? '';
 
   if (disposition === 'auto' || disposition === 'auto_approved') {
-    const byAI =
-      isAIEval ??
-      ((reason ?? '').startsWith('ai_evaluation') ||
-        approvalStatus === 'auto_approved');
+    const byAI = isAIEval ?? reason.startsWith('ai_evaluation');
     return [
       {
         text: byAI
@@ -273,10 +271,7 @@ function resolveDecisionSteps(
     ];
   }
   if (disposition === 'never' || disposition === 'auto_denied') {
-    const byAI =
-      isAIEval ??
-      ((reason ?? '').startsWith('ai_evaluation') ||
-        approvalStatus === 'auto_denied');
+    const byAI = isAIEval ?? reason.startsWith('ai_evaluation');
     return [
       {
         text: byAI ? 'Invocation denied by AI' : 'Invocation denied by rule',

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -112,6 +112,7 @@ export type AuditStep = {
 export type AuditEntry = {
   /** null means no rule matched */
   ruleName: string | null;
+  ruleId: string | null;
   isAIEvaluation: boolean;
   confidence?: number;
   steps: AuditStep[];
@@ -183,11 +184,10 @@ function buildAuditFromEvents(
 
   return ruleEvalEvents.map((evt) => {
     const d = (evt.data ?? {}) as RuleEvaluatedEventData;
-    const rule = d.rule_id
-      ? (rules.find((r) => r.id === d.rule_id) ?? null)
-      : null;
+    const ruleId = d.rule_id ?? null;
+    const rule = ruleId ? (rules.find((r) => r.id === ruleId) ?? null) : null;
     const ruleName =
-      rule?.description ?? (d.rule_id ? `Rule ${d.rule_id}` : null);
+      rule?.description ?? (ruleId ? `Rule ${ruleId}` : null);
     const isAIEval = d.action === 'ai_evaluation';
     const confidence = d.confidence;
 
@@ -217,7 +217,7 @@ function buildAuditFromEvents(
       );
     }
 
-    return { ruleName, isAIEvaluation: isAIEval, confidence, steps };
+    return { ruleName, ruleId, isAIEvaluation: isAIEval, confidence, steps };
   });
 }
 
@@ -246,7 +246,7 @@ function buildAuditFromApproval(
     actor ?? undefined,
   );
 
-  return [{ ruleName, isAIEvaluation: isAIEval, confidence, steps }];
+  return [{ ruleName, ruleId, isAIEvaluation: isAIEval, confidence, steps }];
 }
 
 function resolveDecisionSteps(


### PR DESCRIPTION
## What and why?

Two related changes shipped together:

**1. Backend — audit event instrumentation**

Atryum now emits structured events for each rule evaluation:
- `invocation.rule_evaluated` — fired for every rule checked, carrying `rule_id`, `action`, `disposition`, `confidence`, `skipped` flag
- `invocation.approved` — fired when a human approves, carrying `actor_id`

These events power the new audit UI in both the FOSS admin console and the ValidMind Agent Authority sidebar.

**2. FOSS UI — Invocation Audit section**

The invocation detail panel now shows a "Matched Rule(s)" section above the Summary. Each evaluated rule appears as a collapsible row with its description, a badge (AI Evaluation / Rule), and expandable step history with unicode icons and timestamps. Skipped rules are shown with a `→` icon and "Skipped this rule as per charter". Actor display is omitted since the FOSS admin has no user management system.

## How to test

1. Start Atryum locally (`just run` or `docker compose up`).
2. Configure at least two rules (one that skips for a given agent, one that decides).
3. Trigger an invocation from an agent matching those rules.
4. Open the FOSS admin UI at `/ui/invocations`, select the invocation.
5. Verify the "Matched Rules" section appears above Summary with the correct rule rows.
6. Expand each row and verify the step text, icon (`→` for skipped, `✗` for denied, etc.), and timestamp.

## What needs special review?

- `internal/invocation/service.go` — `emitRuleEvaluatedEvent` and `waitForHumanApproval` changes; ensure events are emitted without blocking the critical path and errors are swallowed safely.
- The `actorID` plumbing through `ApprovalRequest` and handler interfaces.

## Dependencies, breaking changes, and deployment notes

- No schema migration required — events are appended to the existing `invocation_events` table.
- The FOSS UI degrades gracefully for invocations recorded before this change (falls back to approval blob).
- Companion frontend PR: https://github.com/validmind/frontend/pull/2704

## Release notes

Atryum now records structured rule evaluation events for every invocation, and the admin UI surfaces them as a collapsible audit trail showing which rules were evaluated, skipped, or decisive — with timestamps and step-level decision history.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend) — please attach before merging
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [ ] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

Made with [Cursor](https://cursor.com)