### PR TITLE
Curated release notes and worktree-isolated release builds

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: release-notes
+description: Draft the CHANGELOG.md section for an upcoming atryum release. Use before running `just release <tag>` — release-push publishes the matching CHANGELOG section as the curated top half of the GitHub release notes. Optionally takes the intended tag (e.g. v0.3.0) as an argument.
+---
+
+# Release notes
+
+## Why this exists
+
+`just release <tag>` prepends the CHANGELOG.md section matching the tag to
+GitHub's auto-generated release notes (`--generate-notes` supplies the PR
+list, contributor credits, and compare link; the changelog section supplies
+the human-readable story). If no matching section exists, the release still
+goes out with generated notes only — so the changelog is the part that takes
+judgment, and it's this skill's job.
+
+## What good notes look like
+
+The audience is someone **operating or upgrading atryum**, not someone who
+watched the commits land. They want to know what changed in behavior, what
+they must do before or after upgrading, and whether anything is
+security-relevant. Branch names, internal refactor jargon, and commit
+shorthand don't communicate that — describe the effect, not the diff.
+
+Follow [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/):
+group entries under `Added` / `Changed` / `Deprecated` / `Removed` /
+`Fixed` / `Security`, omitting empty groups. The `Security` section
+deserves particular care in this project — auth gating, judge hardening,
+trust boundaries, and anything an operator would want to prioritize an
+upgrade for belongs there, even if the commit called it a "fix" or "feat".
+
+## How to build the section
+
+1. Find the previous release tag (`git tag --sort=-creatordate`, ignore
+   backup/scratch tags) and review everything since:
+   `git log <prev>..HEAD`. PR titles alone hide detail — a single PR here
+   can carry a dozen meaningful commits, so read the commit subjects (and
+   bodies where the subject is vague) before summarizing.
+2. Decide or confirm the version. Semver from the reader's perspective:
+   behavior-visible features → minor, only fixes → patch, breaking
+   config/API/CLI changes → call them out explicitly and bump accordingly.
+3. Update `CHANGELOG.md`:
+   - New heading `## [x.y.z] - YYYY-MM-DD` (today's date, no `v` prefix —
+     release-push strips the `v` from the tag when matching).
+   - Fold in anything sitting under `[Unreleased]`, leaving that section
+     present but empty.
+   - Keep the compare links at the bottom of the file in sync.
+4. Sanity-check the release path: `just release <tag>` builds from a
+   pristine worktree of the tag (at `../atryum-release-<tag>`) and reads
+   the notes from the tag's own `CHANGELOG.md` — so the order is commit
+   the changelog, tag, push the tag, then release. Anything not committed
+   and tagged simply isn't in the release, notes included.
+
+Show the drafted section to the user before they tag — the changelog is a
+judgment call about emphasis, and they may know context the log doesn't
+show (a feature that's half-shipped, a fix that shouldn't be advertised).

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ internal/api/web/atryum-logo.svg
 internal/api/web/atryum-logo-favicon.svg
 internal/api/web/atryum-notification-icon.svg
 internal/api/web/atryum-agent-icons/
+
+# claude code local state
+.claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0] - 2026-07-14
+
+### Added
+
+- Invocation Audit section in the FOSS UI, with audit event instrumentation
+  showing AI evaluation reasons, failed states, and clear handling of
+  no-match and deleted-rule cases.
+- Grounding eval suite for the LLM-as-judge, runnable against any
+  OpenAI-compatible endpoint.
+- Session context for the judge, reconstructed from Atryum-tracked tool
+  calls, with trust fencing, a byte cap, and expiry.
+- Pagination for the Invocations list UI.
+- Auto-sync of agent charters from ValidMind, with stale-record
+  reconciliation on every sync.
+- `insert_before` support: rules created from "Always approve/deny" insert
+  at the top of the rule list and immediately apply their disposition to the
+  triggering invocation.
+- `rule_evaluated` audit events for human-fallback dispositions, keyed by
+  rule ID.
+
+### Changed
+
+- Rule creation from "Always approve/deny" now opens a pre-filled modal
+  instead of a bare form.
+- Shared agent hooks moved to the session model.
+- Charter sync uses a JOIN instead of a subquery when listing ValidMind
+  CUIDs with bindings.
+- Token harness refreshed.
+
+### Fixed
+
+- SSE updates no longer fail to refresh the invocation list after
+  pagination.
+- Rule-creation success callback branches on the saved rule's action rather
+  than the original menu item.
+- Disposition check matches what Atryum actually emits (`human`, not
+  `human_approval`); human disposition copy corrected for direct
+  human-approval rules.
+- MCP server endpoints reject spaces.
+- `ADD COLUMN` store migrations are idempotent.
+- Charter sync guards `DeleteSyncedStaleForOrg` against an empty org CUID.
+
+### Security
+
+- External session routes are gated behind authentication, and
+  `RecordExecution` enforces session ownership.
+- Empty agent bindings are rejected on session mint and use.
+- Judge session context is trust-fenced, byte-capped, and expiring;
+  tool-use caches are bounded.
+
+## [0.1.0] - 2026-06-30
+
+## [0.0.4] - 2026-06-14
+
+## [0.0.3] - 2026-06-05
+
+[Unreleased]: https://github.com/validmind/atryum/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/validmind/atryum/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/validmind/atryum/compare/v0.0.4...v0.1.0
+[0.0.4]: https://github.com/validmind/atryum/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/validmind/atryum/releases/tag/v0.0.3

