### PR TITLE
Add pagination to Invocations list UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ internal/api/web/atryum-logo.png
 internal/api/web/atryum-logo.svg
 internal/api/web/atryum-logo-favicon.svg
 internal/api/web/atryum-notification-icon.svg
+internal/api/web/atryum-agent-icons/

--- a/ui/src/api/AtryumAPI.ts
+++ b/ui/src/api/AtryumAPI.ts
@@ -121,7 +121,7 @@ export interface InvocationFilters {
 export const invocationsApi = {
   list: async (
     filters: InvocationFilters = {},
-  ): Promise<{ items: Invocation[] }> => {
+  ): Promise<{ items: Invocation[]; total: number; offset: number; limit: number }> => {
     const params = new URLSearchParams();
     if (filters.server) params.set('server', filters.server);
     if (filters.tool) params.set('tool', filters.tool);

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -88,6 +88,8 @@ import {
   formatConfidence,
 } from "../utils/invocationDisplay";
 
+const PAGE_SIZE = 50;
+
 const STATUSES: InvocationStatus[] = [
   "pending_approval",
   "approved",
@@ -235,6 +237,7 @@ const Invocations: React.FC = () => {
   const [detailClosed, setDetailClosed] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const [showArgsJson, setShowArgsJson] = useState(false);
+  const [page, setPage] = useState(1);
   const [clearedInvocationIds, setClearedInvocationIds] = useState<Set<string>>(
     () => new Set(),
   );
@@ -266,10 +269,16 @@ const Invocations: React.FC = () => {
     [appliedFilters],
   );
 
-  const { data, isLoading, isError } = useInvocations(filters);
+  const { data, isLoading, isError } = useInvocations({
+    ...filters,
+    offset: (page - 1) * PAGE_SIZE,
+    limit: PAGE_SIZE,
+  });
   const { data: agentsData } = useAgents();
 
   const rawItems = useMemo(() => data?.items ?? [], [data?.items]);
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
   const items = useMemo(
     () =>
       rawItems.filter((item) => !clearedInvocationIds.has(item.invocation_id)),
@@ -387,7 +396,10 @@ const Invocations: React.FC = () => {
     setShowCreateRule(false);
   };
 
-  const handleApply = () => setAppliedFilters({ ...draftFilters });
+  const handleApply = () => {
+    setAppliedFilters({ ...draftFilters });
+    setPage(1);
+  };
 
   const handleCloseDetail = () => {
     setDetailClosed(true);
@@ -873,6 +885,40 @@ const Invocations: React.FC = () => {
                   </Table>
                 )}
               </Box>
+              {totalPages > 1 && (
+                <Box
+                  px={3}
+                  py={2}
+                  borderTopWidth={1}
+                  borderColor="border.base"
+                  flexShrink={0}>
+                  <HStack justify="space-between" align="center">
+                    <Text fontSize="xs" color="text.subtle">
+                      Showing {(page - 1) * PAGE_SIZE + 1}–
+                      {Math.min(page * PAGE_SIZE, total)} of {total}
+                    </Text>
+                    <HStack gap={1}>
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        isDisabled={page <= 1 || isLoading}
+                        onClick={() => setPage((p) => p - 1)}>
+                        Prev
+                      </Button>
+                      <Text fontSize="xs" color="text.subtle">
+                        {page} / {totalPages}
+                      </Text>
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        isDisabled={page >= totalPages || isLoading}
+                        onClick={() => setPage((p) => p + 1)}>
+                        Next
+                      </Button>
+                    </HStack>
+                  </HStack>
+                </Box>
+              )}
             </Box>
           }
           right={


### PR DESCRIPTION
<img width="1215" height="842" alt="Screenshot 2026-07-07 at 11 05 43 AM" src="https://github.com/user-attachments/assets/43e43f5e-ec70-4fbe-9dfc-a9603c2347ef" />

## Summary

- **Invocations page now paginates** at 50 per page. The backend already supported `offset`/`limit` but the UI was silently capped at the default 50. A compact Prev / page-count / Next footer appears inside the left panel when there are more than 50 results; applying filters resets to page 1.
- **Fixed `invocationsApi.list()` return type** to include `total`, `offset`, and `limit` (the backend was already returning these fields; the TypeScript type just omitted them).
- **`.gitignore`** — added `internal/api/web/atryum-agent-icons/` to cover the new icon directory produced by the UI build step (parallel to the existing `assets/` and logo entries).

## Test plan

- [ ] Load the Invocations page with >50 invocations and confirm Prev/Next controls appear
- [ ] Confirm filtering resets to page 1
- [ ] Confirm the footer is hidden when total ≤ 50
- [ ] Confirm `git status` is clean after a local `just build-ui`

Made with [Cursor](https://cursor.com)