### PR TITLE
Fix: rule matching fails closed on corrupt pattern JSON and Submit's …

### DIFF
--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -1288,7 +1288,12 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	var resolvedAIDecision *policy.Decision
 	var resolvedAIConfidence *float64
 	if s.rules != nil {
-		if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
+		approvalRules, err := s.rules.ListApprovalRules(ctx)
+		if err != nil {
+			slog.Error("failed to load approval rules; failing closed to human review",
+				"error", err, "source", source, "tool", req.Tool)
+			s.emitRuleEvaluatedEvent(ctx, inv.InvocationID, "", "", policy.Decision{Disposition: policy.DispositionHuman, Reason: "rule lookup failed: " + err.Error()}, nil)
+		} else {
 			for _, rule := range matchRules(approvalRules, source, req.Tool, agentRec.ID) {
 				r := rule
 				if r.ID != "" {

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -188,6 +188,52 @@ func TestInvokeFailsClosedWhenRuleLoadFails(t *testing.T) {
 	}
 }
 
+// TestSubmitLogsAndAuditsRuleLoadFailure verifies that Submit records a
+// rule-lookup failure in the invocation's audit trail instead of discarding
+// it. Submit already fell back to pending_approval before this fix (unlike
+// Invoke, it has no global-policy fallback to accidentally fall through to),
+// but it did so silently: the error was dropped with no log line and no
+// event, so an operator investigating a stuck pending_approval invocation
+// could not distinguish "no rules matched" from "the rule store errored."
+func TestSubmitLogsAndAuditsRuleLoadFailure(t *testing.T) {
+	db := newSQLiteTestDB(t)
+	service := invocation.NewService(
+		store.NewInvocationRepo(db),
+		store.NewEventRepo(db),
+		nil, nil, nil,
+		5*time.Second,
+		rulesStoreStub{err: errors.New("database is locked")}, // simulates the transient DB hiccup
+		nil, nil, nil,
+	)
+
+	resp, err := service.Submit(context.Background(), invocation.ExternalSubmitRequest{
+		Source: "amp",
+		Tool:   "dangerous-tool",
+		Input:  map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != invocation.StatusPendingApproval {
+		t.Fatalf("status = %q, want pending_approval", resp.Status)
+	}
+
+	events, err := service.Events(context.Background(), resp.InvocationID, invocation.EventListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, evt := range events.Items {
+		if evt.Type == "invocation.rule_evaluated" && jsonContains(evt.Data, "rule lookup failed") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected an invocation.rule_evaluated event recording the rule lookup failure; got none — the error was silently dropped")
+	}
+}
+
 func TestResolverBootstrapsServersFromConfigWhenDBEmpty(t *testing.T) {
 	db := newSQLiteTestDB(t)
 	repo := store.NewServerRepo(db)

--- a/internal/store/rules.go
+++ b/internal/store/rules.go
@@ -288,21 +288,27 @@ func scanRule(scanner interface{ Scan(dest ...any) error }) (Rule, error) {
 	rule.Description = description.String
 	rule.ModelConfigCUID = modelConfigCUID.String
 	rule.AtryumLLMConfigID = atryumLLMConfigID.String
+	// server_pattern/tool_pattern/agent_cuids empty-slice means "match all" (see
+	// matchPatterns/matchAgentCUIDs), so a decode failure must not silently
+	// default to it — that would turn a narrowly-scoped rule (e.g. an
+	// auto_approve limited to one server) into one that matches everything.
+	// Surface the error instead so callers fail closed the same way they
+	// already do for a ListApprovalRules error.
 	if err := json.Unmarshal([]byte(serverJSON), &rule.ServerPatterns); err != nil {
-		rule.ServerPatterns = []string{}
+		return Rule{}, fmt.Errorf("decode rule server_pattern: %w", err)
 	}
 	if rule.ServerPatterns == nil {
 		rule.ServerPatterns = []string{}
 	}
 	if err := json.Unmarshal([]byte(toolJSON), &rule.ToolPatterns); err != nil {
-		rule.ToolPatterns = []string{}
+		return Rule{}, fmt.Errorf("decode rule tool_pattern: %w", err)
 	}
 	if rule.ToolPatterns == nil {
 		rule.ToolPatterns = []string{}
 	}
 	if agentCUIDsJSON != "" {
 		if err := json.Unmarshal([]byte(agentCUIDsJSON), &rule.AgentCUIDs); err != nil {
-			rule.AgentCUIDs = []string{}
+			return Rule{}, fmt.Errorf("decode rule agent_cuids: %w", err)
 		}
 	}
 	if rule.AgentCUIDs == nil {

--- a/internal/store/rules_test.go
+++ b/internal/store/rules_test.go
@@ -50,3 +50,52 @@ func TestRulesRepo_CreateVMPathAIEvaluationRule(t *testing.T) {
 		t.Errorf("AtryumLLMConfigID = %q, want empty string", got.AtryumLLMConfigID)
 	}
 }
+
+// TestRulesRepo_CorruptPatternJSONFailsClosed is a regression test for
+// scanRule silently defaulting a corrupt server_pattern/tool_pattern/
+// agent_cuids column to an empty slice. Per matchPatterns/matchAgentCUIDs, an
+// empty slice means "match all" — so a decode failure used to silently widen
+// a narrowly-scoped rule (e.g. an auto_approve limited to one server) into
+// one that matches every server, tool, or agent. Get/List must now surface
+// the decode error instead of returning a rule with a silently expanded
+// blast radius.
+func TestRulesRepo_CorruptPatternJSONFailsClosed(t *testing.T) {
+	for _, column := range []string{"server_pattern", "tool_pattern", "agent_cuids"} {
+		t.Run(column, func(t *testing.T) {
+			db, cleanup := openTestDB(t)
+			defer cleanup()
+			if err := InitDB(db); err != nil {
+				t.Fatalf("InitDB: %v", err)
+			}
+
+			repo := NewRulesRepo(db)
+			ctx := context.Background()
+
+			rule := Rule{
+				ID:             "rule-corrupt-" + column,
+				Action:         "auto_approve",
+				ServerPatterns: []string{"staging-db"},
+				ToolPatterns:   []string{"read_only_query"},
+				Enabled:        true,
+				Order:          0,
+			}
+			if err := repo.Create(ctx, rule); err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+
+			// Simulate corrupted data (bad manual edit, partial write, disk
+			// corruption) by writing invalid JSON directly, bypassing the
+			// repo's own encoder.
+			if _, err := db.ExecContext(ctx, `UPDATE approval_rules SET `+column+` = ? WHERE id = ?`, "{not valid json", rule.ID); err != nil {
+				t.Fatalf("corrupt %s: %v", column, err)
+			}
+
+			if _, err := repo.Get(ctx, rule.ID); err == nil {
+				t.Fatalf("Get succeeded despite corrupt %s JSON; want an error rather than silently defaulting to \"match all\"", column)
+			}
+			if _, err := repo.List(ctx); err == nil {
+				t.Fatalf("List succeeded despite corrupt %s JSON; want an error", column)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request Description

## What and why?

**Bug fix (two related bugs, found in the same review pass):** a rule whose stored data gets
corrupted can silently start matching far more than it was ever scoped to, and a real database
error that Atryum already handles safely was being handled *silently* — no log, no audit trail.

**Background for context.** An approval rule (`internal/store/rules.go`) can be scoped narrowly —
for example, "only auto-approve `read_only_query` on `staging-db`." That scope is stored as JSON in
three database columns: `server_pattern`, `tool_pattern`, `agent_cuids`. There's an important
convention baked into how those are matched (`internal/invocation/rules.go`): **an empty list means
"match everything."** No `server_pattern` restriction = applies to every server. This is
intentional and used all over the place (e.g. a rule with no `agent_cuids` applies to every agent).

That convention is exactly what made bug #1 dangerous.

### Bug 1: corrupted rule JSON silently becomes "match everything"

The code that reads a rule back out of the database (`scanRule`, `internal/store/rules.go`)
unmarshals those three JSON columns. Before this fix, if any column failed to parse — a bad manual
edit, a partial write from a crashed transaction, disk corruption, a future migration bug — the
code did this:

```go
if err := json.Unmarshal([]byte(serverJSON), &rule.ServerPatterns); err != nil {
    rule.ServerPatterns = []string{}   // <-- this is the "match everything" sentinel!
}
```

It threw the error away and quietly set the field to an empty list. But an empty list isn't a
safe "give up" value here — per the convention above, it's the exact value that means **match
every server** (or every tool, or every agent, depending on which column broke). So a rule that
was supposed to only ever touch `staging-db` could, on data corruption, silently start matching
`prod-db` too — with an `auto_approve` action attached to it.

```mermaid
sequenceDiagram
    autonumber
    participant Operator as Operator
    participant Agent as Agent
    participant DB as approval_rules table
    participant Code as scanRule

    Operator->>DB: Create auto_approve rule,<br/>tool_pattern = ["read_only_query"] only
    Note over DB: tool_pattern column becomes corrupted<br/>(bad edit / partial write / disk issue)
    Agent->>Code: Tool call: drop_table
    Code->>DB: Read the rule back
    DB-->>Code: tool_pattern = "{not valid json" (corrupt)
    rect rgb(120, 30, 30)
    Note over Code: BUG: parse fails, error thrown away,<br/>ToolPatterns silently set to [] = "match ALL tools"
    end
    Code-->>Agent: Rule now matches drop_table too — auto-approved,<br/>even though it was only ever scoped to read_only_query
```

**The fix:** stop swallowing the error. Return it instead — the store package already handles a
different JSON column (a server's `args`/`env` config) this same, correct way, returning the
decode error instead of masking it, so this just makes rule loading consistent with that existing
pattern. The error now flows naturally up through `Get`/`List` → `ListApprovalRules` →
`Invoke`/`Submit`, which **already** know how to fail closed (send the call to a human) when rules
can't be loaded at all for any reason — that existing fail-closed handling is exactly what Bug 2,
below, makes visible instead of silent. A rule that can't be fully understood now blocks the whole
rule load instead of silently widening its own scope.

### Bug 2: `Submit` swallowed a real error with zero logging

Separately: `Submit` (the code path used when an external harness, e.g. a coding-agent hook,
submits a tool call and just asks Atryum for a decision) already handled a failed rules-database
read *safely* — unlike `Invoke`, it has no permissive global-policy fallback to accidentally fall
into, so it always lands in `pending_approval` either way, no matter *why* no rule matched. But it
did this by accident, and it did it silently:

```go
if approvalRules, err := s.rules.ListApprovalRules(ctx); err == nil {
    // ... check rules, decide auto_approve / auto_deny / pending_approval ...
}
// no else branch — on error, this whole block is just skipped: no log, no event
```

No log line anywhere, and no entry in the invocation's audit trail. An operator looking at why a
call landed in `pending_approval` had no way to tell "no rule happened to match" apart from "the
database was having a problem right when this call came in."

**Before this fix:**

```mermaid
sequenceDiagram
    autonumber
    participant Harness as External harness
    participant Submit as Service.Submit
    participant Rules as Database (approval_rules)
    participant Audit as Invocation audit trail

    Harness->>Submit: Submit tool call
    Submit->>Rules: Load approval rules
    Rules-->>Submit: Error (e.g. a database hiccup)
    rect rgb(120, 30, 30)
    Note over Submit: BUG: error discarded silently.<br/>No log line. No audit event.
    end
    Submit-->>Harness: pending_approval (the status happens to be correct)
    Note over Audit: Event history shows nothing unusual —<br/>indistinguishable from "no rule matched"
```

**After this fix:**

```mermaid
sequenceDiagram
    autonumber
    participant Harness as External harness
    participant Submit as Service.Submit
    participant Rules as Database (approval_rules)
    participant Audit as Invocation audit trail

    Harness->>Submit: Submit tool call
    Submit->>Rules: Load approval rules
    Rules-->>Submit: Error (e.g. a database hiccup)
    rect rgb(30, 90, 30)
    Note over Submit: FIXED: error is logged (slog.Error), and an<br/>invocation.rule_evaluated audit event is recorded
    end
    Submit-->>Harness: pending_approval (status unchanged)
    Note over Audit: Event history now explains WHY:<br/>a rule lookup failure, not "nothing matched"
```

**The fix:** make `Submit` log the error (`slog.Error(...)`) and record it in the invocation's
audit trail (the same `invocation.rule_evaluated` event other rule outcomes already produce), so
the failure is now visible instead of invisible. The observable status doesn't change — it was
already correct — only the visibility does.

## How to test

Two new regression tests, one per bug. Both were verified to fail before the fix and pass after
(confirmed by reverting the fix locally and re-running).

```
go test ./internal/store/ -run TestRulesRepo_CorruptPatternJSONFailsClosed -v
go test ./internal/invocation/ -run TestSubmitLogsAndAuditsRuleLoadFailure -v
```

`TestRulesRepo_CorruptPatternJSONFailsClosed` creates a normal rule scoped to one server/tool,
then directly corrupts one of the three JSON columns with a raw `UPDATE ... SET <column> =
'{not valid json'` (simulating the kind of corruption that wouldn't happen through the app's own
code, only through something external touching the database), and asserts `Get` and `List` both
return an error instead of a silently-widened rule. It runs this for all three columns
(`server_pattern`, `tool_pattern`, `agent_cuids`) as subtests.

`TestSubmitLogsAndAuditsRuleLoadFailure` calls `Submit` with a fake rules store that always
returns an error, then checks the invocation's event history for an `invocation.rule_evaluated`
event that mentions the failure.

Also run the full suite, `go vet`, and formatting check to confirm nothing else regressed:

```
go test ./...
go vet ./...
gofmt -l internal/store/rules.go internal/store/rules_test.go internal/invocation/service.go internal/invocation/service_test.go
```

All pass locally / produce no output (gofmt) as of this PR.

## What needs special review?

- **Every existing caller of `RulesRepo.Get`/`List` already handles their error return** (verified
  by grepping all six call sites in `internal/api/handlers.go` — each already does `if err != nil {
  ... }` and returns a 500). That means this change doesn't add a new kind of failure a caller is
  unprepared for; it just makes an existing, already-handled error path reachable in a new (rare)
  situation. Worth a reviewer double-checking that reasoning still holds if any new caller is added
  later.
- **The valid-JSON path is completely unchanged.** For every rule whose columns parse correctly —
  which is the normal case, always, unless something external corrupts the database — behavior is
  byte-for-byte identical to before. Only the error path changed.
- **`Submit`'s observable behavior is unchanged on purpose.** This PR does not change what status
  code or disposition `Submit` returns on a rule-load failure (it was already correct:
  `pending_approval`). It only adds logging and an audit event. A reviewer should confirm the diff
  really is additive here and doesn't accidentally touch the decision logic.

## Dependencies, breaking changes, and deployment notes

- No dependent or dependency PRs.
- No breaking changes. `scanRule`/`Get`/`List` could already fail for other reasons (a bad SQL
  connection, a missing row) — every caller already handles that. This change only makes an
  additional, previously-silent failure mode surface through that same, already-handled `error`
  return. Nothing that was relying on documented behavior changes; only a bug (silently accepting
  corrupt data) goes away.
- No schema or migration changes, no new config, no environment variables.
- No special deployment considerations — plain application code, no data migration required.

## Data impact
- [ ] Yes — this change is data-impacting
- [x] No — this change is not data-impacting

Justification: This does not modify any customer data, configuration format, or the shape of any
API response. It only changes how already-corrupt (invalid) rule data is handled internally — on
the normal path, where rule data is valid, behavior is identical to before.

## Release notes

Label: `bug`

Fixed two issues in approval-rule handling:
- A rule whose stored server/tool/agent scope had become corrupted could silently start matching
  far more than it was configured for, instead of failing safely. Corrupted rule data now blocks
  the rule load and falls back to human review.
- A database error while loading rules during an external tool-call submission is now logged and
  recorded in the invocation's audit trail, instead of failing silently.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend) — N/A, backend-only change
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied — apply `bug` label when opening the PR
- [x] Data impact classified
- [ ] PR linked to Shortcut — link the relevant ticket when opening the PR
- [x] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required) — N/A, this description is self-contained
- [ ] Environment variable additions/changes documented (if required) — N/A, no new env vars
