### PR TITLE
Fix: Invoke fails open to the global policy when rule loading fails

### DIFF
--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -347,7 +347,13 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 	var aiConfidence *float64
 	ruleMatched := false
 	if s.rules != nil {
-		if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
+		approvalRules, err := s.rules.ListApprovalRules(ctx)
+		if err != nil {
+			slog.Error("failed to load approval rules; failing closed to human review",
+				"error", err, "server", upstream.Name, "tool", req.Tool)
+			ruleMatched = true
+			decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "rule lookup failed: " + err.Error()}
+		} else {
 			for _, rule := range matchRules(approvalRules, upstream.Name, req.Tool, agentRec.ID) {
 				r := rule
 				ruleMatched = true

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -117,6 +118,73 @@ func TestBusinessToolErrorMarksInvocationFailed(t *testing.T) {
 	}
 	if len(resp.Error) == 0 {
 		t.Fatal("expected error payload")
+	}
+}
+
+// TestInvokeFailsClosedWhenRuleLoadFails verifies that a failure loading
+// approval rules (e.g. a locked SQLite connection) is not treated as "no
+// rules matched" and does not fall through to the permissive global policy.
+// It must fail closed, matching Submit's behavior on the same error.
+func TestInvokeFailsClosedWhenRuleLoadFails(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		switch body["method"] {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": body["id"],
+				"result": map[string]any{"serverInfo": map[string]any{"name": "fake", "version": "0.1.0"}, "capabilities": map[string]any{}},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusAccepted)
+		case "tools/call":
+			// Should never be reached: a failed-closed invocation waits for a
+			// human and never executes the tool.
+			t.Error("tool executed despite the rule load failure; should have failed closed")
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": 1, "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer upstream.Close()
+
+	db := newSQLiteTestDB(t)
+	serverRepo := store.NewServerRepo(db)
+	resolver := mcp.NewResolver(serverRepo, config.Config{
+		Upstreams: []config.UpstreamConfig{{Name: "shortcut", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+	})
+	if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	service := invocation.NewService(
+		store.NewInvocationRepo(db),
+		store.NewEventRepo(db),
+		resolver,
+		mcp.NewHTTPClient(),
+		policy.AlwaysApproveProvider{}, // the operator's permissive global fallback
+		5*time.Second,
+		rulesStoreStub{err: errors.New("database is locked")}, // simulates the transient DB hiccup
+		nil, nil, nil,
+	)
+
+	// If Invoke correctly fails closed, it blocks in waitForHumanApproval, so
+	// this goroutine denies the invocation once it shows up pending — proving
+	// it reached human review rather than the permissive global policy. If
+	// Invoke instead falls through to the bug's auto-approve path, Invoke
+	// returns before this goroutine ever finds a pending invocation to act on.
+	go denyNextInvocation(t, service, 50*time.Millisecond)
+
+	resp, err := service.Invoke(context.Background(), invocation.CreateInvocationRequest{
+		Server: "shortcut",
+		Tool:   "dangerous-tool",
+		Input:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusDenied {
+		t.Fatalf("status = %q, want denied (a rule-load failure must fail closed to human review, not fall through to the global policy)", resp.Status)
 	}
 }
 
@@ -1086,10 +1154,11 @@ func (s summarySettingsStub) SummarySettings(context.Context) (string, string) {
 
 type rulesStoreStub struct {
 	rules []invocation.ApprovalRule
+	err   error
 }
 
 func (s rulesStoreStub) ListApprovalRules(context.Context) ([]invocation.ApprovalRule, error) {
-	return s.rules, nil
+	return s.rules, s.err
 }
 
 type agentLookupStub struct {
@@ -1149,6 +1218,25 @@ func approveNextInvocation(t *testing.T, service *invocation.Service, delay time
 	}
 	if err := service.Approve(context.Background(), pending.InvocationID, ""); err != nil {
 		t.Errorf("approve invocation: %v", err)
+	}
+}
+
+func denyNextInvocation(t *testing.T, service *invocation.Service, delay time.Duration) {
+	time.Sleep(delay)
+	list, err := service.List(context.Background(), invocation.InvocationListFilter{Limit: 10})
+	// Return silently when there's nothing pending — this is expected when the
+	// invocation completed (auto-approved) before this goroutine runs, which
+	// is exactly the failure mode this test is checking for. Calling
+	// t.Errorf after the test has completed causes a panic.
+	if err != nil || len(list.Items) == 0 {
+		return
+	}
+	pending := list.Items[0]
+	if pending.Status != invocation.StatusPendingApproval {
+		return
+	}
+	if err := service.Deny(context.Background(), pending.InvocationID, "test: proving fail-closed behavior", ""); err != nil {
+		t.Errorf("deny invocation: %v", err)
 	}
 }
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

**Bug fix:** `Invoke` (the code path that runs when Atryum itself executes a tool call
on an agent's behalf) could silently auto-approve a dangerous tool call if the
database had a brief hiccup while loading approval rules.

**Background for context.** Every tool call goes through a two-step decision check in
`internal/invocation/service.go`:
1. First, check the fine-grained `approval_rules` an operator configured (e.g. "always
   auto-deny `delete_database`").
2. If none of those rules match, fall back to a coarse, global policy an operator can
   set (`always_approve`, `manual_approval`, or `always_deny`).

The bug: step 1's code only had a success path — `if approvalRules, err :=
s.rules.ListApprovalRules(ctx); err == nil { ... }` — with no `else`. If the database
call failed (this app uses a single-connection SQLite, so a brief lock is a realistic,
not exotic, way for this to happen), the code didn't skip to an error handler. It just
skipped the whole block silently, with **no log line anywhere**, and treated the
failure exactly like "the rules loaded fine, and none of them matched this call." That
sent every call straight to step 2 — the coarse global policy — even for a call that
had a specific `auto_deny` rule the code simply couldn't read at that moment.

**Before this fix:**

```mermaid
sequenceDiagram
    autonumber
    participant Operator as Operator
    participant Agent as Agent
    participant Invoke as Service.Invoke
    participant Rules as Database (approval_rules)
    participant Policy as Global policy (e.g. always_approve)

    Operator->>Invoke: Configures an auto_deny rule for a dangerous tool,<br/>and sets the global fallback policy to always_approve
    Agent->>Invoke: Calls the dangerous tool
    Invoke->>Rules: Load approval rules
    Rules-->>Invoke: Error (database briefly locked)
    rect rgb(120, 30, 30)
    Note over Invoke: BUG: the code only checked for the success case.<br/>On error it silently moved on, with no log line,<br/>as if zero rules had matched.
    end
    Invoke->>Policy: No rule matched, so ask the global policy
    Policy-->>Invoke: Auto-approve (that's what the operator set it to)
    Invoke-->>Agent: Approved — the dangerous tool runs
    Note over Operator,Invoke: Nothing is logged anywhere to explain<br/>why the auto_deny rule never fired
```

**After this fix:**

```mermaid
sequenceDiagram
    autonumber
    participant Operator as Operator
    participant Agent as Agent
    participant Invoke as Service.Invoke
    participant Rules as Database (approval_rules)
    participant Policy as Global policy (e.g. always_approve)

    Operator->>Invoke: Configures an auto_deny rule for a dangerous tool,<br/>and sets the global fallback policy to always_approve
    Agent->>Invoke: Calls the dangerous tool
    Invoke->>Rules: Load approval rules
    Rules-->>Invoke: Error (database briefly locked)
    rect rgb(30, 90, 30)
    Note over Invoke: FIXED: the error is now logged, and the code treats<br/>it as "we could not check the rules" instead of<br/>"no rules matched"
    end
    Invoke--xPolicy: Global policy is deliberately not consulted
    Invoke-->>Agent: Sent to human review (pending_approval)
    Note over Operator,Invoke: A log line now records exactly<br/>why this happened
```

The fix makes `Invoke` match the behavior of its sibling function, `Submit` (used when
an external harness runs the tool itself and only asks Atryum for a decision) —
`Submit` already "fails closed" on the same kind of error, since it has no fallback to
a global policy at all. `Invoke` was the odd one out.

**The code change**, in plain terms: split "load the rules" into two explicit
outcomes — success (unchanged behavior: check the rules as before) and failure (new:
log the error, and force the decision to "needs a human," which also prevents the code
from ever reaching the "ask the global policy" step below it).

## How to test

Automated (this is the primary way to exercise this — it needs a database error at an
exact moment, which isn't practical to trigger by hand):

```
go test ./internal/invocation/ -run TestInvokeFailsClosedWhenRuleLoadFails -v
```

`TestInvokeFailsClosedWhenRuleLoadFails` (`internal/invocation/service_test.go`) spins
up a real SQLite-backed service and a fake upstream MCP server, injects a rules loader
that always returns an error (simulating the DB hiccup), and sets the global policy to
`always_approve` (the permissive fallback an operator might configure). It:
- Fails the test outright if the fake upstream's tool ever actually gets called
  (proving the call didn't sneak through to auto-approval), and
- Asserts the invocation ends up denied by a human reviewer (proving it correctly
  landed in `pending_approval` instead of being auto-approved).

Also run the full suite to confirm nothing else regressed:

```
go test ./...
```

Both pass locally as of this PR; `go vet ./...` and `gofmt -l` are clean.

## What needs special review?

- The exact placement of `ruleMatched = true` on the new error branch
  (`internal/invocation/service.go`, inside `Invoke`) — this is what prevents the
  `if !ruleMatched && s.policy != nil` block right below it from ever running when the
  rules failed to load. If a future refactor moves that flag around, this fail-closed
  guarantee could quietly break again.
- This PR intentionally only touches `Invoke`. `Submit` already fails closed on the
  same kind of error (it has no global-policy fallback to accidentally fall into), so
  it needed no change — worth double-checking that reasoning holds.
- The rule-matching loop itself (what runs when the load *succeeds*) was not changed at
  all — it was only moved one indentation level deeper into an `else` block. A reviewer
  diffing this should see that loop's body is byte-for-byte identical to before.

## Dependencies, breaking changes, and deployment notes

- No dependent or dependency PRs.
- No breaking changes: this only changes behavior on a previously-undefined error path
  (a failed rules lookup). Any caller relying on the old (buggy) fail-open behavior
  was relying on a bug, not a documented contract.
- No schema or migration changes, no new config, no environment variables.
- No special deployment considerations — this is a plain code fix behind normal
  request handling.

## Data impact
- [ ] Yes — this change is data-impacting
- [x] No — this change is not data-impacting

Justification: This only changes internal control flow on an error path (a failed
database read of approval rules). It does not modify any customer data, configuration
format, or the shape/structure of any API response, and it does not change behavior on
the success path at all.

## Release notes

Fixed an issue where a brief database error while checking approval rules could cause
a tool call to be automatically approved by the global fallback policy instead of
requiring human review. Rule-lookup failures now safely require human approval and are
logged.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend) — N/A, backend-only change
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied — apply `bug` label when opening the PR
- [x] Data impact classified
- [ ] PR linked to Shortcut — link the relevant ticket when opening the PR
- [x] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required) — N/A, no user-facing docs affected
- [ ] Environment variable additions/changes documented (if required) — N/A, no new env vars
