### PR TITLE
Central version injected at release time, exposed via `atryum version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release builds run from a pristine clone of the release tag, with the
   tag's commit stamped into the binaries as VCS provenance, and GitHub
   release notes are drawn from this changelog.
+- `atryum version` command (also `--version`). Release builds report the
+  release tag and VCS revision; the same version is announced in MCP
+  handshake metadata (`serverInfo`/`clientInfo`) instead of a hardcoded
+  `0.1.0`.
 
 ### Changed
 

--- a/Justfile
+++ b/Justfile
@@ -200,6 +200,17 @@ release-build tag:
           exit 1
         fi
 
+        # Run the host-platform binary and check it self-reports the tag —
+        # -ldflags -X silently no-ops if the version symbol is ever renamed.
+        host_bin="$release_dir/atryum-$(go env GOHOSTOS)-$(go env GOHOSTARCH)"
+        if [ -x "$host_bin" ]; then
+          reported="$("$host_bin" version 2>&1 || true)"
+          if [[ "$reported" != "{{tag}} "* && "$reported" != "{{tag}}" ]]; then
+            echo "Release binary reports version \"$reported\", expected \"{{tag}}\". Check the -ldflags -X path against internal/version."
+            exit 1
+          fi
+        fi
+
 # Create or update a GitHub release from releases/<tag>/
 release-push tag:
         #!/usr/bin/env bash

--- a/Justfile
+++ b/Justfile
@@ -181,7 +181,7 @@ release-build tag:
           local goarch="$2"
           local out="atryum-${goos}-${goarch}"
 
-          (cd "$build_dir" && GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -trimpath -tags release_notices -o "$release_dir/$out" ./cmd/atryum)
+          (cd "$build_dir" && GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -trimpath -tags release_notices -ldflags "-X atryum/internal/version.Version={{tag}}" -o "$release_dir/$out" ./cmd/atryum)
         }
 
         # Build targets

--- a/cmd/atryum/commands.go
+++ b/cmd/atryum/commands.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"atryum/internal/version"
 	"bufio"
 	"encoding/json"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 )
@@ -24,6 +26,7 @@ Commands:
 	  setup      First-time setup flows (demo, mcp, validmind).
   hooks      Install or uninstall agent hooks.
   licenses   Print bundled third-party license notices.
+  version    Print the atryum version.
   help       Show this help.
 
 	Examples:
@@ -37,6 +40,35 @@ Commands:
 	  atryum hooks install amp
 	  atryum hooks install pi
 	  atryum licenses`)
