### PR TITLE
Build releases from a local clone of the tag, not a worktree

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -46,10 +46,10 @@ upgrade for belongs there, even if the commit called it a "fix" or "feat".
      present but empty.
    - Keep the compare links at the bottom of the file in sync.
 4. Sanity-check the release path: `just release <tag>` builds from a
-   pristine worktree of the tag (at `../atryum-release-<tag>`) and reads
-   the notes from the tag's own `CHANGELOG.md` — so the order is commit
-   the changelog, tag, push the tag, then release. Anything not committed
-   and tagged simply isn't in the release, notes included.
+   pristine local clone of the tag (at `../atryum-release-<tag>`) and
+   reads the notes from the tag's own `CHANGELOG.md` — so the order is
+   commit the changelog, tag, push the tag, then release. Anything not
+   committed and tagged simply isn't in the release, notes included.
 
 Show the drafted section to the user before they tag — the changelog is a
 judgment call about emphasis, and they may know context the log doesn't

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   triggering invocation.
 - `rule_evaluated` audit events for human-fallback dispositions, keyed by
   rule ID.
+- Release builds run from a pristine clone of the release tag, with the
+  tag's commit stamped into the binaries as VCS provenance, and GitHub
+  release notes are drawn from this changelog.
 
 ### Changed
 

--- a/Justfile
+++ b/Justfile
@@ -154,33 +154,34 @@ release-build tag:
 
         repo_dir="$(pwd)"
         release_dir="$repo_dir/{{release_dir}}/{{tag}}"
-        worktree_dir="$repo_dir/../atryum-release-{{tag}}"
+        build_dir="$repo_dir/../atryum-release-{{tag}}"
 
-        # Build from a clean checkout of the tag: only tracked, tagged content
-        # can reach the artifacts, and the artifacts always match the tag.
-        if [ -e "$worktree_dir" ]; then
-          git worktree remove --force "$worktree_dir" 2>/dev/null || rm -rf "$worktree_dir"
-        fi
-        git worktree add --detach "$worktree_dir" "{{tag}}"
-        trap 'git worktree remove --force "$worktree_dir"' EXIT
+        # Build from a pristine local clone of the tag: only tracked, tagged
+        # content can reach the artifacts, and go stamps the tag's commit into
+        # the binaries as VCS provenance. A clone, not a worktree — go's repo
+        # detection needs a .git directory; a worktree's .git file makes it
+        # walk up and stamp (or choke on) whatever repo encloses the parent.
+        rm -rf "$build_dir"
+        git clone --quiet --branch "{{tag}}" "$repo_dir" "$build_dir"
+        trap 'rm -rf "$build_dir"' EXIT
 
-        (cd "$worktree_dir" && just third-party-notices build-ui)
+        (cd "$build_dir" && just third-party-notices build-ui)
 
         rm -rf "$release_dir"
         mkdir -p "$release_dir"
-        cp "$worktree_dir/LICENSE" "$worktree_dir/NOTICE" "$release_dir/"
-        cp "$worktree_dir/{{license_dir}}/third-party/THIRD_PARTY_NOTICES" "$release_dir/"
-        cp -R "$worktree_dir/{{license_dir}}/third-party/licenses" "$release_dir/third_party_licenses"
-        cp "$worktree_dir/{{license_dir}}/third-party/go-licenses.csv" "$release_dir/"
-        cp "$worktree_dir/{{license_dir}}/third-party/npm-production-licenses.json" "$release_dir/"
-        cp "$worktree_dir/{{license_dir}}/third-party/npm-production-license-files.tsv" "$release_dir/"
+        cp "$build_dir/LICENSE" "$build_dir/NOTICE" "$release_dir/"
+        cp "$build_dir/{{license_dir}}/third-party/THIRD_PARTY_NOTICES" "$release_dir/"
+        cp -R "$build_dir/{{license_dir}}/third-party/licenses" "$release_dir/third_party_licenses"
+        cp "$build_dir/{{license_dir}}/third-party/go-licenses.csv" "$release_dir/"
+        cp "$build_dir/{{license_dir}}/third-party/npm-production-licenses.json" "$release_dir/"
+        cp "$build_dir/{{license_dir}}/third-party/npm-production-license-files.tsv" "$release_dir/"
 
         build_target() {
           local goos="$1"
           local goarch="$2"
           local out="atryum-${goos}-${goarch}"
 
-          (cd "$worktree_dir" && GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -tags release_notices -o "$release_dir/$out" ./cmd/atryum)
+          (cd "$build_dir" && GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -trimpath -tags release_notices -o "$release_dir/$out" ./cmd/atryum)
         }
 
         # Build targets
@@ -188,6 +189,16 @@ release-build tag:
         build_target darwin arm64
         build_target linux amd64
         build_target linux arm64
+
+        # The stamp is the release's provenance: fail if the binaries don't
+        # carry the tag's commit. vcs.modified is not asserted — build-ui may
+        # regenerate tracked UI files in the clone before compiling.
+        tag_commit="$(git rev-parse "{{tag}}^{commit}")"
+        if ! go version -m "$release_dir/atryum-linux-amd64" | grep -q "vcs.revision=$tag_commit"; then
+          echo "Release binary VCS stamp does not match tag {{tag}} ($tag_commit):"
+          go version -m "$release_dir/atryum-linux-amd64" | grep vcs || true
+          exit 1
+        fi
 
 # Create or update a GitHub release from releases/<tag>/
 release-push tag:


### PR DESCRIPTION
## What this does

Fixes `just release` failing with `error obtaining VCS status: exit status 128` during the go builds, and makes release binaries carry verifiable provenance.

### Why

Go's `-buildvcs` repo detection only recognizes a `.git` **directory**. A linked worktree's `.git` is a **file**, so go walks past it and uses whatever repository happens to enclose the parent directory — or none. Depending on the environment, the release build would fail outright, stamp the wrong repository's state into the binaries, or silently skip VCS stamping. In no case did binaries get the tag's revision.

### Fix

- `release-build` clones the tag (`git clone --branch <tag>` from the local repo — hardlinked, so cheap) into `../atryum-release-<tag>` instead of `git worktree add`. A clone has a real `.git` directory, so go stamps the tag's commit as `vcs.revision`. All pristine-source properties of the worktree approach are retained; cleanup is a `rm -rf` trap.
- After building, the recipe asserts the binary's `vcs.revision` equals the tag's commit, so a wrong or missing stamp fails the release instead of passing silently.
- Builds use `-trimpath`, making artifacts independent of the build path.
- CHANGELOG 0.2.0 section and the /release-notes skill updated to match.

With this, `go version -m <released binary> | grep vcs` answers "was this release built from exactly the tagged source?"

## Verification

Ran `just release-build v0.2.0` end-to-end: all four binaries built, stamped with the tag's commit and `vcs.modified=false`, provenance assertion passed, build dir cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)