--- a/Justfile
+++ b/Justfile
@@ -137,8 +137,8 @@ release tag:
         just release-build "{{tag}}"
         just release-push "{{tag}}"
 
-# Build release artifacts into releases/<tag>/
-release-build tag: third-party-notices build-ui
+# Build release artifacts into releases/<tag>/ from a pristine worktree of the tag
+release-build tag:
         #!/usr/bin/env bash
         set -euo pipefail
 
@@ -147,36 +147,40 @@ release-build tag: third-party-notices build-ui
           exit 1
         fi
 
+        if ! git rev-parse -q --verify "refs/tags/{{tag}}" >/dev/null; then
+          echo "Tag {{tag}} does not exist. Commit the release (including CHANGELOG.md), then: git tag {{tag}}"
+          exit 1
+        fi
+
         repo_dir="$(pwd)"
         release_dir="$repo_dir/{{release_dir}}/{{tag}}"
+        worktree_dir="$repo_dir/../atryum-release-{{tag}}"
+
+        # Build from a clean checkout of the tag: only tracked, tagged content
+        # can reach the artifacts, and the artifacts always match the tag.
+        if [ -e "$worktree_dir" ]; then
+          git worktree remove --force "$worktree_dir" 2>/dev/null || rm -rf "$worktree_dir"
+        fi
+        git worktree add --detach "$worktree_dir" "{{tag}}"
+        trap 'git worktree remove --force "$worktree_dir"' EXIT
+
+        (cd "$worktree_dir" && just third-party-notices build-ui)
+
         rm -rf "$release_dir"
         mkdir -p "$release_dir"
-        cp LICENSE NOTICE "$release_dir/"
-        cp "{{license_dir}}/third-party/THIRD_PARTY_NOTICES" "$release_dir/"
-        cp -R "{{license_dir}}/third-party/licenses" "$release_dir/third_party_licenses"
-        cp "{{license_dir}}/third-party/go-licenses.csv" "$release_dir/"
-        cp "{{license_dir}}/third-party/npm-production-licenses.json" "$release_dir/"
-        cp "{{license_dir}}/third-party/npm-production-license-files.tsv" "$release_dir/"
+        cp "$worktree_dir/LICENSE" "$worktree_dir/NOTICE" "$release_dir/"
+        cp "$worktree_dir/{{license_dir}}/third-party/THIRD_PARTY_NOTICES" "$release_dir/"
+        cp -R "$worktree_dir/{{license_dir}}/third-party/licenses" "$release_dir/third_party_licenses"
+        cp "$worktree_dir/{{license_dir}}/third-party/go-licenses.csv" "$release_dir/"
+        cp "$worktree_dir/{{license_dir}}/third-party/npm-production-licenses.json" "$release_dir/"
+        cp "$worktree_dir/{{license_dir}}/third-party/npm-production-license-files.tsv" "$release_dir/"
 
         build_target() {
           local goos="$1"
           local goarch="$2"
           local out="atryum-${goos}-${goarch}"
 
-          tmp_dir="$(mktemp -d)"
-          trap 'rm -rf "$tmp_dir"' RETURN
-
-          mkdir -p "$tmp_dir/atryum"
-          rsync -a --delete \
-            --exclude .git \
-            --exclude /atryum \
-            --exclude /atryum.db \
-            --exclude /{{release_dir}} \
-            --exclude /ui/node_modules \
-            --exclude /ui/dist \
-            "$repo_dir/" "$tmp_dir/atryum/"
-
-          (cd "$tmp_dir/atryum" && GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -tags release_notices -o "$release_dir/$out" ./cmd/atryum)
+          (cd "$worktree_dir" && GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -tags release_notices -o "$release_dir/$out" ./cmd/atryum)
         }
 
         # Build targets