+}
+
+// versionString is the injected release version, annotated with the VCS
+// revision go stamped into the binary when one is present.
+func versionString() string {
+	v := version.Version
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return v
+	}
+	var rev, modified string
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.modified":
+			modified = s.Value
+		}
+	}
+	if rev == "" {
+		return v
+	}
+	if len(rev) > 12 {
+		rev = rev[:12]
+	}
+	if modified == "true" {
+		rev += ", modified"
+	}
+	return fmt.Sprintf("%s (%s)", v, rev)
 }
 
 func runUsage() string {

--- a/cmd/atryum/main.go
+++ b/cmd/atryum/main.go
@@ -48,6 +48,8 @@ func main() {
 		err = runHooks(os.Args[2:])
 	case "licenses":
 		err = runLicenses()
+	case "version", "--version", "-v":
+		fmt.Println(versionString())
 	default:
 		err = fmt.Errorf("unknown command %q\n%s", os.Args[1], globalUsage())
 	}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -31,6 +31,7 @@ import (
 	"atryum/internal/mcp"
 	authprovider "atryum/internal/mcp/auth_provider"
 	"atryum/internal/store"
+	"atryum/internal/version"
 )
 
 //go:embed web/*
@@ -1184,7 +1185,7 @@ func (h *Handler) handleMCPProxy(w http.ResponseWriter, r *http.Request, server 
 			"protocolVersion": protocolVersion,
 			"serverInfo": map[string]any{
 				"name":    "atryum",
-				"version": "0.1.0",
+				"version": version.Version,
 			},
 			"capabilities": map[string]any{
 				"tools": map[string]any{},

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"atryum/internal/config"
+	"atryum/internal/version"
 )
 
 type UpstreamMode string
@@ -893,7 +894,7 @@ func (c *Client) initializeHTTPSession(ctx context.Context, upstream Upstream, p
 		Method:  "initialize",
 		Params: mustRawJSON(map[string]any{
 			"protocolVersion": protocolVersion,
-			"clientInfo":      map[string]any{"name": "atryum", "version": "0.1.0"},
+			"clientInfo":      map[string]any{"name": "atryum", "version": version.Version},
 			"capabilities":    map[string]any{},
 		}),
 	})
@@ -1001,7 +1002,7 @@ func (c *Client) invokeStdio(ctx context.Context, upstream Upstream, tool string
 	reader := bufio.NewReader(stdout)
 	if err := writeRPC(stdin, c.nextRPCID(), "initialize", map[string]any{
 		"protocolVersion": DefaultMCPProtocolVersion,
-		"clientInfo":      map[string]any{"name": "atryum", "version": "0.1.0"},
+		"clientInfo":      map[string]any{"name": "atryum", "version": version.Version},
 		"capabilities":    map[string]any{},
 	}); err != nil {
 		return InvokeResult{}, err
@@ -1062,7 +1063,7 @@ func (c *Client) listToolsStdio(ctx context.Context, upstream Upstream) ([]Tool,
 	reader := bufio.NewReader(stdout)
 	if err := writeRPC(stdin, c.nextRPCID(), "initialize", map[string]any{
 		"protocolVersion": DefaultMCPProtocolVersion,
-		"clientInfo":      map[string]any{"name": "atryum", "version": "0.1.0"},
+		"clientInfo":      map[string]any{"name": "atryum", "version": version.Version},
 		"capabilities":    map[string]any{},
 	}); err != nil {
 		return nil, err
@@ -1272,7 +1273,7 @@ func (c *Client) testStdio(ctx context.Context, upstream Upstream) ConnectionTes
 	reader := bufio.NewReader(stdout)
 	if err := writeRPC(stdin, c.nextRPCID(), "initialize", map[string]any{
 		"protocolVersion": DefaultMCPProtocolVersion,
-		"clientInfo":      map[string]any{"name": "atryum", "version": "0.1.0"},
+		"clientInfo":      map[string]any{"name": "atryum", "version": version.Version},
 		"capabilities":    map[string]any{},
 	}); err != nil {
 		message := err.Error()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,6 @@
+// Package version holds the atryum build version.
+package version
+
+// Version is "dev" for local builds. Release builds inject the release tag
+// via -ldflags "-X atryum/internal/version.Version=<tag>".
+var Version = "dev"

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "atryum-ui",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "atryum-ui",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "dependencies": {
         "@chakra-ui/react": "^2.10.4",
         "@emotion/react": "^11.14.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atryum-ui",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What this does

Gives atryum a single source of truth for its version instead of `0.1.0` hardcoded in six places (which had drifted — every binary since v0.0.x has claimed `0.1.0`).

- `internal/version.Version` defaults to `"dev"`; `release-build` injects the release tag via `-ldflags "-X atryum/internal/version.Version=<tag>"`, so releases self-version and nothing needs bumping by hand.
- MCP handshake metadata reports it: `serverInfo.version` (what connecting MCP clients see) and all four `clientInfo.version` sites (what upstream MCP servers see).
- New `atryum version` command (also `--version`/`-v`), which prints the version alongside the VCS revision go stamps into the binary: `dev (d09346abf30e, modified)` for a local build, `v0.2.0 (<tag commit>)` for a release.
- `release-build` asserts the freshly built host-platform binary self-reports the tag — `-ldflags -X` silently no-ops if the version symbol is ever renamed, and this turns that into a loud release failure instead of binaries quietly shipping as `dev`.
- `ui/package.json` and `package-lock.json` pinned to `0.0.0` — nothing consumes the npm version, and an out-of-sync lock file would let `npm install` dirty the pristine release clone and flip the binaries' `vcs.modified` stamp to `true`.

## Verification

`go build ./...` and tests for the touched packages pass. Exercised both build flavors: a dev build prints `dev (<revision>, modified)`; a full `just release-build` from a pristine clone with a throwaway tag produced binaries reporting `<tag> (<revision>)` with `vcs.modified=false`, and the self-report assertion passed. Negative case verified too: building a tag whose source predates `internal/version` fails the release as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)