### PR TITLE
Fixed a security issue where an external executor could mark a tool i…

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -3622,8 +3623,13 @@ func (h *Handler) externalInvocationDetail(w http.ResponseWriter, r *http.Reques
 		resp, err := h.svc.RecordExecution(r.Context(), id, update)
 		if err != nil {
 			status := http.StatusBadRequest
-			if err == sql.ErrNoRows {
+			switch {
+			case err == sql.ErrNoRows:
 				status = http.StatusNotFound
+			case errors.Is(err, invocation.ErrNotOwner):
+				status = http.StatusForbidden
+			case errors.Is(err, invocation.ErrInvalidTransition):
+				status = http.StatusConflict
 			}
 			writeError(w, status, err.Error())
 			return

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -1543,3 +1543,36 @@ func TestInvocationsByVMCUID(t *testing.T) {
 		}
 	})
 }
+
+func TestExternalInvocationPatchErrorStatusMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"invalid transition maps to 409", fmt.Errorf("invocation inv_1 cannot move to completed from pending_approval: %w", invocation.ErrInvalidTransition), http.StatusConflict},
+		{"not owner maps to 403", fmt.Errorf("invocation inv_1: %w", invocation.ErrNotOwner), http.StatusForbidden},
+		{"missing invocation maps to 404", sql.ErrNoRows, http.StatusNotFound},
+		{"generic error maps to 400", fmt.Errorf("boom"), http.StatusBadRequest},
+		{"success maps to 200", nil, http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &stubService{invErr: tc.err}
+			h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
+			req := httptest.NewRequest(http.MethodPatch, "/api/v1/external/invocations/inv_1", strings.NewReader(`{"execution_status":"completed"}`))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			h.Routes().ServeHTTP(w, req)
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body=%s)", w.Code, tc.wantStatus, w.Body.String())
+			}
+			if svc.recordID != "inv_1" {
+				t.Fatalf("RecordExecution called with id %q, want inv_1", svc.recordID)
+			}
+			if svc.recordReq == nil || svc.recordReq.ExecutionStatus != "completed" {
+				t.Fatalf("RecordExecution update = %+v", svc.recordReq)
+			}
+		})
+	}
+}