@@ -204,10 +208,40 @@ release-push tag:
           exit 1
         fi
 
+        # The GitHub release tag must exist on origin and match the local tag,
+        # or the published release would point at a different commit than the
+        # artifacts were built from.
+        local_sha="$(git rev-parse "refs/tags/{{tag}}")"
+        remote_sha="$(git ls-remote origin "refs/tags/{{tag}}" | cut -f1)"
+        if [ -z "$remote_sha" ]; then
+          echo "Tag {{tag}} is not on origin. Push it first: git push origin {{tag}}"
+          exit 1
+        fi
+        if [ "$remote_sha" != "$local_sha" ]; then
+          echo "Tag {{tag}} differs between local ($local_sha) and origin ($remote_sha). Reconcile before releasing."
+          exit 1
+        fi
+
+        # Curated notes: the CHANGELOG.md section for this version as of the
+        # tagged commit, if present. gh prepends --notes-file content to the
+        # --generate-notes PR list.
+        version="{{tag}}"
+        version="${version#v}"
+        notes_file="$(mktemp)"
+        trap 'rm -f "$notes_file"' EXIT
+        git show "{{tag}}:CHANGELOG.md" 2>/dev/null | awk -v ver="$version" '
+          $0 ~ "^## \\[" ver "\\]" {found=1; next}
+          found && /^## \[/ {exit}
+          found {print}
+        ' > "$notes_file" || true
+
         # Create or upload to release
         if gh release view "{{tag}}" >/dev/null 2>&1; then
           gh release upload "{{tag}}" "${artifacts[@]}" --clobber
+        elif [ -s "$notes_file" ]; then
+          gh release create "{{tag}}" "${artifacts[@]}" --title "{{tag}}" --notes-file "$notes_file" --generate-notes
         else
+          echo "No CHANGELOG.md section found for {{tag}}; falling back to generated notes only."
           gh release create "{{tag}}" "${artifacts[@]}" --generate-notes
         fi
 


### PR DESCRIPTION
## What this does

`just release <tag>` now publishes human-readable release notes and builds artifacts from a pristine checkout of the tag, so nothing uncommitted can reach a release.

### CHANGELOG.md
Adds a [Keep a Changelog 1.0.0](https://keepachangelog.com/en/1.0.0/) changelog with a curated `[0.2.0]` section covering everything since v0.1.0 (invocation audit UI, judge grounding evals + session-context hardening, invocations pagination, ValidMind charter auto-sync, rule-creation UX fixes), including a `Security` section for the auth-gating and trust-fencing work. Earlier tags get dated headings and compare links.

### Justfile
- `release-build` requires the tag to exist, checks it out into a detached worktree at `../atryum-release-<tag>`, runs `third-party-notices` and `build-ui` there, and compiles all four targets from the worktree into the main repo's `releases/<tag>/`. The worktree is removed on exit (including failure), and a leftover from a previous failed run is cleared on the next attempt. This replaces the per-target rsync-to-tmpdir copies of the working tree — which also copied gitignored files like `atryum.toml` and `.envrc` into the build tree; a worktree contains only tracked, tagged content, and artifacts are guaranteed to match the tag rather than whatever HEAD happens to be.
- `release-push` verifies the tag exists on origin at the same SHA as local before creating the release (otherwise `gh release create` would mint a release tag pointing at a different commit than the artifacts were built from). It then extracts the CHANGELOG section for the version from the *tagged* commit (`git show <tag>:CHANGELOG.md`, leading `v` stripped) and passes it via `--notes-file` together with `--generate-notes` — gh prepends the curated section above the auto-generated PR list and compare link. No matching section → warn and fall back to generated notes only, so a missing changelog never blocks a release.

The release flow is therefore: commit the changelog → `git tag <tag>` → `git push origin <tag>` → `just release <tag>`.

### /release-notes skill
Project skill (`.claude/skills/release-notes/SKILL.md`) for drafting each release's changelog section: audience is operators upgrading atryum, security-relevant changes get called out, and the draft is shown to the user before tagging.

### .gitignore
Ignores `.claude/settings.local.json` and `.claude/scheduled_tasks.lock` (session-local files).

## Verification
Ran `just release-build` end-to-end with a throwaway tag on this branch (in a scratch clone): worktree created from the tag, licenses + UI built inside it, all four binaries produced in `releases/<tag>/` alongside LICENSE/NOTICE/THIRD_PARTY_NOTICES and license reports (arch-checked via `file`; linux-amd64 binary runs). Worktree cleanup confirmed on both success and failure paths. Also verified the missing-tag error path and that the awk extraction pulls exactly the `[0.2.0]` section, stopping at the next version heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)