### PR TITLE
Refactor rule creation UX: pre-filled modal for always approve/deny

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -317,6 +317,10 @@ type AdminRuleInput struct {
 	AgentCUIDs        []string `json:"agent_cuids"`
 	Description       string   `json:"description,omitempty"`
 	Enabled           *bool    `json:"enabled,omitempty"`
+	// InsertBefore, when present, inserts the new rule before the rule with this
+	// ID in the priority list. An empty string inserts at position 0 (top).
+	// When absent (nil), the rule is appended at the end (default behaviour).
+	InsertBefore *string `json:"insert_before,omitempty"`
 }
 
 // AdminModelConfig is the API representation of a VM agent model configuration.
@@ -2141,11 +2145,6 @@ func (h *Handler) adminRules(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		order, err := h.rulesRepo.NextOrder(r.Context())
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
-		}
 		enabled := true
 		if req.Enabled != nil {
 			enabled = *req.Enabled
@@ -2160,11 +2159,24 @@ func (h *Handler) adminRules(w http.ResponseWriter, r *http.Request) {
 			AgentCUIDs:        normalizePatternSlice(req.AgentCUIDs),
 			Description:       req.Description,
 			Enabled:           enabled,
-			Order:             order,
 		}
-		if err := h.rulesRepo.Create(r.Context(), rule); err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
+		if req.InsertBefore != nil {
+			// insert_before="" → top of list; insert_before="<id>" → before that rule.
+			if err := h.rulesRepo.InsertBefore(r.Context(), *req.InsertBefore, rule); err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+		} else {
+			order, err := h.rulesRepo.NextOrder(r.Context())
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			rule.Order = order
+			if err := h.rulesRepo.Create(r.Context(), rule); err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
 		}
 		created, err := h.rulesRepo.Get(r.Context(), rule.ID)
 		if err != nil {

--- a/ui/src/api/AtryumAPI.ts
+++ b/ui/src/api/AtryumAPI.ts
@@ -363,6 +363,12 @@ export interface RuleInput {
   /** Local LLM config ID for native ai_evaluation (alternative to model_config_cuid). */
   atryum_llm_config_id?: string;
   enabled: boolean;
+  /**
+   * When present, inserts the new rule before the rule with this ID.
+   * Pass an empty string ("") to insert at position 0 (top of list).
+   * Omit to append at the end (default).
+   */
+  insert_before?: string;
 }
 
 export const rulesApi = {

--- a/ui/src/components/CreateRuleModal.tsx
+++ b/ui/src/components/CreateRuleModal.tsx
@@ -102,10 +102,10 @@ export type CreateRuleModalProps = {
   initialValues?: Partial<RuleInput>;
   /**
    * Called after a rule is successfully created (not on edit or delete).
-   * Use this to trigger a follow-up action such as approving or denying the
-   * current invocation after the rule has been saved.
+   * Receives the saved rule so callers can inspect the final action before
+   * deciding whether to approve or deny the current invocation.
    */
-  onSuccess?: () => void | Promise<void>;
+  onSuccess?: (savedRule: Rule) => void | Promise<void>;
 };
 
 export const CreateRuleModal: React.FC<CreateRuleModalProps> = ({
@@ -224,10 +224,10 @@ export const CreateRuleModal: React.FC<CreateRuleModalProps> = ({
         toast({ title: 'Rule saved', status: 'success', duration: 3000, isClosable: true });
         onClose();
       } else {
-        await createRule.mutateAsync(form);
+        const saved = await createRule.mutateAsync(form);
         toast({ title: 'Rule created', status: 'success', duration: 3000, isClosable: true });
         onClose();
-        await onSuccess?.();
+        await onSuccess?.(saved);
       }
     } catch (err: unknown) {
       setStatusMsg({ text: apiErrorMessage(err, 'Save failed.'), isError: true });

--- a/ui/src/components/CreateRuleModal.tsx
+++ b/ui/src/components/CreateRuleModal.tsx
@@ -100,6 +100,12 @@ export type CreateRuleModalProps = {
    * invocation's server/tool/agent).
    */
   initialValues?: Partial<RuleInput>;
+  /**
+   * Called after a rule is successfully created (not on edit or delete).
+   * Use this to trigger a follow-up action such as approving or denying the
+   * current invocation after the rule has been saved.
+   */
+  onSuccess?: () => void | Promise<void>;
 };
 
 export const CreateRuleModal: React.FC<CreateRuleModalProps> = ({
@@ -107,6 +113,7 @@ export const CreateRuleModal: React.FC<CreateRuleModalProps> = ({
   onClose,
   rule,
   initialValues,
+  onSuccess,
 }) => {
   const toast = useToast();
   const isEditing = !!rule;
@@ -215,15 +222,17 @@ export const CreateRuleModal: React.FC<CreateRuleModalProps> = ({
       if (isEditing && rule) {
         await updateRule.mutateAsync({ id: rule.id, input: form });
         toast({ title: 'Rule saved', status: 'success', duration: 3000, isClosable: true });
+        onClose();
       } else {
         await createRule.mutateAsync(form);
         toast({ title: 'Rule created', status: 'success', duration: 3000, isClosable: true });
+        onClose();
+        await onSuccess?.();
       }
-      onClose();
     } catch (err: unknown) {
       setStatusMsg({ text: apiErrorMessage(err, 'Save failed.'), isError: true });
     }
-  }, [createRule, form, isEditing, onClose, rule, toast, updateRule]);
+  }, [createRule, form, isEditing, onClose, onSuccess, rule, toast, updateRule]);
 
   const handleDelete = useCallback(async () => {
     if (!rule) return;

--- a/ui/src/components/CreateRuleModal.tsx
+++ b/ui/src/components/CreateRuleModal.tsx
@@ -1,0 +1,467 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  Button,
+  Checkbox,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  VStack,
+  useToast,
+} from '@chakra-ui/react';
+import { CreatableSelect, Select } from 'chakra-react-select';
+import { useQuery } from 'react-query';
+
+import {
+  useCreateRule,
+  useUpdateRule,
+  useRemoveRule,
+  useServerTools,
+} from '../hooks/useRules';
+import { useServers } from '../hooks/useServers';
+import { useAgents } from '../hooks/useAgents';
+import { useSettings } from '../hooks/useSettings';
+import { useLLMConfigs } from '../hooks/useLLMConfigs';
+import {
+  type LLMConfig,
+  type Rule,
+  type RuleAction,
+  type RuleInput,
+  apiErrorMessage,
+  modelConfigsApi,
+} from '../api/AtryumAPI';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const EMPTY_RULE_FORM: RuleInput = {
+  action: 'human_approval',
+  server_patterns: [],
+  tool_patterns: [],
+  agent_cuids: [],
+  description: '',
+  model_config_cuid: '',
+  atryum_llm_config_id: '',
+  enabled: true,
+};
+
+const BASE_ACTION_OPTIONS: { value: RuleAction; label: string }[] = [
+  { value: 'auto_approve', label: 'Auto Approve' },
+  { value: 'auto_deny', label: 'Auto Deny' },
+  { value: 'human_approval', label: 'Human Approval' },
+];
+
+const AI_EVAL_OPTION: { value: RuleAction; label: string } = {
+  value: 'ai_evaluation',
+  label: 'AI Evaluation',
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+type SelectOption = { value: string; label: string };
+
+const toOptions = (names: string[]): SelectOption[] =>
+  names.map((n) => ({ value: n, label: n }));
+const fromOptions = (opts: readonly SelectOption[]): string[] =>
+  opts.map((o) => o.value);
+const formatCreateLabel = (input: string): string => `Add "${input}"`;
+
+export const ruleToInput = (r: Rule): RuleInput => ({
+  action: r.action,
+  server_patterns: r.server_patterns,
+  tool_patterns: r.tool_patterns,
+  agent_cuids: r.agent_cuids ?? [],
+  description: r.description ?? '',
+  model_config_cuid: r.model_config_cuid ?? '',
+  atryum_llm_config_id: r.atryum_llm_config_id ?? '',
+  enabled: r.enabled,
+});
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export type CreateRuleModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  /** When provided, opens in edit mode for this rule. */
+  rule?: Rule | null;
+  /**
+   * Initial form values for create mode, merged over EMPTY_RULE_FORM so you
+   * only need to specify the fields you want pre-filled (e.g. from an
+   * invocation's server/tool/agent).
+   */
+  initialValues?: Partial<RuleInput>;
+};
+
+export const CreateRuleModal: React.FC<CreateRuleModalProps> = ({
+  isOpen,
+  onClose,
+  rule,
+  initialValues,
+}) => {
+  const toast = useToast();
+  const isEditing = !!rule;
+
+  const buildInitialForm = useCallback((): RuleInput => {
+    if (rule) return ruleToInput(rule);
+    return { ...EMPTY_RULE_FORM, ...initialValues };
+  }, [rule, initialValues]);
+
+  const [form, setForm] = useState<RuleInput>(buildInitialForm);
+  const [statusMsg, setStatusMsg] = useState<{
+    text: string;
+    isError: boolean;
+  } | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setForm(buildInitialForm());
+      setStatusMsg(null);
+    }
+  }, [isOpen, buildInitialForm]);
+
+  // ── Queries ────────────────────────────────────────────────────────────────
+
+  const { data: serversData } = useServers(true);
+  const { data: toolsData, isFetching: toolsFetching } = useServerTools(
+    form.server_patterns,
+  );
+  const { data: agentsData } = useAgents();
+  const { isConnected } = useSettings();
+  const { data: modelConfigsData } = useQuery(
+    ['model-configs'],
+    modelConfigsApi.list,
+    { enabled: isConnected, staleTime: 60_000 },
+  );
+  const { data: llmConfigsData } = useLLMConfigs();
+
+  const serverOptions = toOptions(
+    (serversData?.items ?? []).map((s) => s.name),
+  );
+  const toolOptions = toOptions((toolsData ?? []).map((t) => t.name));
+  const agentOptions = (agentsData?.items ?? []).map((a) => ({
+    value: a.cuid,
+    label: a.name,
+  }));
+  const modelConfigOptions = (modelConfigsData?.items ?? []).map((mc) => ({
+    value: `vm:${mc.cuid}`,
+    label: mc.name,
+  }));
+  const llmConfigOptions = ((llmConfigsData?.items ?? []) as LLMConfig[])
+    .filter((c) => c.enabled)
+    .map((c) => ({ value: `local:${c.id}`, label: c.name }));
+
+  const hasAIEval = isConnected || llmConfigOptions.length > 0;
+  const actionOptions = hasAIEval
+    ? [...BASE_ACTION_OPTIONS, AI_EVAL_OPTION]
+    : BASE_ACTION_OPTIONS;
+
+  const aiEvalGroups: { label: string; options: SelectOption[] }[] = [];
+  if (isConnected && modelConfigOptions.length > 0) {
+    aiEvalGroups.push({ label: 'ValidMind Models', options: modelConfigOptions });
+  }
+  if (llmConfigOptions.length > 0) {
+    aiEvalGroups.push({ label: 'Local LLMs', options: llmConfigOptions });
+  }
+
+  const aiEvalValue: SelectOption | null = form.model_config_cuid
+    ? (modelConfigOptions.find(
+        (o) => o.value === `vm:${form.model_config_cuid}`,
+      ) ?? null)
+    : form.atryum_llm_config_id
+      ? (llmConfigOptions.find(
+          (o) => o.value === `local:${form.atryum_llm_config_id}`,
+        ) ?? null)
+      : null;
+
+  // ── Mutations ──────────────────────────────────────────────────────────────
+
+  const createRule = useCreateRule();
+  const updateRule = useUpdateRule();
+  const removeRule = useRemoveRule();
+
+  const isBusy =
+    createRule.isLoading || updateRule.isLoading || removeRule.isLoading;
+
+  // ── Handlers ───────────────────────────────────────────────────────────────
+
+  const handleServerChange = useCallback(
+    (selected: readonly SelectOption[]) => {
+      const newServers = fromOptions(selected);
+      const validTools = new Set(toolOptions.map((t) => t.value));
+      const filteredTools = form.tool_patterns.filter((t) =>
+        validTools.has(t),
+      );
+      setForm((f) => ({
+        ...f,
+        server_patterns: newServers,
+        tool_patterns: filteredTools,
+      }));
+    },
+    [form.tool_patterns, toolOptions],
+  );
+
+  const handleSave = useCallback(async () => {
+    try {
+      if (isEditing && rule) {
+        await updateRule.mutateAsync({ id: rule.id, input: form });
+        toast({ title: 'Rule saved', status: 'success', duration: 3000, isClosable: true });
+      } else {
+        await createRule.mutateAsync(form);
+        toast({ title: 'Rule created', status: 'success', duration: 3000, isClosable: true });
+      }
+      onClose();
+    } catch (err: unknown) {
+      setStatusMsg({ text: apiErrorMessage(err, 'Save failed.'), isError: true });
+    }
+  }, [createRule, form, isEditing, onClose, rule, toast, updateRule]);
+
+  const handleDelete = useCallback(async () => {
+    if (!rule) return;
+    if (!window.confirm('Delete this rule?')) return;
+    try {
+      await removeRule.mutateAsync(rule.id);
+      toast({ title: 'Rule deleted', status: 'success', duration: 3000, isClosable: true });
+      onClose();
+    } catch (err: unknown) {
+      setStatusMsg({ text: apiErrorMessage(err, 'Delete failed.'), isError: true });
+    }
+  }, [onClose, removeRule, rule, toast]);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <Modal
+      size="lg"
+      isCentered
+      closeOnEsc
+      closeOnOverlayClick
+      isOpen={isOpen}
+      onClose={onClose}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{isEditing ? 'Edit Rule' : 'New Rule'}</ModalHeader>
+        <ModalCloseButton />
+
+        <ModalBody>
+          <VStack align="stretch" gap={4}>
+            {statusMsg && (
+              <Alert
+                status={statusMsg.isError ? 'error' : 'success'}
+                borderRadius="md"
+                py={2}
+              >
+                <AlertIcon />
+                <AlertDescription fontSize="sm">{statusMsg.text}</AlertDescription>
+              </Alert>
+            )}
+
+            {/* Action */}
+            <FormControl isRequired>
+              <FormLabel fontSize="sm">Action</FormLabel>
+              <Select
+                size="sm"
+                options={actionOptions}
+                value={actionOptions.find((o) => o.value === form.action) ?? null}
+                onChange={(opt) => {
+                  if (!opt) return;
+                  setForm((f) => ({
+                    ...f,
+                    action: opt.value as RuleAction,
+                    model_config_cuid:
+                      opt.value !== 'ai_evaluation' ? '' : f.model_config_cuid,
+                    atryum_llm_config_id:
+                      opt.value !== 'ai_evaluation' ? '' : f.atryum_llm_config_id,
+                  }));
+                }}
+                classNamePrefix="chakra-react-select"
+              />
+            </FormControl>
+
+            {/* Evaluation model */}
+            {form.action === 'ai_evaluation' &&
+              (aiEvalGroups.length > 0 ? (
+                <FormControl isRequired>
+                  <FormLabel fontSize="sm">Evaluation Model</FormLabel>
+                  <Select
+                    size="sm"
+                    options={aiEvalGroups}
+                    value={aiEvalValue}
+                    onChange={(opt) => {
+                      if (!opt) {
+                        setForm((f) => ({
+                          ...f,
+                          model_config_cuid: '',
+                          atryum_llm_config_id: '',
+                        }));
+                        return;
+                      }
+                      if (opt.value.startsWith('vm:')) {
+                        setForm((f) => ({
+                          ...f,
+                          model_config_cuid: opt.value.slice(3),
+                          atryum_llm_config_id: '',
+                        }));
+                      } else {
+                        setForm((f) => ({
+                          ...f,
+                          atryum_llm_config_id: opt.value.slice(6),
+                          model_config_cuid: '',
+                        }));
+                      }
+                    }}
+                    placeholder="Select a model…"
+                    isClearable
+                    classNamePrefix="chakra-react-select"
+                  />
+                  <FormHelperText fontSize="xs">
+                    Choose a ValidMind model configuration or a locally-configured
+                    LLM.
+                  </FormHelperText>
+                </FormControl>
+              ) : (
+                <Alert status="warning" borderRadius="md" py={2}>
+                  <AlertIcon />
+                  <AlertDescription fontSize="xs">
+                    No evaluation models available. Connect to ValidMind or add a
+                    local LLM in Settings.
+                  </AlertDescription>
+                </Alert>
+              ))}
+
+            {/* Agents */}
+            <FormControl>
+              <FormLabel fontSize="sm">Agents</FormLabel>
+              <Select
+                isMulti
+                size="sm"
+                placeholder="All agents"
+                options={agentOptions}
+                value={agentOptions.filter((o) =>
+                  (form.agent_cuids ?? []).includes(o.value),
+                )}
+                onChange={(selected) =>
+                  setForm((f) => ({
+                    ...f,
+                    agent_cuids: selected.map((o) => o.value),
+                  }))
+                }
+                classNamePrefix="chakra-react-select"
+              />
+              <FormHelperText fontSize="xs">
+                Restrict this rule to specific agents. Leave empty to apply to all.
+              </FormHelperText>
+            </FormControl>
+
+            {/* Servers */}
+            <FormControl>
+              <FormLabel fontSize="sm">Servers / Sources</FormLabel>
+              <CreatableSelect
+                isMulti
+                size="sm"
+                placeholder="All servers"
+                options={serverOptions}
+                value={toOptions(form.server_patterns)}
+                onChange={handleServerChange}
+                formatCreateLabel={formatCreateLabel}
+                classNamePrefix="chakra-react-select"
+              />
+              <FormHelperText fontSize="xs">
+                Pick an MCP server or type a coding harness source name. Leave
+                empty to match all.
+              </FormHelperText>
+            </FormControl>
+
+            {/* Tools */}
+            <FormControl>
+              <FormLabel fontSize="sm">Tools</FormLabel>
+              <CreatableSelect
+                isMulti
+                size="sm"
+                placeholder={
+                  form.server_patterns.length === 0
+                    ? 'Select servers first or type a tool name'
+                    : toolsFetching
+                      ? 'Loading tools…'
+                      : 'All tools'
+                }
+                isLoading={toolsFetching}
+                options={toolOptions}
+                value={toOptions(form.tool_patterns)}
+                onChange={(selected) =>
+                  setForm((f) => ({ ...f, tool_patterns: fromOptions(selected) }))
+                }
+                formatCreateLabel={formatCreateLabel}
+                classNamePrefix="chakra-react-select"
+              />
+              <FormHelperText fontSize="xs">
+                Pick from discovered tools or type a tool name. Leave empty to
+                match all.
+              </FormHelperText>
+            </FormControl>
+
+            {/* Description */}
+            <FormControl>
+              <FormLabel fontSize="sm">Description (optional)</FormLabel>
+              <Input
+                size="sm"
+                placeholder="e.g. Allow all read-only tools"
+                value={form.description ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, description: e.target.value }))
+                }
+              />
+            </FormControl>
+
+            {/* Enabled */}
+            <Checkbox
+              isChecked={form.enabled}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, enabled: e.target.checked }))
+              }
+            >
+              <Text fontSize="sm">Enabled</Text>
+            </Checkbox>
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter gap={2}>
+          {isEditing && (
+            <Button
+              variant="outlineDanger"
+              size="sm"
+              isLoading={removeRule.isLoading}
+              isDisabled={isBusy}
+              onClick={handleDelete}
+              mr="auto"
+            >
+              Delete
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" isDisabled={isBusy} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            isLoading={createRule.isLoading || updateRule.isLoading}
+            isDisabled={isBusy}
+            onClick={handleSave}
+          >
+            {isEditing ? 'Save' : 'Create Rule'}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/ui/src/hooks/useInvocationStream.ts
+++ b/ui/src/hooks/useInvocationStream.ts
@@ -1,6 +1,6 @@
 // Direct useEffect is required here to manage the SSE connection lifecycle.
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useQueryClient } from 'react-query';
 import type { QueryKey } from 'react-query';
 import { getAdminAccessToken, refreshAdminAccessToken } from '../auth/adminAuth';
@@ -9,7 +9,6 @@ import {
   INVOCATION_DETAIL_KEY,
   INVOCATION_EVENTS_KEY,
   INVOCATIONS_KEY,
-  normalizeInvocationFilters,
 } from './useInvocations';
 import type { InvocationFilters } from '../api/AtryumAPI';
 
@@ -26,11 +25,6 @@ const buildStreamUrl = (filters: InvocationFilters): string => {
   params.set('limit', String(filters.limit ?? 50));
   return `/api/v1/admin/invocations/stream?${params.toString()}`;
 };
-
-const listKey = (filters: InvocationFilters): QueryKey => [
-  INVOCATIONS_KEY,
-  normalizeInvocationFilters(filters),
-];
 
 const detailKey = (id: string): QueryKey => [INVOCATION_DETAIL_KEY, id];
 const eventsKey = (id: string): QueryKey => [INVOCATION_EVENTS_KEY, id];
@@ -56,11 +50,6 @@ export const useInvocationStream = (
   const selectedIdRef = useRef<string | null>(selectedId);
   selectedIdRef.current = selectedId;
 
-  const normalizedFilters = useMemo(
-    () => normalizeInvocationFilters(filters),
-    [filters],
-  );
-
   useEffect(() => {
     if (!isEnabled) return;
 
@@ -73,10 +62,11 @@ export const useInvocationStream = (
       const payload = JSON.parse(data) as InvocationStreamPayload;
       const items = payload.items ?? [];
 
-      queryClient.setQueryData<{ items: Invocation[] }>(
-        listKey(normalizedFilters),
-        { items },
-      );
+      // Invalidate all invocations list queries regardless of offset/limit so
+      // the currently-viewed page (which includes offset in its cache key)
+      // picks up the update. Using setQueryData with the stream's own key no
+      // longer works since pagination added offset to the useInvocations key.
+      void queryClient.invalidateQueries([INVOCATIONS_KEY]);
 
       const currentSelectedId = selectedIdRef.current;
       if (!currentSelectedId) return;
@@ -124,7 +114,7 @@ export const useInvocationStream = (
         const headers: HeadersInit = { Accept: 'text/event-stream' };
         if (token) headers.Authorization = `Bearer ${token}`;
 
-        let response = await fetch(buildStreamUrl(normalizedFilters), {
+        let response = await fetch(buildStreamUrl(filters), {
           headers,
           signal: controller.signal,
         });
@@ -132,7 +122,7 @@ export const useInvocationStream = (
         if (response.status === 401 && !didRefresh) {
           token = await refreshAdminAccessToken();
           if (token) {
-            response = await fetch(buildStreamUrl(normalizedFilters), {
+            response = await fetch(buildStreamUrl(filters), {
               headers: {
                 Accept: 'text/event-stream',
                 Authorization: `Bearer ${token}`,
@@ -203,5 +193,5 @@ export const useInvocationStream = (
       if (retryTimer) window.clearTimeout(retryTimer);
       controller?.abort();
     };
-  }, [isEnabled, normalizedFilters, queryClient]);
+  }, [isEnabled, filters, queryClient]);
 };

--- a/ui/src/hooks/useInvocationStream.ts
+++ b/ui/src/hooks/useInvocationStream.ts
@@ -10,6 +10,7 @@ import {
   INVOCATION_EVENTS_KEY,
   INVOCATIONS_KEY,
 } from './useInvocations';
+import { RULES_KEY } from './useRules';
 import type { InvocationFilters } from '../api/AtryumAPI';
 
 interface InvocationStreamPayload {
@@ -67,6 +68,11 @@ export const useInvocationStream = (
       // picks up the update. Using setQueryData with the stream's own key no
       // longer works since pagination added offset to the useInvocations key.
       void queryClient.invalidateQueries([INVOCATIONS_KEY]);
+
+      // Also refresh the rules cache: a new invocation may reference a rule
+      // that was created after the rules list was last fetched, which would
+      // cause the audit display to show "*Deleted Rule*" for a valid rule.
+      void queryClient.invalidateQueries([RULES_KEY]);
 
       const currentSelectedId = selectedIdRef.current;
       if (!currentSelectedId) return;

--- a/ui/src/hooks/useRules.ts
+++ b/ui/src/hooks/useRules.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { rulesApi, serversApi, type RuleInput, type ServerTool } from '../api/AtryumAPI';
 
-const RULES_KEY = 'atryum-rules';
+export const RULES_KEY = 'atryum-rules';
 
 export const useRules = () =>
   useQuery([RULES_KEY], () => rulesApi.list(), {

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -22,13 +22,6 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
   Spinner,
   Stack,
   Table,
@@ -45,6 +38,7 @@ import {
   Alert,
   AlertDescription,
   AlertIcon,
+  useDisclosure,
   useToast,
 } from "@chakra-ui/react";
 import { Select } from "chakra-react-select";
@@ -56,6 +50,7 @@ import {
 } from "@heroicons/react/24/outline";
 
 import { ContentPageTitle } from "../components/Layout";
+import { CreateRuleModal } from "../components/CreateRuleModal";
 import DiffViewer from "../components/DiffViewer";
 import { extractDiff } from "../components/diffUtils";
 import AgentIcon, { detectAgentKind } from "../components/AgentIcon";
@@ -68,7 +63,7 @@ import {
   useSummarizeInvocation,
 } from "../hooks/useInvocations";
 import { useSettings } from "../hooks/useSettings";
-import { useCreateRule, useRules } from "../hooks/useRules";
+import { useRules } from "../hooks/useRules";
 import { useAgents } from "../hooks/useAgents";
 import { useInvocationStream } from "../hooks/useInvocationStream";
 import {
@@ -76,7 +71,6 @@ import {
   type Invocation,
   type InvocationEvent,
   type InvocationStatus,
-  type RuleAction,
   type RuleInput,
 } from "../api/AtryumAPI";
 import {
@@ -151,6 +145,25 @@ const AUDIT_STEP_ICON: Record<AuditStep["variant"], string> = {
   pending: "…",
   info: "→",
   error: "✗",
+};
+
+const ACTION_LABEL: Partial<Record<string, string>> = {
+  auto_approve: "Auto-approve",
+  auto_deny: "Auto-deny",
+  human_approval: "Human approval",
+  ai_evaluation: "AI evaluation",
+};
+
+const buildRuleDescription = (
+  action: string | undefined,
+  serverName: string | null | undefined,
+  toolName: string | null | undefined,
+): string => {
+  const parts: string[] = [];
+  if (action && ACTION_LABEL[action]) parts.push(ACTION_LABEL[action]!);
+  const target = [serverName, toolName].filter(Boolean).join("/");
+  if (target) parts.push(target);
+  return parts.join(" ");
 };
 
 const AuditEntryRow: React.FC<{ entry: AuditEntry }> = ({ entry }) => {
@@ -339,24 +352,14 @@ const Invocations: React.FC = () => {
     () => new Set(),
   );
   const [denyMode, setDenyMode] = useState<"once" | "always">("once");
-  const [showCustomizeScope, setShowCustomizeScope] = useState(false);
-  const [ruleForm, setRuleForm] = useState({
-    server_patterns: "",
-    tool_patterns: "",
-    description: "",
-  });
-  const [showCreateRule, setShowCreateRule] = useState(false);
-  const [createRuleForm, setCreateRuleForm] = useState<{
-    action: RuleAction;
-    server_patterns: string;
-    tool_patterns: string;
-    description: string;
-  }>({
-    action: "auto_approve",
-    server_patterns: "",
-    tool_patterns: "",
-    description: "",
-  });
+  const [ruleModalInitial, setRuleModalInitial] = useState<
+    Partial<RuleInput> | undefined
+  >();
+  const {
+    isOpen: isRuleModalOpen,
+    onOpen: openRuleModal,
+    onClose: closeRuleModal,
+  } = useDisclosure();
 
   const filters = useMemo(
     () =>
@@ -423,7 +426,6 @@ const Invocations: React.FC = () => {
   const approve = useApproveInvocation();
   const deny = useDenyInvocation();
   const summarize = useSummarizeInvocation();
-  const createRule = useCreateRule();
   const { data: rulesData } = useRules();
   const { data: settings } = useSettings();
 
@@ -469,42 +471,6 @@ const Invocations: React.FC = () => {
     }
   }, [resolvedSelectedId, summarize, summaryModelConfigCuid]);
 
-  const buildScopeRule = (action: RuleAction): RuleInput => ({
-    action,
-    server_patterns: ruleForm.server_patterns
-      ? ruleForm.server_patterns
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean)
-      : [],
-    tool_patterns: ruleForm.tool_patterns
-      ? ruleForm.tool_patterns
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean)
-      : [],
-    description: ruleForm.description || undefined,
-    enabled: true,
-  });
-
-  const resetRuleForm = (serverName?: string, toolName?: string) => {
-    setRuleForm({
-      server_patterns: serverName ?? "",
-      tool_patterns: toolName ?? "",
-      description: "",
-    });
-    setShowCustomizeScope(false);
-  };
-
-  const resetCreateRuleForm = (serverName?: string, toolName?: string) => {
-    setCreateRuleForm({
-      action: "auto_approve",
-      server_patterns: serverName ?? "",
-      tool_patterns: toolName ?? "",
-      description: "",
-    });
-    setShowCreateRule(false);
-  };
 
   const handleApply = () => {
     setAppliedFilters({ ...draftFilters });
@@ -535,38 +501,24 @@ const Invocations: React.FC = () => {
     if (!resolvedSelectedId) return;
     await approve.mutateAsync({ id: resolvedSelectedId });
     setShowDenyInput(false);
-    resetRuleForm();
   };
 
-  const handleAlwaysApprove = async () => {
-    if (!resolvedSelectedId) return;
-    const rule = buildScopeRule("auto_approve");
-    await approve.mutateAsync({ id: resolvedSelectedId, createRule: rule });
-
-    const matchingPendingInvocations = (await loadPendingInvocations()).filter(
-      (invocation) =>
-        invocation.invocation_id !== resolvedSelectedId &&
-        invocation.status === "pending_approval" &&
-        matchesRuleScope(invocation, rule),
-    );
-
-    if (
-      matchingPendingInvocations.length > 0 &&
-      window.confirm(
-        `Apply this auto-approve rule to ${matchingPendingInvocations.length} other pending approval${
-          matchingPendingInvocations.length === 1 ? "" : "s"
-        } now?`,
-      )
-    ) {
-      await Promise.all(
-        matchingPendingInvocations.map((invocation) =>
-          approve.mutateAsync({ id: invocation.invocation_id }),
-        ),
-      );
-    }
-
-    setShowDenyInput(false);
-    resetRuleForm();
+  const handleAlwaysApprove = () => {
+    const agentEntry = detail?.agent_id
+      ? agentByAgentID.get(detail.agent_id)
+      : undefined;
+    setRuleModalInitial({
+      action: "auto_approve",
+      server_patterns: detail?.server_name ? [detail.server_name] : [],
+      tool_patterns: detail?.tool_name ? [detail.tool_name] : [],
+      agent_cuids: agentEntry?.cuid ? [agentEntry.cuid] : [],
+      description: buildRuleDescription(
+        "auto_approve",
+        detail?.server_name,
+        detail?.tool_name,
+      ),
+    });
+    openRuleModal();
   };
 
   const handleDenyOnce = async () => {
@@ -574,63 +526,24 @@ const Invocations: React.FC = () => {
     await deny.mutateAsync({ id: resolvedSelectedId, message: denyMessage });
     setDenyMessage("");
     setShowDenyInput(false);
-    resetRuleForm();
   };
 
-  const handleAlwaysDeny = async () => {
-    if (!resolvedSelectedId) return;
-    const rule = buildScopeRule("auto_deny");
-    await deny.mutateAsync({
-      id: resolvedSelectedId,
-      message: denyMessage,
-      createRule: rule,
+  const handleAlwaysDeny = () => {
+    const agentEntry = detail?.agent_id
+      ? agentByAgentID.get(detail.agent_id)
+      : undefined;
+    setRuleModalInitial({
+      action: "auto_deny",
+      server_patterns: detail?.server_name ? [detail.server_name] : [],
+      tool_patterns: detail?.tool_name ? [detail.tool_name] : [],
+      agent_cuids: agentEntry?.cuid ? [agentEntry.cuid] : [],
+      description: buildRuleDescription(
+        "auto_deny",
+        detail?.server_name,
+        detail?.tool_name,
+      ),
     });
-    setDenyMessage("");
-    setShowDenyInput(false);
-    resetRuleForm();
-  };
-
-  const handleSaveRule = async () => {
-    const input: RuleInput = {
-      action: createRuleForm.action,
-      server_patterns: createRuleForm.server_patterns
-        ? createRuleForm.server_patterns
-            .split(",")
-            .map((s) => s.trim())
-            .filter(Boolean)
-        : [],
-      tool_patterns: createRuleForm.tool_patterns
-        ? createRuleForm.tool_patterns
-            .split(",")
-            .map((s) => s.trim())
-            .filter(Boolean)
-        : [],
-      description: createRuleForm.description || undefined,
-      enabled: true,
-    };
-    try {
-      await createRule.mutateAsync(input);
-      resetCreateRuleForm();
-      toast({
-        title: "Rule created",
-        status: "success",
-        duration: 3000,
-        isClosable: true,
-      });
-    } catch (err) {
-      const message =
-        (err as { response?: { data?: { error?: { message?: string } } } })
-          ?.response?.data?.error?.message ??
-        (err as Error)?.message ??
-        "Failed to create rule";
-      toast({
-        title: "Failed to create rule",
-        description: message,
-        status: "error",
-        duration: 6000,
-        isClosable: true,
-      });
-    }
+    openRuleModal();
   };
 
   const isPending = detail?.status === "pending_approval";
@@ -844,11 +757,6 @@ const Invocations: React.FC = () => {
                               setShowDenyInput(false);
                               setShowArgsJson(false);
                               setDenyMessage("");
-                              resetRuleForm(inv.server_name, inv.tool_name);
-                              resetCreateRuleForm(
-                                inv.server_name,
-                                inv.tool_name,
-                              );
                             }
                           }}>
                           <Td
@@ -1479,10 +1387,7 @@ const Invocations: React.FC = () => {
                                 />
                                 <MenuList>
                                   <MenuItem
-                                    onClick={() => {
-                                      setDenyMode("always");
-                                      setShowDenyInput(true);
-                                    }}
+                                    onClick={handleAlwaysDeny}
                                     data-testid="invocation-always-deny-menu-item">
                                     Always deny
                                   </MenuItem>
@@ -1531,97 +1436,6 @@ const Invocations: React.FC = () => {
                           </VStack>
                         )}
 
-                        <Box mt={3}>
-                          <Button
-                            variant="ghost"
-                            size="xs"
-                            onClick={() => {
-                              if (!showCustomizeScope) {
-                                setRuleForm((f) => ({
-                                  ...f,
-                                  server_patterns:
-                                    f.server_patterns ||
-                                    detail.server_name ||
-                                    "",
-                                  tool_patterns:
-                                    f.tool_patterns || detail.tool_name || "",
-                                }));
-                              }
-                              setShowCustomizeScope((v) => !v);
-                            }}>
-                            {showCustomizeScope
-                              ? "▲ Hide rule scope"
-                              : "▼ Customize rule scope"}
-                          </Button>
-                          <Collapse in={showCustomizeScope} animateOpacity>
-                            <VStack
-                              align="stretch"
-                              gap={2}
-                              mt={2}
-                              p={3}
-                              borderWidth={1}
-                              borderColor="border.base"
-                              borderRadius="md">
-                              <Text
-                                fontSize="xs"
-                                color="text.subtle"
-                                fontWeight="semibold">
-                                Rule scope for &ldquo;Always approve&rdquo; /
-                                &ldquo;Always deny&rdquo;
-                              </Text>
-                              <FormControl size="sm">
-                                <FormLabel fontSize="xs" mb={1}>
-                                  Server patterns (comma-separated)
-                                </FormLabel>
-                                <Input
-                                  size="sm"
-                                  fontFamily="mono"
-                                  placeholder="e.g. github, *"
-                                  value={ruleForm.server_patterns}
-                                  onChange={(e) =>
-                                    setRuleForm((f) => ({
-                                      ...f,
-                                      server_patterns: e.target.value,
-                                    }))
-                                  }
-                                />
-                              </FormControl>
-                              <FormControl size="sm">
-                                <FormLabel fontSize="xs" mb={1}>
-                                  Tool patterns (comma-separated)
-                                </FormLabel>
-                                <Input
-                                  size="sm"
-                                  fontFamily="mono"
-                                  placeholder="e.g. list_issues, *"
-                                  value={ruleForm.tool_patterns}
-                                  onChange={(e) =>
-                                    setRuleForm((f) => ({
-                                      ...f,
-                                      tool_patterns: e.target.value,
-                                    }))
-                                  }
-                                />
-                              </FormControl>
-                              <FormControl size="sm">
-                                <FormLabel fontSize="xs" mb={1}>
-                                  Description (optional)
-                                </FormLabel>
-                                <Input
-                                  size="sm"
-                                  placeholder="e.g. Allow GitHub read tools"
-                                  value={ruleForm.description}
-                                  onChange={(e) =>
-                                    setRuleForm((f) => ({
-                                      ...f,
-                                      description: e.target.value,
-                                    }))
-                                  }
-                                />
-                              </FormControl>
-                            </VStack>
-                          </Collapse>
-                        </Box>
                       </Box>
                     )}
 
@@ -1631,132 +1445,38 @@ const Invocations: React.FC = () => {
                       alignSelf="flex-start"
                       leftIcon={<Icon as={ShieldCheckIcon} boxSize={4} />}
                       onClick={() => {
-                        setCreateRuleForm((f) => ({
-                          ...f,
-                          server_patterns:
-                            f.server_patterns || detail.server_name || "",
-                          tool_patterns:
-                            f.tool_patterns || detail.tool_name || "",
-                        }));
-                        setShowCreateRule(true);
+                        const agentEntry = detail.agent_id
+                          ? agentByAgentID.get(detail.agent_id)
+                          : undefined;
+                        setRuleModalInitial({
+                          server_patterns: detail.server_name
+                            ? [detail.server_name]
+                            : [],
+                          tool_patterns: detail.tool_name
+                            ? [detail.tool_name]
+                            : [],
+                          agent_cuids: agentEntry?.cuid
+                            ? [agentEntry.cuid]
+                            : [],
+                          description: buildRuleDescription(
+                            undefined,
+                            detail.server_name,
+                            detail.tool_name,
+                          ),
+                        });
+                        openRuleModal();
                       }}
                       data-testid="invocation-create-rule-button">
                       Create Rule From This
                     </Button>
-                    <Modal
-                      isOpen={showCreateRule}
-                      onClose={() => setShowCreateRule(false)}
-                      size="lg"
-                      isCentered>
-                      <ModalOverlay />
-                      <ModalContent data-testid="create-rule-modal">
-                        <ModalHeader>
-                          Create Rule From This Invocation
-                        </ModalHeader>
-                        <ModalCloseButton data-testid="create-rule-modal-close-button" />
-                        <ModalBody>
-                          <VStack align="stretch" gap={2}>
-                            <FormControl size="sm">
-                              <FormLabel fontSize="xs" mb={1}>
-                                Action
-                              </FormLabel>
-                              <Select
-                                classNamePrefix="chakra-react-select"
-                                size="sm"
-                                options={[
-                                  {
-                                    value: "auto_approve",
-                                    label: "Auto Approve",
-                                  },
-                                  { value: "auto_deny", label: "Auto Deny" },
-                                ]}
-                                value={{
-                                  value: createRuleForm.action,
-                                  label:
-                                    createRuleForm.action === "auto_approve"
-                                      ? "Auto Approve"
-                                      : "Auto Deny",
-                                }}
-                                onChange={(opt) =>
-                                  opt &&
-                                  setCreateRuleForm((f) => ({
-                                    ...f,
-                                    action: opt.value as RuleAction,
-                                  }))
-                                }
-                              />
-                            </FormControl>
-                            <FormControl size="sm">
-                              <FormLabel fontSize="xs" mb={1}>
-                                Server patterns (comma-separated)
-                              </FormLabel>
-                              <Input
-                                size="sm"
-                                fontFamily="mono"
-                                placeholder="e.g. github, *"
-                                value={createRuleForm.server_patterns}
-                                onChange={(e) =>
-                                  setCreateRuleForm((f) => ({
-                                    ...f,
-                                    server_patterns: e.target.value,
-                                  }))
-                                }
-                              />
-                            </FormControl>
-                            <FormControl size="sm">
-                              <FormLabel fontSize="xs" mb={1}>
-                                Tool patterns (comma-separated)
-                              </FormLabel>
-                              <Input
-                                size="sm"
-                                fontFamily="mono"
-                                placeholder="e.g. list_issues, *"
-                                value={createRuleForm.tool_patterns}
-                                onChange={(e) =>
-                                  setCreateRuleForm((f) => ({
-                                    ...f,
-                                    tool_patterns: e.target.value,
-                                  }))
-                                }
-                              />
-                            </FormControl>
-                            <FormControl size="sm">
-                              <FormLabel fontSize="xs" mb={1}>
-                                Description (optional)
-                              </FormLabel>
-                              <Input
-                                size="sm"
-                                placeholder="e.g. Allow GitHub read tools"
-                                value={createRuleForm.description}
-                                onChange={(e) =>
-                                  setCreateRuleForm((f) => ({
-                                    ...f,
-                                    description: e.target.value,
-                                  }))
-                                }
-                              />
-                            </FormControl>
-                          </VStack>
-                        </ModalBody>
-                        <ModalFooter gap={2}>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => setShowCreateRule(false)}
-                            data-testid="create-rule-modal-cancel-button">
-                            Cancel
-                          </Button>
-                          <Button
-                            variant="primary"
-                            size="sm"
-                            isLoading={createRule.isLoading}
-                            onClick={handleSaveRule}
-                            data-testid="create-rule-modal-save-button">
-                            Save Rule
-                          </Button>
-                        </ModalFooter>
-                      </ModalContent>
-                    </Modal>
+
+                    <CreateRuleModal
+                      isOpen={isRuleModalOpen}
+                      onClose={closeRuleModal}
+                      {...(ruleModalInitial
+                        ? { initialValues: ruleModalInitial }
+                        : {})}
+                    />
 
                     {detail.result != null && (
                       <Box>

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -68,7 +68,6 @@ import { useAgents } from "../hooks/useAgents";
 import { useInvocationStream } from "../hooks/useInvocationStream";
 import {
   invocationsApi,
-  type Invocation,
   type InvocationEvent,
   type InvocationStatus,
   type RuleInput,
@@ -104,39 +103,6 @@ const STATUS_OPTIONS = STATUSES.map((status) => ({
   value: status,
 }));
 
-const wildcardToRegExp = (pattern: string): RegExp => {
-  const escapedPattern = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`^${escapedPattern.replace(/\*/g, ".*")}$`);
-};
-
-const matchesAnyPattern = (
-  patterns: string[],
-  value: string | null | undefined,
-): boolean => {
-  if (patterns.length === 0) return true;
-  const normalizedValue = value ?? "";
-  return patterns.some((pattern) =>
-    wildcardToRegExp(pattern).test(normalizedValue),
-  );
-};
-
-const matchesRuleScope = (invocation: Invocation, rule: RuleInput): boolean =>
-  matchesAnyPattern(rule.server_patterns, invocation.server_name) &&
-  matchesAnyPattern(rule.tool_patterns, invocation.tool_name);
-
-const loadPendingInvocations = async (): Promise<Invocation[]> => {
-  const limit = 50;
-  const pendingInvocations: Invocation[] = [];
-  for (let offset = 0; ; offset += limit) {
-    const page = await invocationsApi.list({
-      status: "pending_approval",
-      limit,
-      offset,
-    });
-    pendingInvocations.push(...page.items);
-    if (page.items.length < limit) return pendingInvocations;
-  }
-};
 
 const AUDIT_STEP_ICON: Record<AuditStep["variant"], string> = {
   approve: "✓",

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-no-bind */
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ResizablePanels from "../components/ResizablePanels";
 import {
   Badge,
@@ -355,6 +355,10 @@ const Invocations: React.FC = () => {
   const [ruleModalInitial, setRuleModalInitial] = useState<
     Partial<RuleInput> | undefined
   >();
+  // Stored as a ref so the callback is never stale without causing re-renders.
+  const ruleModalOnSuccessRef = useRef<
+    (() => void | Promise<void>) | undefined
+  >(undefined);
   const {
     isOpen: isRuleModalOpen,
     onOpen: openRuleModal,
@@ -518,6 +522,9 @@ const Invocations: React.FC = () => {
         detail?.tool_name,
       ),
     });
+    ruleModalOnSuccessRef.current = resolvedSelectedId
+      ? () => approve.mutateAsync({ id: resolvedSelectedId })
+      : undefined;
     openRuleModal();
   };
 
@@ -543,6 +550,9 @@ const Invocations: React.FC = () => {
         detail?.tool_name,
       ),
     });
+    ruleModalOnSuccessRef.current = resolvedSelectedId
+      ? () => deny.mutateAsync({ id: resolvedSelectedId, message: denyMessage })
+      : undefined;
     openRuleModal();
   };
 
@@ -1464,6 +1474,7 @@ const Invocations: React.FC = () => {
                             detail.tool_name,
                           ),
                         });
+                        ruleModalOnSuccessRef.current = undefined;
                         openRuleModal();
                       }}
                       data-testid="invocation-create-rule-button">
@@ -1473,6 +1484,7 @@ const Invocations: React.FC = () => {
                     <CreateRuleModal
                       isOpen={isRuleModalOpen}
                       onClose={closeRuleModal}
+                      onSuccess={ruleModalOnSuccessRef.current}
                       {...(ruleModalInitial
                         ? { initialValues: ruleModalInitial }
                         : {})}

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -184,7 +184,7 @@ const AuditEntryRow: React.FC<{ entry: AuditEntry }> = ({ entry }) => {
             flexShrink={0}
           />
           <Text fontSize="sm" fontWeight="medium" noOfLines={1}>
-            {entry.ruleName ?? "No rule matched"}
+            {entry.ruleName ?? "*No rule matched*"}
           </Text>
           {badge}
         </HStack>

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -487,6 +487,7 @@ const Invocations: React.FC = () => {
         detail?.server_name,
         detail?.tool_name,
       ),
+      insert_before: "",
     });
     ruleModalOnSuccessRef.current = resolvedSelectedId
       ? () => approve.mutateAsync({ id: resolvedSelectedId })
@@ -515,6 +516,7 @@ const Invocations: React.FC = () => {
         detail?.server_name,
         detail?.tool_name,
       ),
+      insert_before: "",
     });
     ruleModalOnSuccessRef.current = resolvedSelectedId
       ? () => deny.mutateAsync({ id: resolvedSelectedId, message: denyMessage })

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -70,6 +70,7 @@ import {
   invocationsApi,
   type InvocationEvent,
   type InvocationStatus,
+  type Rule,
   type RuleInput,
 } from "../api/AtryumAPI";
 import {
@@ -323,7 +324,7 @@ const Invocations: React.FC = () => {
   >();
   // Stored as a ref so the callback is never stale without causing re-renders.
   const ruleModalOnSuccessRef = useRef<
-    (() => void | Promise<void>) | undefined
+    ((savedRule: Rule) => void | Promise<void>) | undefined
   >(undefined);
   const {
     isOpen: isRuleModalOpen,
@@ -490,7 +491,12 @@ const Invocations: React.FC = () => {
       insert_before: "",
     });
     ruleModalOnSuccessRef.current = resolvedSelectedId
-      ? () => approve.mutateAsync({ id: resolvedSelectedId })
+      ? (savedRule) => {
+          if (savedRule.action === "auto_approve")
+            return approve.mutateAsync({ id: resolvedSelectedId });
+          if (savedRule.action === "auto_deny")
+            return deny.mutateAsync({ id: resolvedSelectedId, message: denyMessage });
+        }
       : undefined;
     openRuleModal();
   };
@@ -519,7 +525,12 @@ const Invocations: React.FC = () => {
       insert_before: "",
     });
     ruleModalOnSuccessRef.current = resolvedSelectedId
-      ? () => deny.mutateAsync({ id: resolvedSelectedId, message: denyMessage })
+      ? (savedRule) => {
+          if (savedRule.action === "auto_approve")
+            return approve.mutateAsync({ id: resolvedSelectedId });
+          if (savedRule.action === "auto_deny")
+            return deny.mutateAsync({ id: resolvedSelectedId, message: denyMessage });
+        }
       : undefined;
     openRuleModal();
   };

--- a/ui/src/pages/Rules.tsx
+++ b/ui/src/pages/Rules.tsx
@@ -1,27 +1,12 @@
 import React, { useCallback, useState } from 'react';
 import {
-  Alert,
-  AlertDescription,
-  AlertIcon,
   Badge,
   Box,
   Button,
-  Checkbox,
   Flex,
-  FormControl,
-  FormHelperText,
-  FormLabel,
   HStack,
   Icon,
   IconButton,
-  Input,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
   Spinner,
   Table,
   Tbody,
@@ -30,27 +15,17 @@ import {
   Th,
   Thead,
   Tr,
-  VStack,
   useDisclosure,
 } from '@chakra-ui/react';
-import { CreatableSelect, Select } from 'chakra-react-select';
 import { ShieldCheckIcon, ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
-import { useQuery } from 'react-query';
 
 import { ContentPageTitle } from '../components/Layout';
-import {
-  useRules,
-  useCreateRule,
-  useUpdateRule,
-  useRemoveRule,
-  useMoveRule,
-  useServerTools,
-} from '../hooks/useRules';
-import { useServers } from '../hooks/useServers';
+import { CreateRuleModal } from '../components/CreateRuleModal';
+import { useRules, useMoveRule } from '../hooks/useRules';
 import { useAgents } from '../hooks/useAgents';
-import { useSettings } from '../hooks/useSettings';
-import { useLLMConfigs } from '../hooks/useLLMConfigs';
-import { type Agent, type LLMConfig, type Rule, type RuleAction, type RuleInput, apiErrorMessage, modelConfigsApi } from '../api/AtryumAPI';
+import { type Agent, type Rule, type RuleAction } from '../api/AtryumAPI';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
 
 const ACTION_COLOR: Record<RuleAction, string> = {
   auto_approve: 'green',
@@ -66,50 +41,14 @@ const ACTION_LABEL: Record<RuleAction, string> = {
   ai_evaluation: 'AI Evaluation',
 };
 
-const BASE_ACTION_OPTIONS: { value: RuleAction; label: string }[] = [
-  { value: 'auto_approve', label: 'Auto Approve' },
-  { value: 'auto_deny', label: 'Auto Deny' },
-  { value: 'human_approval', label: 'Human Approval' },
-];
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-const AI_EVAL_OPTION: { value: RuleAction; label: string } = {
-  value: 'ai_evaluation',
-  label: 'AI Evaluation',
-};
-
-const EMPTY_FORM: RuleInput = {
-  action: 'human_approval',
-  server_patterns: [],
-  tool_patterns: [],
-  agent_cuids: [],
-  description: '',
-  model_config_cuid: '',
-  atryum_llm_config_id: '',
-  enabled: true,
-};
-
-const ruleToInput = (r: Rule): RuleInput => ({
-  action: r.action,
-  server_patterns: r.server_patterns,
-  tool_patterns: r.tool_patterns,
-  agent_cuids: r.agent_cuids ?? [],
-  description: r.description ?? '',
-  model_config_cuid: r.model_config_cuid ?? '',
-  atryum_llm_config_id: r.atryum_llm_config_id ?? '',
-  enabled: r.enabled,
-});
-
-type SelectOption = { value: string; label: string };
-
-const toOptions = (names: string[]): SelectOption[] =>
-  names.map((n) => ({ value: n, label: n }));
-const fromOptions = (opts: readonly SelectOption[]): string[] =>
-  opts.map((o) => o.value);
-const formatCreateLabel = (input: string): string => `Add "${input}"`;
 const patternLabel = (patterns: string[]): string =>
   patterns.length === 0 ? 'all' : patterns.join(', ');
 
 const stopPropagation = (e: React.MouseEvent): void => e.stopPropagation();
+
+// ─── RuleRow ──────────────────────────────────────────────────────────────────
 
 type RuleRowProps = {
   rule: Rule;
@@ -132,7 +71,10 @@ const RuleRow: React.FC<RuleRowProps> = ({
 }) => {
   const handleClick = useCallback(() => onEdit(rule), [onEdit, rule]);
   const handleMoveUp = useCallback(() => onMove(rule.id, 'up'), [onMove, rule.id]);
-  const handleMoveDown = useCallback(() => onMove(rule.id, 'down'), [onMove, rule.id]);
+  const handleMoveDown = useCallback(
+    () => onMove(rule.id, 'down'),
+    [onMove, rule.id],
+  );
   const selectedAgentCuids = rule.agent_cuids ?? [];
   const agentByCuid = new Map(agents.map((agent) => [agent.cuid, agent]));
 
@@ -168,11 +110,17 @@ const RuleRow: React.FC<RuleRowProps> = ({
         </HStack>
       </Td>
       <Td>
-        <Badge colorScheme={ACTION_COLOR[rule.action]} fontSize="2xs" whiteSpace="nowrap">
+        <Badge
+          colorScheme={ACTION_COLOR[rule.action]}
+          fontSize="2xs"
+          whiteSpace="nowrap"
+        >
           {ACTION_LABEL[rule.action]}
         </Badge>
       </Td>
-      <Td><Text fontSize="sm">{rule.description || '—'}</Text></Td>
+      <Td>
+        <Text fontSize="sm">{rule.description || '—'}</Text>
+      </Td>
       <Td>
         {selectedAgentCuids.length === 0 ? (
           <Badge colorScheme="gray" fontSize="2xs" variant="subtle">
@@ -224,116 +172,31 @@ const RuleRow: React.FC<RuleRowProps> = ({
   );
 };
 
+// ─── Main page ────────────────────────────────────────────────────────────────
+
 const Rules: React.FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [isCreating, setIsCreating] = useState(false);
-  const [form, setForm] = useState<RuleInput>(EMPTY_FORM);
-  const [statusMsg, setStatusMsg] = useState<{ text: string; isError: boolean } | null>(null);
+  const [selectedRule, setSelectedRule] = useState<Rule | null>(null);
 
-  const { data: rulesData, isLoading, refetch } = useRules();
-  const { data: serversData } = useServers(true);
-  const { data: toolsData, isFetching: toolsFetching } = useServerTools(form.server_patterns);
+  const { data: rulesData, isLoading } = useRules();
   const { data: agentsData } = useAgents();
-  const { isConnected } = useSettings();
-  const { data: modelConfigsData } = useQuery(
-    ['model-configs'],
-    modelConfigsApi.list,
-    { enabled: isConnected, staleTime: 60_000 },
-  );
-  const { data: llmConfigsData } = useLLMConfigs();
-
-  const createRule = useCreateRule();
-  const updateRule = useUpdateRule();
-  const removeRule = useRemoveRule();
   const moveRule = useMoveRule();
 
   const rules = rulesData?.items ?? [];
-  const serverOptions = toOptions((serversData?.items ?? []).map((s) => s.name));
-  const toolOptions = toOptions((toolsData ?? []).map((t) => t.name));
-  const agentOptions = (agentsData?.items ?? []).map((a) => ({
-    value: a.cuid,
-    label: a.name,
-  }));
-  const modelConfigOptions = (modelConfigsData?.items ?? []).map((mc) => ({
-    value: `vm:${mc.cuid}`,
-    label: mc.name,
-  }));
-  const llmConfigOptions = ((llmConfigsData?.items ?? []) as LLMConfig[])
-    .filter((c) => c.enabled)
-    .map((c) => ({ value: `local:${c.id}`, label: c.name }));
-
-  // ai_evaluation is available when either ValidMind is connected OR local LLMs are configured
-  const hasAIEval = isConnected || llmConfigOptions.length > 0;
-  const actionOptions = hasAIEval
-    ? [...BASE_ACTION_OPTIONS, AI_EVAL_OPTION]
-    : BASE_ACTION_OPTIONS;
-
-  // Build grouped options for the single AI evaluation model picker
-  const aiEvalGroups: { label: string; options: SelectOption[] }[] = [];
-  if (isConnected && modelConfigOptions.length > 0) {
-    aiEvalGroups.push({ label: 'ValidMind Models', options: modelConfigOptions });
-  }
-  if (llmConfigOptions.length > 0) {
-    aiEvalGroups.push({ label: 'Local LLMs', options: llmConfigOptions });
-  }
-
-  // Derive the currently selected grouped option value
-  const aiEvalValue: SelectOption | null =
-    form.model_config_cuid
-      ? (modelConfigOptions.find((o) => o.value === `vm:${form.model_config_cuid}`) ?? null)
-      : form.atryum_llm_config_id
-        ? (llmConfigOptions.find((o) => o.value === `local:${form.atryum_llm_config_id}`) ?? null)
-        : null;
+  const isBusy = moveRule.isLoading;
 
   const openForCreate = useCallback(() => {
-    setSelectedId(null);
-    setIsCreating(true);
-    setForm(EMPTY_FORM);
-    setStatusMsg(null);
+    setSelectedRule(null);
     onOpen();
   }, [onOpen]);
 
   const openForEdit = useCallback(
     (rule: Rule) => {
-      setSelectedId(rule.id);
-      setIsCreating(false);
-      setForm(ruleToInput(rule));
-      setStatusMsg(null);
+      setSelectedRule(rule);
       onOpen();
     },
     [onOpen],
   );
-
-  const handleClose = useCallback(() => {
-    setStatusMsg(null);
-    onClose();
-  }, [onClose]);
-
-  const handleSave = useCallback(async () => {
-    try {
-      if (isCreating) {
-        await createRule.mutateAsync(form);
-        handleClose();
-      } else {
-        await updateRule.mutateAsync({ id: selectedId!, input: form });
-        handleClose();
-      }
-    } catch (err: unknown) {
-      setStatusMsg({ text: apiErrorMessage(err, 'Save failed.'), isError: true });
-    }
-  }, [createRule, form, handleClose, isCreating, selectedId, updateRule]);
-
-  const handleDelete = useCallback(async () => {
-    if (!selectedId) return;
-    if (!window.confirm('Delete this rule?')) return;
-    try {
-      await removeRule.mutateAsync(selectedId);
-      handleClose();
-    } catch (err: unknown) {
-      setStatusMsg({ text: apiErrorMessage(err, 'Delete failed.'), isError: true });
-    }
-  }, [handleClose, removeRule, selectedId]);
 
   const handleMove = useCallback(
     async (id: string, direction: 'up' | 'down') => {
@@ -345,22 +208,6 @@ const Rules: React.FC = () => {
     },
     [moveRule],
   );
-
-  const handleServerChange = useCallback(
-    (selected: readonly SelectOption[]) => {
-      const newServers = fromOptions(selected);
-      const validTools = new Set(toolOptions.map((t) => t.value));
-      const filteredTools = form.tool_patterns.filter((t) => validTools.has(t));
-      setForm((f) => ({ ...f, server_patterns: newServers, tool_patterns: filteredTools }));
-    },
-    [form.tool_patterns, toolOptions],
-  );
-
-  const isBusy =
-    createRule.isLoading ||
-    updateRule.isLoading ||
-    removeRule.isLoading ||
-    moveRule.isLoading;
 
   return (
     <Box>
@@ -384,14 +231,20 @@ const Rules: React.FC = () => {
         </Button>
       </HStack>
 
-      <Box borderWidth={1} borderColor="border.base" borderRadius="md" overflow="hidden">
+      <Box
+        borderWidth={1}
+        borderColor="border.base"
+        borderRadius="md"
+        overflow="hidden"
+      >
         {isLoading ? (
           <HStack justify="center" py={10}>
             <Spinner size="sm" color="brand.base" />
           </HStack>
         ) : rules.length === 0 ? (
           <Text p={6} color="text.subtle" fontSize="sm">
-            No rules configured. First match wins — more specific rules should be ordered first.
+            No rules configured. First match wins — more specific rules should be
+            ordered first.
           </Text>
         ) : (
           <Table size="sm" variant="simple">
@@ -424,185 +277,7 @@ const Rules: React.FC = () => {
         )}
       </Box>
 
-      <Modal size="lg" isCentered closeOnEsc closeOnOverlayClick isOpen={isOpen} onClose={handleClose}>
-        <ModalOverlay />
-        <ModalContent>
-          <ModalHeader>{isCreating ? 'New Rule' : 'Edit Rule'}</ModalHeader>
-          <ModalCloseButton />
-
-          <ModalBody>
-            <VStack align="stretch" gap={4}>
-              {statusMsg && (
-                <Alert status={statusMsg.isError ? 'error' : 'success'} borderRadius="md" py={2}>
-                  <AlertIcon />
-                  <AlertDescription fontSize="sm">{statusMsg.text}</AlertDescription>
-                </Alert>
-              )}
-
-              <FormControl isRequired>
-                <FormLabel fontSize="sm">Action</FormLabel>
-                <Select
-                  size="sm"
-                  options={actionOptions}
-                  value={actionOptions.find((o) => o.value === form.action) ?? null}
-                  onChange={(opt) => {
-                    if (!opt) return;
-                    setForm((f) => ({
-                      ...f,
-                      action: opt.value as RuleAction,
-                      model_config_cuid: opt.value !== 'ai_evaluation' ? '' : f.model_config_cuid,
-                      atryum_llm_config_id: opt.value !== 'ai_evaluation' ? '' : f.atryum_llm_config_id,
-                    }));
-                  }}
-                  classNamePrefix="chakra-react-select"
-                />
-              </FormControl>
-
-              {form.action === 'ai_evaluation' && (
-                aiEvalGroups.length > 0 ? (
-                  <FormControl isRequired>
-                    <FormLabel fontSize="sm">Evaluation Model</FormLabel>
-                    <Select
-                      size="sm"
-                      options={aiEvalGroups}
-                      value={aiEvalValue}
-                      onChange={(opt) => {
-                        if (!opt) {
-                          setForm((f) => ({ ...f, model_config_cuid: '', atryum_llm_config_id: '' }));
-                          return;
-                        }
-                        if (opt.value.startsWith('vm:')) {
-                          setForm((f) => ({ ...f, model_config_cuid: opt.value.slice(3), atryum_llm_config_id: '' }));
-                        } else {
-                          setForm((f) => ({ ...f, atryum_llm_config_id: opt.value.slice(6), model_config_cuid: '' }));
-                        }
-                      }}
-                      placeholder="Select a model…"
-                      isClearable
-                      classNamePrefix="chakra-react-select"
-                    />
-                    <FormHelperText fontSize="xs">
-                      Choose a ValidMind model configuration or a locally-configured LLM.
-                    </FormHelperText>
-                  </FormControl>
-                ) : (
-                  <Alert status="warning" borderRadius="md" py={2}>
-                    <AlertIcon />
-                    <AlertDescription fontSize="xs">
-                      No evaluation models available. Connect to ValidMind or add a local LLM in Settings.
-                    </AlertDescription>
-                  </Alert>
-                )
-              )}
-
-              <FormControl>
-                <FormLabel fontSize="sm">Agents</FormLabel>
-                <Select
-                  isMulti
-                  size="sm"
-                  placeholder="All agents"
-                  options={agentOptions}
-                  value={agentOptions.filter((o) => (form.agent_cuids ?? []).includes(o.value))}
-                  onChange={(selected) =>
-                    setForm((f) => ({ ...f, agent_cuids: selected.map((o) => o.value) }))
-                  }
-                  classNamePrefix="chakra-react-select"
-                />
-                <FormHelperText fontSize="xs">
-                  Restrict this rule to specific agents. Leave empty to apply to all.
-                </FormHelperText>
-              </FormControl>
-
-              <FormControl>
-                <FormLabel fontSize="sm">Servers / Sources</FormLabel>
-                <CreatableSelect
-                  isMulti
-                  size="sm"
-                  placeholder="All servers"
-                  options={serverOptions}
-                  value={toOptions(form.server_patterns)}
-                  onChange={handleServerChange}
-                  formatCreateLabel={formatCreateLabel}
-                  classNamePrefix="chakra-react-select"
-                />
-                <FormHelperText fontSize="xs">
-                  Pick an MCP server or type a coding harness source name. Leave empty to match all.
-                </FormHelperText>
-              </FormControl>
-
-              <FormControl>
-                <FormLabel fontSize="sm">Tools</FormLabel>
-                <CreatableSelect
-                  isMulti
-                  size="sm"
-                  placeholder={
-                    form.server_patterns.length === 0
-                      ? 'Select servers first or type a tool name'
-                      : toolsFetching
-                        ? 'Loading tools…'
-                        : 'All tools'
-                  }
-                  isLoading={toolsFetching}
-                  options={toolOptions}
-                  value={toOptions(form.tool_patterns)}
-                  onChange={(selected) =>
-                    setForm((f) => ({ ...f, tool_patterns: fromOptions(selected) }))
-                  }
-                  formatCreateLabel={formatCreateLabel}
-                  classNamePrefix="chakra-react-select"
-                />
-                <FormHelperText fontSize="xs">
-                  Pick from discovered tools or type a tool name. Leave empty to match all.
-                </FormHelperText>
-              </FormControl>
-
-              <FormControl>
-                <FormLabel fontSize="sm">Description (optional)</FormLabel>
-                <Input
-                  size="sm"
-                  placeholder="e.g. Allow all read-only tools"
-                  value={form.description ?? ''}
-                  onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
-                />
-              </FormControl>
-
-              <Checkbox
-                isChecked={form.enabled}
-                onChange={(e) => setForm((f) => ({ ...f, enabled: e.target.checked }))}
-              >
-                <Text fontSize="sm">Enabled</Text>
-              </Checkbox>
-            </VStack>
-          </ModalBody>
-
-          <ModalFooter gap={2}>
-            {!isCreating && (
-              <Button
-                variant="outlineDanger"
-                size="sm"
-                isLoading={removeRule.isLoading}
-                isDisabled={isBusy}
-                onClick={handleDelete}
-                mr="auto"
-              >
-                Delete
-              </Button>
-            )}
-            <Button variant="ghost" size="sm" isDisabled={isBusy} onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button
-              variant="primary"
-              size="sm"
-              isLoading={createRule.isLoading || updateRule.isLoading}
-              isDisabled={isBusy}
-              onClick={handleSave}
-            >
-              {isCreating ? 'Create Rule' : 'Save'}
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+      <CreateRuleModal isOpen={isOpen} onClose={onClose} rule={selectedRule} />
     </Box>
   );
 };

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -215,14 +215,18 @@ function buildAuditFromEvents(
     const rule = ruleId ? (rules.find((r) => r.id === ruleId) ?? null) : null;
     const ruleName =
       rule?.description ?? (ruleId ? `Rule ${ruleId}` : null);
-    const isAIEval = d.action === 'ai_evaluation';
+    const isAIEval = d.action === 'ai_evaluation' && !!ruleId;
     const confidence = d.confidence;
+    const aiReason =
+      d.action === 'ai_evaluation' && d.reason
+        ? extractAIReason(d.reason)
+        : undefined;
 
     const steps: AuditStep[] = [];
 
     if (d.skipped) {
       steps.push({
-        text: 'Skipped this rule as per charter',
+        text: aiReason ?? 'Skipped this rule as per charter',
         variant: 'info',
         timestamp: evt.timestamp,
       });
@@ -232,6 +236,7 @@ function buildAuditFromEvents(
         inv,
         actor,
         isAIEval,
+        aiReason,
       );
       steps.push(
         ...resolved.map((step) => ({
@@ -277,14 +282,37 @@ function buildAuditFromApproval(
   return [{ ruleName, ruleId, isAIEvaluation: isAIEval, confidence, steps }];
 }
 
+function extractAIReason(raw: string): string {
+  const exact: Record<string, string> = {
+    'ai_evaluation: all matching rules deferred; falling back to human_approval':
+      'All matching rules deferred — falling back to human approval',
+  };
+  if (exact[raw]) return exact[raw];
+
+  const prefixes = [
+    'ai_evaluation requires human approval: ',
+    'ai_evaluation approved: ',
+    'ai_evaluation denied: ',
+    'ai_evaluation deferred to next rule: ',
+  ];
+  for (const prefix of prefixes) {
+    if (raw.startsWith(prefix)) return raw.slice(prefix.length);
+  }
+  return raw;
+}
+
 function resolveDecisionSteps(
   disposition: string,
   inv: InvocationAuditInput,
   actor?: string,
   isAIEval?: boolean,
+  aiReason?: string,
 ): AuditStep[] {
   const approvalStatus = inv.approval?.status ?? null;
   const reason = inv.approval?.reason ?? '';
+  const deferReason =
+    aiReason ??
+    (isAIEval && reason ? extractAIReason(reason) : undefined);
 
   if (disposition === 'auto' || disposition === 'auto_approved') {
     const byAI = isAIEval ?? reason.startsWith('ai_evaluation');
@@ -311,12 +339,14 @@ function resolveDecisionSteps(
     disposition === 'ai_escalated_approved' ||
     disposition === 'ai_escalated_denied'
   ) {
+    const escalatedDeferText =
+      deferReason ?? 'Deferring to human approval as per charter';
     if (
       approvalStatus === 'ai_escalated_approved' ||
       approvalStatus === 'approved'
     ) {
       return [
-        { text: 'Deferring to human approval as per charter', variant: 'defer' },
+        { text: escalatedDeferText, variant: 'defer' },
         { text: 'Invocation approved by human', variant: 'approve', actor },
       ];
     }
@@ -325,12 +355,12 @@ function resolveDecisionSteps(
       approvalStatus === 'denied'
     ) {
       return [
-        { text: 'Deferring to human approval as per charter', variant: 'defer' },
+        { text: escalatedDeferText, variant: 'defer' },
         { text: 'Invocation denied by human', variant: 'deny', actor },
       ];
     }
     return [
-      { text: 'Deferring to human approval as per charter', variant: 'defer' },
+      { text: escalatedDeferText, variant: 'defer' },
       ...undecidedSteps(inv),
     ];
   }
@@ -338,9 +368,7 @@ function resolveDecisionSteps(
     const deferText =
       disposition === 'workflow'
         ? 'Deferring to approval workflow'
-        : isAIEval
-          ? 'Deferring to human approval as per charter'
-          : 'Human approval required as per rule';
+        : deferReason ?? 'Human approval required as per rule';
     if (
       approvalStatus === 'approved' ||
       approvalStatus === 'ai_escalated_approved'

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -214,7 +214,7 @@ function buildAuditFromEvents(
     const ruleId = d.rule_id ?? null;
     const rule = ruleId ? (rules.find((r) => r.id === ruleId) ?? null) : null;
     const ruleName =
-      rule?.description ?? (ruleId ? `Rule ${ruleId}` : null);
+      rule?.description ?? (ruleId ? '*Deleted Rule*' : null);
     const isAIEval = d.action === 'ai_evaluation' && !!ruleId;
     const confidence = d.confidence;
     const aiReason =
@@ -237,6 +237,7 @@ function buildAuditFromEvents(
         actor,
         isAIEval,
         aiReason,
+        !ruleId && !isAIEval,
       );
       steps.push(
         ...resolved.map((step) => ({
@@ -259,7 +260,6 @@ function buildAuditFromApproval(
 ): AuditEntry[] {
   const ruleId = inv.matched_rule_id ?? null;
   const rule = ruleId ? (rules.find((r) => r.id === ruleId) ?? null) : null;
-  const ruleName = rule?.description ?? (ruleId ? `Rule ${ruleId}` : null);
 
   const approvalStatus = inv.approval?.status ?? null;
   const reason = inv.approval?.reason ?? '';
@@ -272,11 +272,27 @@ function buildAuditFromApproval(
     approvalStatus === 'ai_escalated_approved' ||
     approvalStatus === 'ai_escalated_denied';
 
+  // When matched_rule_id is absent but the reason indicates a specific rule was
+  // AI-evaluated (not the all-deferred fallback), the rule likely existed and
+  // was since deleted. Distinguish that from a genuine no-match fallback.
+  const isAIAllDeferred = reason.startsWith(
+    'ai_evaluation: all matching rules deferred',
+  );
+  const ruleName =
+    rule?.description ??
+    (ruleId
+      ? '*Deleted Rule*'
+      : isAIEval && !isAIAllDeferred
+        ? '*Deleted Rule*'
+        : null);
+
   const steps = resolveDecisionSteps(
     approvalStatus ?? '',
     inv,
     actor ?? undefined,
     isAIEval,
+    undefined,
+    !ruleId && !isAIEval,
   );
 
   return [{ ruleName, ruleId, isAIEvaluation: isAIEval, confidence, steps }];
@@ -307,6 +323,7 @@ function resolveDecisionSteps(
   actor?: string,
   isAIEval?: boolean,
   aiReason?: string,
+  isServerDefault?: boolean,
 ): AuditStep[] {
   const approvalStatus = inv.approval?.status ?? null;
   const reason = inv.approval?.reason ?? '';
@@ -320,7 +337,9 @@ function resolveDecisionSteps(
       {
         text: byAI
           ? 'Invocation approved by AI'
-          : 'Invocation approved by rule',
+          : isServerDefault
+            ? 'Invocation approved by server default'
+            : 'Invocation approved by rule',
         variant: 'approve',
       },
     ];
@@ -329,7 +348,11 @@ function resolveDecisionSteps(
     const byAI = isAIEval ?? reason.startsWith('ai_evaluation');
     return [
       {
-        text: byAI ? 'Invocation denied by AI' : 'Invocation denied by rule',
+        text: byAI
+          ? 'Invocation denied by AI'
+          : isServerDefault
+            ? 'Invocation denied by server default'
+            : 'Invocation denied by rule',
         variant: 'deny',
       },
     ];


### PR DESCRIPTION
## What and why?

A collection of fixes and UX improvements to the Agent Authority invocations and rules experience.

---

### 1. Show AI evaluation reasons in audit display

Instead of a generic "Deferring to human approval as per charter" label, the audit trail now shows the actual LLM-generated reason from the AI evaluation (e.g. the specific charter clause or rule that caused deferral or approval).

### 2. Fix invocation audit display for no-match and deleted rules

- Invocations with no matched rule now show **\*No rule matched\*** (previously blank or inconsistent)
- Invocations matched to a rule that has since been deleted show **\*Deleted Rule\*** instead of "No rule matched"
- "Invocation approved/denied by AI" vs "by rule" vs "by server default" now correctly differentiated
- AI Evaluation badge hidden for server-default fallback events

### 3. Fix SSE updates not refreshing the invocation list

After pagination was added, the SSE stream was writing to a cache key without an `offset`, so updates were invisible to the paginated view. Fixed by switching to `invalidateQueries` so the active page always refetches.

### 4. Refactor rule creation UX: pre-filled modal for always approve/deny

Replaces the implicit "always approve / always deny" behaviour — which silently created an overly-broad rule matching every server, tool, and agent — with a pre-filled **Create Rule** modal that lets the user review and narrow the scope before saving.

- `CreateRuleModal` extracted from `Rules.tsx` → `ui/src/components/CreateRuleModal.tsx`
- "Always approve" / "Always deny" open the modal pre-filled with `auto_approve` / `auto_deny` + the invocation's server, tool, and agent
- "Create Rule From This" replaced with the same `CreateRuleModal`
- Rule description auto-generated from action + server + tool (e.g. "Auto-approve filesystem/read_file")
- Rules cache invalidated on every SSE event so newly created rules resolve immediately without a hard reload

## How to test

1. Trigger an invocation evaluated by AI — audit trail should show the actual LLM reason, not a generic string
2. Trigger an invocation with no matching rule — should show "*No rule matched*" with no badge
3. Delete a rule, then view an invocation that previously matched it — should show "*Deleted Rule*"
4. On the Invocations page, click "Always approve" → modal opens pre-filled with server/tool/agent and a generated description; adjust and save → rule appears in Rules list immediately
5. Repeat with "Always deny"
6. Create a rule while on the Invocations page, trigger a matching invocation — audit display should show the rule name without a hard reload

## What needs special review?

- The inline "Customize rule scope" UI and old inline Create Rule modal are fully removed
- Rules cache is now invalidated on every SSE tick — may cause extra network requests at high invocation volume

## Dependencies, breaking changes, and deployment notes

Companion PR in `validmind/frontend`: https://github.com/validmind/frontend/pull/2724

## Release notes

Invocation audit trails now show AI evaluation reasons and correctly distinguish deleted rules from unmatched ones. The "Always approve / Always deny" actions now open a pre-filled rule editor instead of silently creating broad rules.

## Checklist
- [x] What and why
- [ ] Screenshots or videos
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] Tested locally