--- a/internal/invocation/record_execution_test.go
+++ b/internal/invocation/record_execution_test.go
@@ -1,0 +1,326 @@
+package invocation_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"atryum/internal/auth"
+	"atryum/internal/invocation"
+	"atryum/internal/store"
+
+	_ "modernc.org/sqlite"
+)
+
+// newRecordExecutionService builds a service wired to a fresh in-memory DB
+// with no rules, resolver, or upstream client — external Submit/RecordExecution
+// flows don't need them.
+func newRecordExecutionService(t *testing.T) *invocation.Service {
+	t.Helper()
+	db := newSQLiteTestDB(t)
+	return invocation.NewService(store.NewInvocationRepo(db), store.NewEventRepo(db), nil, nil, nil, 5*time.Second, nil, nil, nil, nil)
+}
+
+// submitExternal creates an external invocation (which lands in
+// pending_approval since no rules are configured) and returns its ID.
+func submitExternal(t *testing.T, svc *invocation.Service, agentID string) string {
+	t.Helper()
+	resp, err := svc.Submit(context.Background(), invocation.ExternalSubmitRequest{
+		Source:  "amp",
+		Tool:    "bash",
+		Input:   map[string]any{"cmd": "ls"},
+		AgentID: agentID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusPendingApproval {
+		t.Fatalf("submit status = %q, want pending_approval", resp.Status)
+	}
+	return resp.InvocationID
+}
+
+func getInvocation(t *testing.T, svc *invocation.Service, id string) invocation.InvocationResponse {
+	t.Helper()
+	resp, err := svc.Get(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func countEvents(t *testing.T, svc *invocation.Service, id string, eventType string) int {
+	t.Helper()
+	events, err := svc.Events(context.Background(), id, invocation.EventListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, evt := range events.Items {
+		if evt.Type == eventType {
+			n++
+		}
+	}
+	return n
+}
+
+func TestRecordExecutionRejectsUnapprovedInvocation(t *testing.T) {
+	for _, execStatus := range []string{"running", "completed", "failed"} {
+		t.Run(execStatus, func(t *testing.T) {
+			svc := newRecordExecutionService(t)
+			id := submitExternal(t, svc, "")
+
+			_, err := svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{
+				ExecutionStatus: execStatus,
+				Result:          json.RawMessage(`{"forged":true}`),
+			})
+			if !errors.Is(err, invocation.ErrInvalidTransition) {
+				t.Fatalf("err = %v, want ErrInvalidTransition", err)
+			}
+
+			got := getInvocation(t, svc, id)
+			if got.Status != invocation.StatusPendingApproval {
+				t.Fatalf("status = %q, want pending_approval to be preserved", got.Status)
+			}
+			if len(got.Result) != 0 {
+				t.Fatalf("result = %s, want no result recorded", got.Result)
+			}
+			if n := countEvents(t, svc, id, "invocation.succeeded"); n != 0 {
+				t.Fatalf("invocation.succeeded events = %d, want 0", n)
+			}
+			if n := countEvents(t, svc, id, "invocation.failed"); n != 0 {
+				t.Fatalf("invocation.failed events = %d, want 0", n)
+			}
+		})
+	}
+}
+
+func TestRecordExecutionRejectsOverwritingHumanDenial(t *testing.T) {
+	svc := newRecordExecutionService(t)
+	id := submitExternal(t, svc, "")
+	if err := svc.Deny(context.Background(), id, "not on my watch", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, execStatus := range []string{"running", "completed", "failed", "cancelled"} {
+		_, err := svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{
+			ExecutionStatus: execStatus,
+			Result:          json.RawMessage(`{"forged":true}`),
+		})
+		if !errors.Is(err, invocation.ErrInvalidTransition) {
+			t.Fatalf("%s after denial: err = %v, want ErrInvalidTransition", execStatus, err)
+		}
+	}
+
+	got := getInvocation(t, svc, id)
+	if got.Status != invocation.StatusDenied {
+		t.Fatalf("status = %q, want denied to be preserved", got.Status)
+	}
+}
+
+func TestRecordExecutionApprovedLifecycle(t *testing.T) {
+	svc := newRecordExecutionService(t)
+	id := submitExternal(t, svc, "")
+	if err := svc.Approve(context.Background(), id, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{ExecutionStatus: "running"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusExecuting {
+		t.Fatalf("status after running = %q, want executing", resp.Status)
+	}
+
+	resp, err = svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{
+		ExecutionStatus: "completed",
+		Result:          json.RawMessage(`{"output":"ok"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusSucceeded {
+		t.Fatalf("status after completed = %q, want succeeded", resp.Status)
+	}
+	if resp.CompletedAt == nil {
+		t.Fatal("completed_at not set")
+	}
+	if string(resp.Result) != `{"output":"ok"}` {
+		t.Fatalf("result = %s", resp.Result)
+	}
+	if n := countEvents(t, svc, id, "invocation.succeeded"); n != 1 {
+		t.Fatalf("invocation.succeeded events = %d, want 1", n)
+	}
+}
+
+func TestRecordExecutionTerminalStatusesAllowedFromApproved(t *testing.T) {
+	// Executors may skip the "running" step and report the outcome directly
+	// from approved.
+	cases := []struct {
+		execStatus string
+		want       invocation.Status
+	}{
+		{"completed", invocation.StatusSucceeded},
+		{"failed", invocation.StatusFailed},
+		{"cancelled", invocation.StatusCancelled},
+	}
+	for _, tc := range cases {
+		t.Run(tc.execStatus, func(t *testing.T) {
+			svc := newRecordExecutionService(t)
+			id := submitExternal(t, svc, "")
+			if err := svc.Approve(context.Background(), id, ""); err != nil {
+				t.Fatal(err)
+			}
+			resp, err := svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{ExecutionStatus: tc.execStatus})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.Status != tc.want {
+				t.Fatalf("status = %q, want %q", resp.Status, tc.want)
+			}
+		})
+	}
+}
+
+func TestRecordExecutionCancelledAllowedFromPendingApproval(t *testing.T) {
+	// Abandoning a call that never got approved is legitimate — it only makes
+	// the record more conservative.
+	svc := newRecordExecutionService(t)
+	id := submitExternal(t, svc, "")
+
+	resp, err := svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{
+		ExecutionStatus: "cancelled",
+		Message:         "user aborted the agent run",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusCancelled {
+		t.Fatalf("status = %q, want cancelled", resp.Status)
+	}
+	if n := countEvents(t, svc, id, "invocation.cancelled"); n != 1 {
+		t.Fatalf("invocation.cancelled events = %d, want 1", n)
+	}
+}
+
+func TestRecordExecutionTerminalRetryIsIdempotent(t *testing.T) {
+	svc := newRecordExecutionService(t)
+	id := submitExternal(t, svc, "")
+	if err := svc.Approve(context.Background(), id, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{
+		ExecutionStatus: "completed",
+		Result:          json.RawMessage(`{"attempt":1}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Status != invocation.StatusSucceeded {
+		t.Fatalf("status = %q, want succeeded", first.Status)
+	}
+
+	// A retry of the same terminal status succeeds but must not overwrite the
+	// recorded outcome or emit a second event.
+	retry, err := svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{
+		ExecutionStatus: "completed",
+		Result:          json.RawMessage(`{"attempt":2}`),
+	})
+	if err != nil {
+		t.Fatalf("idempotent retry: %v", err)
+	}
+	if string(retry.Result) != `{"attempt":1}` {
+		t.Fatalf("retry result = %s, want first outcome preserved", retry.Result)
+	}
+	if n := countEvents(t, svc, id, "invocation.succeeded"); n != 1 {
+		t.Fatalf("invocation.succeeded events = %d, want 1", n)
+	}
+}
+
+func TestRecordExecutionRejectsTerminalOverwrite(t *testing.T) {
+	svc := newRecordExecutionService(t)
+	id := submitExternal(t, svc, "")
+	if err := svc.Approve(context.Background(), id, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{ExecutionStatus: "completed"}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, execStatus := range []string{"running", "failed", "cancelled"} {
+		_, err := svc.RecordExecution(context.Background(), id, invocation.ExternalExecutionUpdate{ExecutionStatus: execStatus})
+		if !errors.Is(err, invocation.ErrInvalidTransition) {
+			t.Fatalf("%s after succeeded: err = %v, want ErrInvalidTransition", execStatus, err)
+		}
+	}
+	if got := getInvocation(t, svc, id); got.Status != invocation.StatusSucceeded {
+		t.Fatalf("status = %q, want succeeded to be preserved", got.Status)
+	}
+}
+
+func TestRecordExecutionEnforcesAgentOwnership(t *testing.T) {
+	newApproved := func(t *testing.T, svc *invocation.Service, agentID string) string {
+		t.Helper()
+		id := submitExternal(t, svc, agentID)
+		if err := svc.Approve(context.Background(), id, ""); err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+	update := invocation.ExternalExecutionUpdate{ExecutionStatus: "completed"}
+
+	t.Run("different agent is rejected", func(t *testing.T) {
+		svc := newRecordExecutionService(t)
+		id := newApproved(t, svc, "agent-a")
+		ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-b"})
+		_, err := svc.RecordExecution(ctx, id, update)
+		if !errors.Is(err, invocation.ErrNotOwner) {
+			t.Fatalf("err = %v, want ErrNotOwner", err)
+		}
+		if got := getInvocation(t, svc, id); got.Status != invocation.StatusApproved {
+			t.Fatalf("status = %q, want approved to be preserved", got.Status)
+		}
+	})
+
+	t.Run("owning agent is allowed", func(t *testing.T) {
+		svc := newRecordExecutionService(t)
+		id := newApproved(t, svc, "agent-a")
+		ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-a"})
+		resp, err := svc.RecordExecution(ctx, id, update)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != invocation.StatusSucceeded {
+			t.Fatalf("status = %q, want succeeded", resp.Status)
+		}
+	})
+
+	t.Run("server-internal caller without identity is exempt", func(t *testing.T) {
+		svc := newRecordExecutionService(t)
+		id := newApproved(t, svc, "agent-a")
+		resp, err := svc.RecordExecution(context.Background(), id, update)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != invocation.StatusSucceeded {
+			t.Fatalf("status = %q, want succeeded", resp.Status)
+		}
+	})
+
+	t.Run("anonymous invocation accepts any identity", func(t *testing.T) {
+		svc := newRecordExecutionService(t)
+		id := newApproved(t, svc, "")
+		ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-b"})
+		resp, err := svc.RecordExecution(ctx, id, update)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.Status != invocation.StatusSucceeded {
+			t.Fatalf("status = %q, want succeeded", resp.Status)
+		}
+	})
+}

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -1453,10 +1453,37 @@ func (s *Service) summarizePendingApproval(invocationID string) {
 	}()
 }
 
+// ErrInvalidTransition is returned by RecordExecution when the reported
+// execution status is not reachable from the invocation's current status —
+// e.g. an executor claiming "completed" while the invocation is still
+// pending_approval, or after a human denied it.
+var ErrInvalidTransition = errors.New("invalid execution status transition")
+
+// ErrNotOwner is returned by RecordExecution when the verified agent identity
+// on the request does not match the agent the invocation belongs to.
+var ErrNotOwner = errors.New("invocation belongs to a different agent")
+
+// requireStatus rejects an execution-status transition unless the invocation
+// is currently in one of the allowed states.
+func requireStatus(inv Invocation, target string, allowed ...Status) error {
+	for _, status := range allowed {
+		if inv.Status == status {
+			return nil
+		}
+	}
+	return fmt.Errorf("invocation %s cannot move to %s from %s: %w", inv.InvocationID, target, inv.Status, ErrInvalidTransition)
+}
+
 // RecordExecution updates an externally-executed invocation with the outcome
 // reported by the executor. Valid execStatus values:
 //
 //	running | completed | failed | cancelled
+//
+// Transitions are guarded: an outcome may only be recorded once the invocation
+// has been approved (or, for cancelled, while it is still awaiting approval —
+// abandoning a pending call is always safe). Reporting the same terminal
+// status twice is an idempotent no-op so executors can retry safely; the
+// first recorded outcome wins and is never overwritten.
 func (s *Service) RecordExecution(ctx context.Context, invocationID string, update ExternalExecutionUpdate) (InvocationResponse, error) {
 	inv, err := s.invocations.Get(ctx, invocationID)
 	if err != nil {
@@ -1465,28 +1492,29 @@ func (s *Service) RecordExecution(ctx context.Context, invocationID string, upda
 	// Ownership: update.Result/Error are surfaced to the judge as trusted
 	// evidence, so a caller who knows another agent's invocation_id could
 	// poison that agent's session context. The PATCH
-	// /api/v1/external/invocations/{id} route now runs under the agent-runtime
+	// /api/v1/external/invocations/{id} route runs under the agent-runtime
 	// OAuth middleware, so in auth mode ctx carries the authenticated caller.
 	// When an identity is present, reject any attempt to write an invocation
 	// this agent does not own (inv.AgentID is set from the authenticated
-	// identity at Submit time, so a match proves ownership). In no-auth mode
-	// there is no identity to check against — behavior is unchanged, and the
-	// in-process managed-agents watcher (which calls RecordExecution directly
-	// with no auth identity) is likewise unaffected.
+	// identity at Submit time, so a match proves ownership). Invocations
+	// submitted anonymously (no agent_id) skip the ownership check. In no-auth
+	// mode there is no identity to check against — behavior is unchanged, and
+	// the in-process managed-agents watcher (which calls RecordExecution
+	// directly with no auth identity) is likewise unaffected.
 	if callerID := strings.TrimSpace(auth.AgentIDFromContext(ctx)); callerID != "" {
 		owner := ""
 		if inv.AgentID != nil {
 			owner = strings.TrimSpace(*inv.AgentID)
 		}
-		if owner != callerID {
-			return InvocationResponse{}, fmt.Errorf("invocation does not belong to this agent")
+		if owner != "" && owner != callerID {
+			return InvocationResponse{}, fmt.Errorf("invocation %s: %w", invocationID, ErrNotOwner)
 		}
 	}
 	now := time.Now().UTC()
 	switch update.ExecutionStatus {
 	case "running":
-		if inv.Status != StatusApproved && inv.Status != StatusExecuting {
-			return InvocationResponse{}, fmt.Errorf("invocation %s cannot move to running from %s", invocationID, inv.Status)
+		if err := requireStatus(inv, "running", StatusApproved, StatusExecuting); err != nil {
+			return InvocationResponse{}, err
 		}
 		inv.Status = StatusExecuting
 		if err := s.invocations.UpdateResult(ctx, inv); err != nil {
@@ -1494,6 +1522,12 @@ func (s *Service) RecordExecution(ctx context.Context, invocationID string, upda
 		}
 		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.executing", Payload: mustJSON(map[string]any{"upstream": inv.Upstream, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "external": true}), CreatedAt: now})
 	case "completed":
+		if inv.Status == StatusSucceeded {
+			return s.toResponse(inv), nil // idempotent retry
+		}
+		if err := requireStatus(inv, "completed", StatusApproved, StatusExecuting); err != nil {
+			return InvocationResponse{}, err
+		}
 		inv.Status = StatusSucceeded
 		inv.CompletedAt = &now
 		if len(update.Result) > 0 {
@@ -1504,6 +1538,12 @@ func (s *Service) RecordExecution(ctx context.Context, invocationID string, upda
 		}
 		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.succeeded", Payload: mustJSON(map[string]any{"upstream": inv.Upstream, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "body": json.RawMessage(nullableRaw(inv.Response)), "external": true}), CreatedAt: now})
 	case "failed":
+		if inv.Status == StatusFailed {
+			return s.toResponse(inv), nil // idempotent retry
+		}
+		if err := requireStatus(inv, "failed", StatusApproved, StatusExecuting); err != nil {
+			return InvocationResponse{}, err
+		}
 		inv.Status = StatusFailed
 		inv.CompletedAt = &now
 		if len(update.Error) > 0 {
@@ -1518,6 +1558,14 @@ func (s *Service) RecordExecution(ctx context.Context, invocationID string, upda
 		}
 		_ = s.events.Create(ctx, Event{InvocationID: inv.InvocationID, EventType: "invocation.failed", Payload: mustJSON(map[string]any{"upstream": inv.Upstream, "input": json.RawMessage(inv.Input), "arguments": json.RawMessage(inv.Input), "body": json.RawMessage(inv.Error), "external": true}), CreatedAt: now})
 	case "cancelled":
+		if inv.Status == StatusCancelled {
+			return s.toResponse(inv), nil // idempotent retry
+		}
+		// pending_approval is allowed here: an executor abandoning a call
+		// that never got approved makes the record strictly more conservative.
+		if err := requireStatus(inv, "cancelled", StatusApproved, StatusExecuting, StatusPendingApproval); err != nil {
+			return InvocationResponse{}, err
+		}
 		inv.Status = StatusCancelled
 		inv.CompletedAt = &now
 		if len(update.Error) > 0 {

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -727,11 +728,15 @@ func TestRecordExecutionRejectsMismatchedAuthenticatedCaller(t *testing.T) {
 	attacker := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "attacker"})
 	if _, err := service.RecordExecution(attacker, inv.InvocationID, invocation.ExternalExecutionUpdate{
 		ExecutionStatus: "completed", Result: json.RawMessage(`{"stdout":"pwned"}`),
-	}); err == nil || !strings.Contains(err.Error(), "does not belong") {
-		t.Fatalf("expected ownership rejection, got %v", err)
+	}); err == nil || !errors.Is(err, invocation.ErrNotOwner) {
+		t.Fatalf("expected ErrNotOwner, got %v", err)
 	}
 
-	// The owning agent succeeds.
+	if err := service.Approve(context.Background(), inv.InvocationID, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// The owning agent succeeds once the invocation is approved.
 	if _, err := service.RecordExecution(owner, inv.InvocationID, invocation.ExternalExecutionUpdate{
 		ExecutionStatus: "completed", Result: json.RawMessage(`{"stdout":"file.txt"}`),
 	}); err != nil {
@@ -746,10 +751,13 @@ func TestRecordExecutionRejectsMismatchedAuthenticatedCaller(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := service.Approve(context.Background(), noauth.InvocationID, ""); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := service.RecordExecution(context.Background(), noauth.InvocationID, invocation.ExternalExecutionUpdate{
 		ExecutionStatus: "completed", Result: json.RawMessage(`{"stdout":"ok"}`),
 	}); err != nil {
-		t.Fatalf("no-auth RecordExecution should be unchanged: %v", err)
+		t.Fatalf("no-auth RecordExecution should succeed after approval: %v", err)
 	}
 }
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

**Security fix:** the external invocation status endpoint (`PATCH /api/v1/external/invocations/{id}`) allowed an agent to bypass human approval — the core control this product provides.

**Background for context:** external executors (e.g. a coding-harness plugin) submit a tool call, which is parked in `pending_approval`. The executor is supposed to poll until a human approves, run the tool itself, then report the outcome back via the PATCH endpoint (`Service.RecordExecution`).

**How this fix fits the three agent entry paths:**

```mermaid
flowchart TB
    subgraph paths [Three agent entry paths]
        P1["Path 1: Decision-only hook<br/>Submit + RecordExecution<br/>(this PR)"]
        P2["Path 2: MCP proxy / Invoke<br/>Atryum executes upstream"]
        P3["Path 3: Managed Agents bridge<br/>watcher calls Submit + RecordExecution"]
    end

    subgraph shared [Shared core]
        Rules[approval_rules + rule engine]
        Inv[(invocations + invocation_events)]
    end

    P1 --> Rules
    P2 --> Rules
    P3 --> Rules
    Rules --> Inv

    Fix["RecordExecution guards<br/>409 invalid transition<br/>403 wrong agent<br/>idempotent terminal retry"]
    P1 --> Fix
    P3 --> Fix

    style Fix fill:#efe,stroke:#3a3
    style P1 fill:#eef,stroke:#36c
```

**Before this change:** only the `running` branch of `RecordExecution` checked the invocation's current status. The `completed`, `failed`, and `cancelled` branches overwrote the status unconditionally. That meant a caller could:

1. Submit a tool call → it lands in `pending_approval`.
2. Immediately PATCH `{"execution_status": "completed", "result": {...}}`.
3. The invocation jumps straight to `succeeded` with a fabricated result and a normal-looking `invocation.succeeded` audit event — no human ever approved it. Even a **human-denied** invocation could be flipped to `succeeded`, and terminal states could be overwritten later.

```mermaid
sequenceDiagram
    participant Executor as External executor
    participant API as PATCH /external/invocations/{id}
    participant Svc as RecordExecution
    participant DB as Invocation store

    Executor->>API: POST submit tool call
    API->>DB: status = pending_approval
    API-->>Executor: 200 pending_approval

    Note over Executor,DB: Before fix — no approval required

    Executor->>API: PATCH execution_status=completed<br/>result={forged}
    API->>Svc: RecordExecution
    Note over Svc: Only "running" checked status,<br/>completed/failed/cancelled<br/>overwrote unconditionally
    Svc->>DB: status = succeeded + forged result
    Svc->>DB: event invocation.succeeded
    API-->>Executor: 200 succeeded

    Note over Executor,DB: Audit trail looks legitimate,<br/>human approval was never involved
```

**After this change**, `RecordExecution` is a guarded state machine:

| Reported status | Allowed only from |
|---|---|
| `running` | `approved`, `executing` *(unchanged)* |
| `completed` | `approved`, `executing` |
| `failed` | `approved`, `executing` |
| `cancelled` | `approved`, `executing`, `pending_approval`¹ |

¹ Cancelling a still-pending call is allowed because abandoning an unapproved call only makes the record *more* conservative — it can never fake an approval.

```mermaid
stateDiagram-v2
    direction LR

    [*] --> pending_approval: Submit

    pending_approval --> approved: Human approves
    pending_approval --> denied: Human denies
    pending_approval --> cancelled: PATCH cancelled¹

    approved --> executing: PATCH running
    approved --> succeeded: PATCH completed
    approved --> failed: PATCH failed
    approved --> cancelled: PATCH cancelled

    executing --> succeeded: PATCH completed
    executing --> failed: PATCH failed
    executing --> cancelled: PATCH cancelled

    note right of pending_approval
        ¹ cancel from pending_approval is allowed,
        all other PATCH outcomes require approval first
    end note

    note right of denied
        Terminal — PATCH blocked (409)
    end note

    note right of succeeded
        Terminal — idempotent retry only,
        no overwrite (409 on other statuses)
    end note
```

**Intended happy path** (unchanged for well-behaved executors):

```mermaid
sequenceDiagram
    participant Executor as External executor
    participant API as Atryum API
    participant Human as Human approver
    participant DB as Invocation store

    Executor->>API: POST submit tool call
    API->>DB: pending_approval
    API-->>Executor: invocation_id

    loop Poll until approved
        Executor->>API: GET /external/invocations/{id}
        API-->>Executor: pending_approval
    end

    Human->>API: Approve in UI
    API->>DB: approved

    Executor->>API: GET /external/invocations/{id}
    API-->>Executor: approved

    Executor->>Executor: Run tool locally
    Executor->>API: PATCH running
    API->>DB: executing

    Executor->>API: PATCH completed + result
    API->>DB: succeeded + invocation.succeeded event
    API-->>Executor: 200 succeeded
```

**`RecordExecution` decision flow** (after fix):

```mermaid
flowchart TD
    A[PATCH execution_status] --> B{Invocation exists?}
    B -->|no| N404[404 Not Found]
    B -->|yes| C{Caller identity present<br/>and invocation has agent_id?}
    C -->|mismatch| N403[403 ErrNotOwner]
    C -->|ok or exempt| D{Reported status}

    D -->|running| E{From approved or executing?}
    D -->|completed| F{Already succeeded?}
    D -->|failed| G{Already failed?}
    D -->|cancelled| H{Already cancelled?}

    F -->|yes| OK[200 idempotent no-op]
    G -->|yes| OK
    H -->|yes| OK

    F -->|no| I{From approved or executing?}
    G -->|no| I
    H -->|no| J{From approved, executing,<br/>or pending_approval?}

    E -->|no| N409[409 ErrInvalidTransition]
    I -->|no| N409
    J -->|no| N409

    E -->|yes| W[Write executing + event]
    I -->|yes| W2[Write terminal outcome + event]
    J -->|yes| W2

    W --> OK
    W2 --> OK
```

Plus two related hardening fixes in the same function:

- **Ownership check** — if the request carries a verified OAuth agent identity, it must match the invocation's `agent_id` (new `ErrNotOwner`, HTTP **403**). Previously any authenticated agent could PATCH *any* invocation, including other agents'. Server-internal callers (the managed-agents watcher) run without an identity on the context and are exempt, and anonymously-submitted invocations are unaffected — so existing legitimate flows keep working.
- **Idempotent retries** — re-reporting the same terminal status (e.g. the executor retries a `completed` PATCH after a network blip) is now a safe no-op: the first recorded outcome wins, nothing is overwritten, and no duplicate audit event is emitted. This also fixes a latent bug where replayed managed-agents tool results double-wrote the outcome and emitted a second `invocation.succeeded` event.

Invalid transitions return the new sentinel `ErrInvalidTransition`, mapped to HTTP **409 Conflict** at the API layer (was 400 with no guard at all).

**Files changed:**
- `internal/invocation/service.go` — guards, ownership check, idempotency, sentinel errors
- `internal/api/handlers.go` — `errors.Is` mapping to 409/403
- `internal/invocation/record_execution_test.go` — new service-level tests
- `internal/api/handlers_test.go` — HTTP status-mapping test

## How to test

Automated (all green, including `-race`):

```bash
go test ./...
go test -race ./internal/invocation/ ./internal/api/ ./internal/managedagents/
```

Manual repro of the original attack (run the server locally):

```bash
# 1. Submit an external tool call — response shows status "pending_approval"
curl -s -X POST localhost:PORT/api/v1/external/invocations \
  -d '{"source":"amp","tool":"bash","input":{"cmd":"ls"}}'

# 2. Try to skip approval (use the invocation_id from step 1)
curl -s -X PATCH localhost:PORT/api/v1/external/invocations/<invocation_id> \
  -d '{"execution_status":"completed","result":{"forged":true}}'
```

Before this PR: step 2 returns 200 and the invocation shows `succeeded`.
After this PR: step 2 returns **409** with `...cannot move to completed from pending_approval...`, and the invocation stays `pending_approval`.

```mermaid
sequenceDiagram
    participant Executor as External executor
    participant API as PATCH /external/invocations/{id}
    participant Svc as RecordExecution
    participant DB as Invocation store

    Executor->>API: POST submit tool call
    API->>DB: pending_approval
    API-->>Executor: 200 pending_approval

    Executor->>API: PATCH execution_status=completed<br/>result={forged}
    API->>Svc: RecordExecution
    Note over Svc: requireStatus rejects:<br/>completed not allowed from pending_approval
    Svc-->>API: ErrInvalidTransition
    API-->>Executor: 409 Conflict
    Note over DB: Status unchanged — still pending_approval
```

Happy path still works: approve the invocation in the UI (or `POST .../approve`), then repeat the PATCH — it succeeds and records the result.

## What needs special review?

- **The allowed-transition table above** — especially the decision to let `cancelled` be reported from `pending_approval`. I believe it's safe (see footnote), but it's a product-behavior call.
- **Ownership check semantics** (`service.go`, top of `RecordExecution`): it only rejects when *both* a verified caller identity *and* the invocation's `agent_id` are present and differ. Confirm no legitimate flow submits under one identity and reports under another.
- **Managed-agents watcher compatibility** (`internal/managedagents/watcher.go`): it reports outcomes from `approved`/`executing` and runs without a context identity, so it passes both new checks — please sanity-check that reasoning.
- Known gap left **out of scope** (flagged for follow-up ticket): `GET /api/v1/external/invocations/{id}` still has no ownership check, so any authenticated agent can read any invocation's input/context.

## Dependencies, breaking changes, and deployment notes

- No dependent PRs, no DB migrations, no config or env-var changes. Safe to deploy standalone; rolling deploy is fine.
- **Behavioral change to the public PATCH endpoint** (intentional — this was the vulnerability):
  - Reporting `completed`/`failed`/`cancelled` on an unapproved or denied invocation now returns **409** instead of silently succeeding.
  - Reporting on another agent's invocation now returns **403**.
  - A well-behaved executor that polls until approved (the documented contract) is unaffected. Only clients relying on the buggy behavior will see new errors.

## Release notes

Fixed a security issue where an external executor could mark a tool invocation as completed, failed, or cancelled before it was approved — bypassing human approval and forging the audit record. Execution outcomes can now only be reported for approved invocations, executors may only report on their own invocations, and recorded outcomes can no longer be overwritten. Retrying an already-recorded outcome is a safe no-op.

Suggested label: `bug` (arguably also `breaking-change` if we consider the stricter 409/403 responses part of the public API contract).

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend) — N/A, backend only
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [ ] PR linked to Shortcut
- [x] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required) — N/A, no documented API contract change for honest clients
- [ ] Environment variable additions/changes documented (if required) — N/A
