### PR TITLE
Server-side session get-or-create keyed by agent + client_session_id

### DIFF
--- a/examples/amp-plugin/README.md
+++ b/examples/amp-plugin/README.md
@@ -91,7 +91,7 @@ To remove the global plugin later:
 | `ATRYUM_TOKEN_REFRESH_SKEW_MS`    | `60000`                           | refresh command cache skew before token expiry                                                                             |
 | `ATRYUM_TOKEN_COMMAND_TIMEOUT_MS` | `10000`                           | timeout for the token command subprocess                                                                                   |
 | `ATRYUM_STATE_DIR`                | `~/.atryum/amp-plugin-state`      | directory for the on-disk token cache (`token-cache.json`, mode 0600)                                                      |
-| `ATRYUM_AMP_SESSION_FILE`         | `~/.local/share/amp/session.json` | Amp session state file used to label the Atryum session with Amp's thread id                                              |
+| `ATRYUM_AMP_SESSION_FILE`         | `~/.local/share/amp/session.json` | Amp session state file used to derive Amp's thread id, sent as `client_session_id`                                        |
 
 ## LLM-as-judge session context
 
@@ -99,17 +99,17 @@ The plugin does **not** send a free-form chat/context blob to Atryum. The
 harness is trusted to report _which_ session a tool call belongs to, but a
 runaway agent must not be able to hand the judge arbitrary text to poison it.
 
-Instead, on the first tool call the plugin mints an Atryum session via
-`POST /api/v1/external/sessions` (passing `harness` and, for cross-referencing
-only, Amp's own thread id as `client_session_id`). It caches the returned
-`session_id` for the lifetime of the process and echoes it on every
-`POST /api/v1/external/invocations`. Atryum then reconstructs the judge's
-context from the prior tool calls it recorded for that session — trusting tool
-outputs more than tool inputs, and ignoring agent chat entirely.
+Instead, the plugin sends Amp's own thread id as `client_session_id` on every
+`POST /api/v1/external/invocations` and lets Atryum manage the session
+server-side. Atryum resolves the internal session with get-or-create keyed by
+(agent binding, `client_session_id`) and reconstructs the judge's context from
+the prior tool calls it recorded for that session — trusting tool outputs more
+than tool inputs, and ignoring agent chat entirely. The plugin never mints,
+persists, or echoes an Atryum session id.
 
-If session creation fails, the plugin falls back to submitting without a
-`session_id` (tool calls are still gated, just without prior-call context)
-rather than blocking the agent.
+If the caller has no agent binding, Atryum simply resolves no session and
+evaluates the call history-free (tool calls are still gated, just without
+prior-call context) rather than blocking the agent.
 
 ## Tagging invocations to an Agent Record
 

--- a/examples/amp-plugin/atryum.ts
+++ b/examples/amp-plugin/atryum.ts
@@ -9,11 +9,13 @@
 // Session context for the LLM-as-judge is NOT sent by this plugin. The harness
 // is trusted to report which session a tool call belongs to, but it does not
 // get to hand Atryum a free-form context blob (a runaway agent could use that
-// to poison the judge). Instead, the plugin mints an Atryum session once at
-// startup (POST /api/v1/external/sessions) and echoes the returned session_id
-// on every submission. Atryum reconstructs the judge's context from the prior
-// tool calls it recorded for that session, which it trusts at the appropriate
-// level (tool outputs > tool inputs > nothing from agent chat).
+// to poison the judge). Instead, the plugin sends Amp's own thread id as
+// `client_session_id` on every submission and lets Atryum manage the session
+// server-side: Atryum resolves the internal session with get-or-create keyed by
+// (agent binding, client_session_id) and reconstructs the judge's context from
+// the prior tool calls it recorded for that session, which it trusts at the
+// appropriate level (tool outputs > tool inputs > nothing from agent chat). The
+// plugin never mints, persists, or echoes an Atryum session id.
 //
 // Configure via env:
 //   ATRYUM_URL       base URL of the atryum server, default http://localhost:8080
@@ -38,8 +40,9 @@
 //                    token is refreshed on expiry and on a 401.
 //   ATRYUM_AMP_SESSION_FILE
 //                    override Amp session JSON file, default
-//                    ~/.local/share/amp/session.json. Used only to label the
-//                    session with Amp's own thread id (client_session_id).
+//                    ~/.local/share/amp/session.json. Used to derive Amp's own
+//                    thread id, sent as client_session_id so Atryum can group a
+//                    thread's tool calls into one server-managed session.
 
 import type { PluginAPI } from "@ampcode/plugin";
 import { exec } from "node:child_process";
@@ -283,10 +286,6 @@ type InvocationResponse = {
   error?: unknown;
 };
 
-type SessionResponse = {
-  session_id: string;
-};
-
 // toolUseID -> atryum invocation id, so tool.result can patch the right row.
 const invocationMap = new Map<string, string>();
 
@@ -317,39 +316,6 @@ function activeThreadID(): string {
   return "";
 }
 
-// Atryum-minted session id, created lazily on the first tool call and reused
-// for the lifetime of this plugin process. Atryum links every invocation
-// carrying this id and reconstructs the judge's context from them.
-let sessionPromise: Promise<string | undefined> | undefined;
-
-async function createSession(): Promise<string | undefined> {
-  const res = await atryumFetch(`${API}/api/v1/external/sessions`, {
-    method: "POST",
-    contentType: true,
-    body: JSON.stringify({
-      harness: SOURCE,
-      // Amp's own thread id, for cross-referencing only. Atryum keys off the
-      // session_id it mints, not this.
-      client_session_id: activeThreadID() || undefined,
-      agent_id: AGENT_ID || undefined,
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as SessionResponse;
-  return body.session_id || undefined;
-}
-
-async function ensureSession(): Promise<string | undefined> {
-  // Sessions are an optimization for richer judge context. If creation fails,
-  // fall back to submitting without a session_id rather than blocking tools.
-  if (!sessionPromise) {
-    sessionPromise = createSession().catch(() => undefined);
-  }
-  return sessionPromise;
-}
-
 function describe(input: Record<string, unknown>): string {
   const parts = Object.entries(input)
     .filter(([, v]) => typeof v === "string")
@@ -374,8 +340,8 @@ async function submit(
   tool: string,
   toolUseID: string,
   input: Record<string, unknown>,
-  sessionID: string | undefined,
 ): Promise<InvocationResponse> {
+  const threadID = activeThreadID() || undefined;
   const res = await atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
     contentType: true,
@@ -385,8 +351,11 @@ async function submit(
       description: describe(input),
       input,
       request_id: toolUseID,
-      thread_id: activeThreadID() || undefined,
-      session_id: sessionID,
+      thread_id: threadID,
+      // Amp's own thread id. Atryum resolves the internal session with
+      // get-or-create keyed by (agent binding, client_session_id) — no mint,
+      // no persisted session id, no re-mint on expiry.
+      client_session_id: threadID,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,
       agent_id: AGENT_ID || undefined,
@@ -444,12 +413,10 @@ async function patchExecution(
 export default function (amp: PluginAPI) {
   amp.on("tool.call", async (event, ctx) => {
     try {
-      const sessionID = await ensureSession();
       const submitted = await submit(
         event.tool,
         event.toolUseID,
         event.input,
-        sessionID,
       );
       invocationMap.set(event.toolUseID, submitted.invocation_id);
 

--- a/examples/claude-code-hook/README.md
+++ b/examples/claude-code-hook/README.md
@@ -62,7 +62,7 @@ Restart Claude Code after changing settings.
 | `ATRYUM_TOKEN_COMMAND`            | _(empty)_                    | optional command run to mint each new token; prints a raw token with no whitespace or OAuth token JSON with `access_token` |
 | `ATRYUM_TOKEN_REFRESH_SKEW_MS`    | `60000`                      | refresh command cache skew before token expiry                                                                             |
 | `ATRYUM_TOKEN_COMMAND_TIMEOUT_MS` | `10000`                      | timeout for the token command subprocess                                                                                   |
-| `ATRYUM_STATE_DIR`                | `~/.atryum/agent-hook-state` | tool-use to invocation-id state, the cached Atryum session, and the on-disk token cache (`token-cache.json`, mode 0600)     |
+| `ATRYUM_STATE_DIR`                | `~/.atryum/agent-hook-state` | tool-use to invocation-id state and the on-disk token cache (`token-cache.json`, mode 0600)                                 |
 
 ## Authentication
 
@@ -128,20 +128,19 @@ blob to Atryum. The harness is trusted to report _which_ session a tool call
 belongs to, but a runaway agent must not be able to hand the judge arbitrary
 text to poison it.
 
-Instead, the hook mints an Atryum session via `POST /api/v1/external/sessions`
-(passing `harness` and, for cross-referencing only, Claude Code's own session id
-as `client_session_id`). Because each hook invocation is a fresh process, the
-returned `session_id` is cached on disk under `$ATRYUM_STATE_DIR` keyed by the
-host session id and echoed on every `POST /api/v1/external/invocations`. Atryum
-then reconstructs the judge's context from the prior tool calls it recorded for
-that session — trusting tool outputs more than tool inputs, and ignoring agent
-chat entirely.
+Instead, the hook sends Claude Code's own session id as `client_session_id` on
+every `POST /api/v1/external/invocations` and lets Atryum manage the session
+server-side. Atryum resolves the internal session with get-or-create keyed by
+(agent binding, `client_session_id`) and reconstructs the judge's context from
+the prior tool calls it recorded for that session — trusting tool outputs more
+than tool inputs, and ignoring agent chat entirely. Because the server manages
+the session, the hook keeps no session state on disk even though each hook
+invocation is a fresh process — no mint call, no cache file, no re-mint/retry.
 
-Sessions require an agent binding: `ATRYUM_AGENT_ID` (no-auth mode) or the
-bearer token (auth mode). With neither, the caller is anonymous and the hook
-submits without a `session_id` (tool calls are still gated, just without
-prior-call context). If a cached session is unknown, foreign, or expired, the
-hook mints a fresh one and retries the submit once.
+A session still requires an agent binding: `ATRYUM_AGENT_ID` (no-auth mode) or
+the bearer token (auth mode). With neither, the caller is anonymous and Atryum
+resolves no session, evaluating the call history-free (tool calls are still
+gated, just without prior-call context).
 
 ## Notes
 

--- a/examples/claude-code-hook/README.md
+++ b/examples/claude-code-hook/README.md
@@ -142,6 +142,20 @@ the bearer token (auth mode). With neither, the caller is anonymous and Atryum
 resolves no session, evaluating the call history-free (tool calls are still
 gated, just without prior-call context).
 
+### Subagent isolation
+
+When the Task tool spawns subagents (e.g. Explore, Plan), they inherit the
+parent's top-level `session_id` — Claude Code doesn't mint a new top-level
+session per subagent. Instead, hook events fired from inside a subagent carry
+the host's own subagent instance id on the same event (a field distinct from
+the session id, and unrelated to Atryum's `ATRYUM_AGENT_ID`/agent-binding
+concept). The hook folds that instance id into `client_session_id` as
+`<session-id>:<instance-id>`, so each subagent get-or-creates its own Atryum
+session distinct from its parent and from sibling subagents, instead of all of
+them sharing — and cross-contaminating — one judge context. Main-session hook
+calls are unaffected: `client_session_id` is just the session id, exactly as
+before.
+
 ## Notes
 
 Claude Code hook support is documented around `PreToolUse` and `PostToolUse`.

--- a/examples/codex-mcp/README.md
+++ b/examples/codex-mcp/README.md
@@ -61,7 +61,7 @@ the hook definition, so changing the command requires re-review.
 | `ATRYUM_POLL_MS` | `2000` | approval polling interval |
 | `ATRYUM_AGENT_ID` | _(empty)_ | self-declared agent identifier; matched against Agent Record `agent_ids` |
 | `ATRYUM_ACCESS_TOKEN` | _(empty)_ | optional OAuth bearer token for Atryum agent runtime APIs |
-| `ATRYUM_STATE_DIR` | `~/.atryum/agent-hook-state` | tool-use to invocation-id state and the cached Atryum session |
+| `ATRYUM_STATE_DIR` | `~/.atryum/agent-hook-state` | tool-use to invocation-id state |
 
 ## LLM-as-judge session context
 
@@ -70,20 +70,19 @@ history, or send any chat/context blob to Atryum. The harness is trusted to
 report _which_ session a tool call belongs to, but a runaway agent must not be
 able to hand the judge arbitrary text to poison it.
 
-Instead, the hook mints an Atryum session via `POST /api/v1/external/sessions`
-(passing `harness` and, for cross-referencing only, Codex's own session id as
-`client_session_id`). Because each hook invocation is a fresh process, the
-returned `session_id` is cached on disk under `$ATRYUM_STATE_DIR` keyed by the
-host session id and echoed on every `POST /api/v1/external/invocations`. Atryum
-then reconstructs the judge's context from the prior tool calls it recorded for
-that session — trusting tool outputs more than tool inputs, and ignoring agent
-chat entirely.
+Instead, the hook sends Codex's own session id as `client_session_id` on every
+`POST /api/v1/external/invocations` and lets Atryum manage the session
+server-side. Atryum resolves the internal session with get-or-create keyed by
+(agent binding, `client_session_id`) and reconstructs the judge's context from
+the prior tool calls it recorded for that session — trusting tool outputs more
+than tool inputs, and ignoring agent chat entirely. Because the server manages
+the session, the hook keeps no session state on disk even though each hook
+invocation is a fresh process — no mint call, no cache file, no re-mint/retry.
 
-Sessions require an agent binding: `ATRYUM_AGENT_ID` (no-auth mode) or the
-bearer token (auth mode). With neither, the caller is anonymous and the hook
-submits without a `session_id` (tool calls are still gated, just without
-prior-call context). If a cached session is unknown, foreign, or expired, the
-hook mints a fresh one and retries the submit once.
+A session still requires an agent binding: `ATRYUM_AGENT_ID` (no-auth mode) or
+the bearer token (auth mode). With neither, the caller is anonymous and Atryum
+resolves no session, evaluating the call history-free (tool calls are still
+gated, just without prior-call context).
 
 ## MCP proxy
 

--- a/examples/cursor-hook/README.md
+++ b/examples/cursor-hook/README.md
@@ -53,7 +53,7 @@ Restart Cursor after changing hooks.
 | `ATRYUM_TOKEN_COMMAND`            | _(empty)_                         | optional command run to mint each new token; prints a raw token with no whitespace or OAuth token JSON with `access_token` |
 | `ATRYUM_TOKEN_REFRESH_SKEW_MS`    | `60000`                           | refresh command cache skew before token expiry                                                                             |
 | `ATRYUM_TOKEN_COMMAND_TIMEOUT_MS` | `10000`                           | timeout for the token command subprocess                                                                                   |
-| `ATRYUM_STATE_DIR`                | `~/.atryum/agent-hook-state`      | tool-use to invocation-id state, the cached Atryum session, and the on-disk token cache (`token-cache.json`, mode 0600)     |
+| `ATRYUM_STATE_DIR`                | `~/.atryum/agent-hook-state`      | tool-use to invocation-id state and the on-disk token cache (`token-cache.json`, mode 0600)                                 |
 
 ## Authentication
 
@@ -118,20 +118,19 @@ chat/context blob to Atryum. The harness is trusted to report _which_ session a
 tool call belongs to, but a runaway agent must not be able to hand the judge
 arbitrary text to poison it.
 
-Instead, the hook mints an Atryum session via `POST /api/v1/external/sessions`
-(passing `harness` and, for cross-referencing only, Cursor's own session id as
-`client_session_id`). Because each hook invocation is a fresh process, the
-returned `session_id` is cached on disk under `$ATRYUM_STATE_DIR` keyed by the
-host session id and echoed on every `POST /api/v1/external/invocations`. Atryum
-then reconstructs the judge's context from the prior tool calls it recorded for
-that session — trusting tool outputs more than tool inputs, and ignoring agent
-chat entirely.
+Instead, the hook sends Cursor's own session id as `client_session_id` on every
+`POST /api/v1/external/invocations` and lets Atryum manage the session
+server-side. Atryum resolves the internal session with get-or-create keyed by
+(agent binding, `client_session_id`) and reconstructs the judge's context from
+the prior tool calls it recorded for that session — trusting tool outputs more
+than tool inputs, and ignoring agent chat entirely. Because the server manages
+the session, the hook keeps no session state on disk even though each hook
+invocation is a fresh process — no mint call, no cache file, no re-mint/retry.
 
-Sessions require an agent binding: `ATRYUM_AGENT_ID` (no-auth mode) or the
-bearer token (auth mode). With neither, the caller is anonymous and the hook
-submits without a `session_id` (tool calls are still gated, just without
-prior-call context). If a cached session is unknown, foreign, or expired, the
-hook mints a fresh one and retries the submit once.
+A session still requires an agent binding: `ATRYUM_AGENT_ID` (no-auth mode) or
+the bearer token (auth mode). With neither, the caller is anonymous and Atryum
+resolves no session, evaluating the call history-free (tool calls are still
+gated, just without prior-call context).
 
 ## Plugin packaging
 

--- a/examples/pi-extension/README.md
+++ b/examples/pi-extension/README.md
@@ -92,17 +92,17 @@ The extension does **not** send a free-form chat/context blob to Atryum. The
 harness is trusted to report _which_ session a tool call belongs to, but a
 runaway agent must not be able to hand the judge arbitrary text to poison it.
 
-Instead, on the first tool call the extension mints an Atryum session via
-`POST /api/v1/external/sessions` (passing `harness` and, for cross-referencing
-only, Pi's own session id as `client_session_id`). It caches the returned
-`session_id` for the lifetime of the session and echoes it on every
-`POST /api/v1/external/invocations`. Atryum then reconstructs the judge's
-context from the prior tool calls it recorded for that session — trusting tool
-outputs more than tool inputs, and ignoring agent chat entirely.
+Instead, the extension sends Pi's own session id as `client_session_id` on
+every `POST /api/v1/external/invocations` and lets Atryum manage the session
+server-side. Atryum resolves the internal session with get-or-create keyed by
+(agent binding, `client_session_id`) and reconstructs the judge's context from
+the prior tool calls it recorded for that session — trusting tool outputs more
+than tool inputs, and ignoring agent chat entirely. The extension never mints,
+persists, or echoes an Atryum session id.
 
-If session creation fails, the extension falls back to submitting without a
-`session_id` (tool calls are still gated, just without prior-call context)
-rather than blocking the agent.
+If the caller has no agent binding, Atryum simply resolves no session and
+evaluates the call history-free (tool calls are still gated, just without
+prior-call context) rather than blocking the agent.
 
 ## Tagging invocations to an Agent Record
 

--- a/examples/pi-extension/index.ts
+++ b/examples/pi-extension/index.ts
@@ -224,10 +224,6 @@ type InvocationResponse = {
   error?: unknown;
 };
 
-type SessionResponse = {
-  session_id: string;
-};
-
 type ToolInput = Record<string, unknown>;
 
 const invocationMap = new Map<string, string>();
@@ -256,8 +252,10 @@ function rulesEndpointHint(tool: string): string {
   return `atryum: to see the approval rules that apply to this call, GET ${url.toString()} (advisory only; Atryum re-checks policy during the actual gated call).`;
 }
 
-// Pi's own session identifier, used only for cross-referencing (thread_id and
-// client_session_id). Atryum keys off the session_id it mints, not this.
+// Pi's own session identifier, sent as client_session_id (and thread_id) on
+// every submission. Atryum resolves the internal session with get-or-create
+// keyed by (agent binding, client_session_id) — the extension never mints,
+// persists, or echoes an Atryum session id.
 function piClientSessionID(ctx: unknown): string | undefined {
   const manager = (ctx as { sessionManager?: unknown }).sessionManager as
     | { getSessionFile?: () => string; sessionId?: string; id?: string }
@@ -271,48 +269,11 @@ function piClientSessionID(ctx: unknown): string | undefined {
   return undefined;
 }
 
-// Atryum-minted session id, created lazily on the first tool call and reused
-// for the lifetime of this extension. Atryum links every invocation carrying
-// this id and reconstructs the judge's context from them — the extension never
-// sends a free-form context blob.
-let sessionPromise: Promise<string | undefined> | undefined;
-
-async function createSession(
-  clientSessionID: string | undefined,
-): Promise<string | undefined> {
-  const res = await atryumFetch(`${API}/api/v1/external/sessions`, {
-    method: "POST",
-    contentType: true,
-    body: JSON.stringify({
-      harness: SOURCE,
-      client_session_id: clientSessionID || undefined,
-      agent_id: AGENT_ID || undefined,
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`${res.status} ${await res.text()}`);
-  }
-  const body = (await res.json()) as SessionResponse;
-  return body.session_id || undefined;
-}
-
-async function ensureSession(ctx: unknown): Promise<string | undefined> {
-  // Sessions are an optimization for richer judge context. If creation fails,
-  // fall back to submitting without a session_id rather than blocking tools.
-  if (!sessionPromise) {
-    sessionPromise = createSession(piClientSessionID(ctx)).catch(
-      () => undefined,
-    );
-  }
-  return sessionPromise;
-}
-
 async function submit(
   tool: string,
   toolCallID: string,
   input: ToolInput,
   threadID: string | undefined,
-  sessionID: string | undefined,
 ): Promise<InvocationResponse> {
   const res = await atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
@@ -324,7 +285,9 @@ async function submit(
       input,
       request_id: toolCallID,
       thread_id: threadID,
-      session_id: sessionID,
+      // Pi's own session id. Atryum resolves the internal session with
+      // get-or-create keyed by (agent binding, client_session_id).
+      client_session_id: threadID,
       agent_id: AGENT_ID || undefined,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,
@@ -383,13 +346,11 @@ export default function (pi: ExtensionAPI) {
   pi.on("tool_call", async (event, ctx) => {
     try {
       const input = (event.input || {}) as ToolInput;
-      const sessionID = await ensureSession(ctx);
       const submitted = await submit(
         event.toolName,
         event.toolCallId,
         input,
         piClientSessionID(ctx),
-        sessionID,
       );
       invocationMap.set(event.toolCallId, submitted.invocation_id);
 

--- a/examples/shared-agent-hook/atryum-hook.mjs
+++ b/examples/shared-agent-hook/atryum-hook.mjs
@@ -13,19 +13,21 @@
 // Session context for the LLM-as-judge is NOT scraped or sent by this hook. The
 // harness is trusted to report which session a tool call belongs to, but it does
 // not get to hand Atryum a free-form context blob (a runaway agent could use that
-// to poison the judge). Instead, the hook mints an Atryum session once per host
-// session (POST /api/v1/external/sessions), caches the returned session_id in a
-// state file keyed by the host's own session/thread id (the hook runs as a fresh
-// process per tool event, so the cache must live on disk), and echoes that
-// session_id on every /api/v1/external/invocations submit. Atryum reconstructs
-// the judge's context from the prior tool calls it recorded for that session,
-// trusting tool outputs more than tool inputs and ignoring agent chat entirely.
+// to poison the judge). Instead, the hook sends the host's own session/thread id
+// as `client_session_id` on every /api/v1/external/invocations submit and lets
+// Atryum manage the session server-side: Atryum resolves the internal session
+// with get-or-create keyed by (agent binding, client_session_id) and
+// reconstructs the judge's context from the prior tool calls it recorded for
+// that session, trusting tool outputs more than tool inputs and ignoring agent
+// chat entirely. Because the server manages the session, this hook keeps no
+// session state on disk — no mint call, no cache file, no re-mint/retry — even
+// though it runs as a fresh process per tool event.
 //
-// Sessions require an agent binding. In no-auth mode the binding comes from
-// ATRYUM_AGENT_ID; in auth mode it comes from the bearer token. When neither is
-// available the caller is anonymous: the hook skips minting and submits without a
-// session_id (tool calls are still gated, just without prior-call context),
-// matching the graceful degradation of the session-less fake_agent.py baseline.
+// A session still requires an agent binding (from ATRYUM_AGENT_ID in no-auth
+// mode, or the bearer token in auth mode). When neither is present the caller is
+// anonymous: the server simply resolves no session and evaluates the call
+// history-free — the same graceful degradation as the session-less
+// fake_agent.py baseline, now decided server-side rather than gated here.
 
 import { createHash } from "node:crypto";
 import { exec } from "node:child_process";
@@ -61,11 +63,6 @@ const STATE_DIR =
 const AGENT_ID = process.env.ATRYUM_AGENT_ID || "";
 const ACCESS_TOKEN = process.env.ATRYUM_ACCESS_TOKEN || "";
 const TOKEN_COMMAND = process.env.ATRYUM_TOKEN_COMMAND || "";
-// A session must be bound to an agent identity. That comes from ATRYUM_AGENT_ID
-// (no-auth mode) or from the bearer token (auth mode). With neither, the caller
-// is anonymous and the server rejects session minting with a 400, so skip
-// minting entirely and submit history-free.
-const CAN_BIND_SESSION = Boolean(AGENT_ID || ACCESS_TOKEN || TOKEN_COMMAND);
 // Malformed values (e.g. "10s") would otherwise become NaN, which silently
 // disables the cache comparisons and makes exec() throw ERR_OUT_OF_RANGE.
 const envMs = (name, fallback) => {
@@ -300,9 +297,9 @@ function rulesEndpointHint(tool) {
   return `atryum: to see the approval rules that apply to this call, GET ${url.toString()} (advisory only; Atryum re-checks policy during the actual gated call).`;
 }
 
-// The host's own session/thread identifier. Used only for cross-referencing:
-// it becomes the invocation `thread_id` and the session's `client_session_id`.
-// Atryum keys the judge's context off the session_id it mints, not this value.
+// The host's own session/thread identifier. Sent as the invocation `thread_id`
+// and `client_session_id`; Atryum resolves the internal session with
+// get-or-create keyed by (agent binding, client_session_id).
 function sessionId(event) {
   return (
     event.session_id ||
@@ -316,101 +313,16 @@ function sessionId(event) {
 }
 
 // ---------------------------------------------------------------------------
-// Atryum session (LLM-as-judge context lives server-side, keyed by session_id).
+// Atryum submit (LLM-as-judge context lives server-side; the session is resolved
+// by (agent binding, client_session_id) get-or-create — nothing to persist here).
 // ---------------------------------------------------------------------------
 
-// Ties a cached session to the agent identity and server that minted it, so
-// switching ATRYUM_AGENT_ID or ATRYUM_URL invalidates stale cache entries.
-const SESSION_CACHE_KEY = createHash("sha256")
-  .update(`${AGENT_ID}\n${API.replace(/\/+$/, "")}`)
-  .digest("hex");
-
-// The disk key under which a session is cached. Prefer the host's own session
-// id so each host conversation reuses one Atryum session across the fresh
-// per-event processes; fall back to a per-host key when the host exposes none.
-function sessionCacheKey(event) {
-  return sessionId(event) || `${SOURCE}:default`;
-}
-
-function sessionStatePath(hostKey) {
-  const safe = createHash("sha256").update(`session:${hostKey}`).digest("hex");
-  return path.join(STATE_DIR, `session-${safe}.json`);
-}
-
-async function readSessionCache(hostKey) {
-  try {
-    const raw = await readFile(sessionStatePath(hostKey), "utf8");
-    const { session_id: id, key } = JSON.parse(raw);
-    if (typeof id === "string" && id && key === SESSION_CACHE_KEY) return id;
-  } catch {
-    // cache miss or unreadable
-  }
-  return "";
-}
-
-async function writeSessionCache(hostKey, id) {
-  try {
-    await mkdir(STATE_DIR, { recursive: true });
-    await writeFile(
-      sessionStatePath(hostKey),
-      JSON.stringify({ session_id: id, key: SESSION_CACHE_KEY }),
-      "utf8",
-    );
-  } catch {
-    // best-effort; a failed cache just means we mint again next event
-  }
-}
-
-async function deleteSessionCache(hostKey) {
-  await rm(sessionStatePath(hostKey), { force: true });
-}
-
-async function createSession(clientSessionID) {
-  const res = await atryumFetch(`${API}/api/v1/external/sessions`, {
-    method: "POST",
-    contentType: true,
-    body: JSON.stringify({
-      harness: SOURCE,
-      client_session_id: clientSessionID || undefined,
-      agent_id: AGENT_ID || undefined,
-    }),
-  });
-  if (!res.ok) {
-    throw new Error(`${res.status} ${await res.text()}`);
-  }
-  const body = await res.json();
-  return body.session_id || "";
-}
-
-// Returns a usable session_id, minting one if needed. Sessions are an
-// optimization for richer judge context: on any failure this returns "" and the
-// caller submits without a session_id rather than blocking the tool call.
-async function ensureSession(hostKey, clientSessionID, forceNew = false) {
-  if (!CAN_BIND_SESSION) return "";
-  if (!forceNew) {
-    const cached = await readSessionCache(hostKey);
-    if (cached) return cached;
-  }
-  try {
-    const id = await createSession(clientSessionID);
-    if (id) await writeSessionCache(hostKey, id);
-    return id;
-  } catch {
-    return "";
-  }
-}
-
-// Unknown/foreign/expired sessions are hard 400 rejections whose body mentions
-// "session". Those are recoverable by minting a fresh session and retrying once.
-function looksLikeSessionError(status, body) {
-  return status >= 400 && status < 500 && /session/i.test(body || "");
-}
-
-async function submitOnce(event, sessionIDValue) {
+async function submit(event) {
   const name = toolName(event);
   const input = toolInput(event);
   const id = toolUseID(event);
-  return atryumFetch(`${API}/api/v1/external/invocations`, {
+  const clientSessionID = sessionId(event) || undefined;
+  const res = await atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
     contentType: true,
     body: JSON.stringify({
@@ -419,32 +331,13 @@ async function submitOnce(event, sessionIDValue) {
       description: describe(input),
       input,
       request_id: id,
-      thread_id: sessionId(event) || undefined,
-      session_id: sessionIDValue || undefined,
+      thread_id: clientSessionID,
+      client_session_id: clientSessionID,
       client_name: CLIENT_NAME,
       client_version: CLIENT_VERSION || undefined,
       agent_id: AGENT_ID || undefined,
     }),
   });
-}
-
-async function submit(event) {
-  const hostKey = sessionCacheKey(event);
-  const clientSessionID = sessionId(event) || undefined;
-  let sessionIDValue = await ensureSession(hostKey, clientSessionID);
-  let res = await submitOnce(event, sessionIDValue);
-
-  if (!res.ok && sessionIDValue) {
-    const body = await res.text();
-    if (looksLikeSessionError(res.status, body)) {
-      // Stale session — drop the cache, mint a fresh one, and retry once.
-      await deleteSessionCache(hostKey);
-      sessionIDValue = await ensureSession(hostKey, clientSessionID, true);
-      res = await submitOnce(event, sessionIDValue);
-    } else {
-      throw new Error(`atryum submit failed: ${res.status} ${body}`);
-    }
-  }
   if (!res.ok) {
     throw new Error(`atryum submit failed: ${res.status} ${await res.text()}`);
   }

--- a/examples/shared-agent-hook/atryum-hook.mjs
+++ b/examples/shared-agent-hook/atryum-hook.mjs
@@ -23,6 +23,17 @@
 // session state on disk — no mint call, no cache file, no re-mint/retry — even
 // though it runs as a fresh process per tool event.
 //
+// Subagents (e.g. Claude Code's Task tool spawning Explore/Plan-style workers)
+// share their parent's top-level session/thread id but carry their own
+// host-native subagent instance id on the same hook event. That instance id has
+// nothing to do with Atryum's own `agent_id` agent-binding concept below — it
+// identifies one subagent run within a session, not an authenticated caller —
+// so this hook folds it into `client_session_id` as `<session-id>:<instance-id>`
+// when present, giving each subagent its own get-or-create key distinct from
+// its parent and from sibling subagents. Main-session hook calls, and hosts
+// that never send a subagent instance id, are unaffected: `client_session_id`
+// is just the session id, exactly as before.
+//
 // A session still requires an agent binding (from ATRYUM_AGENT_ID in no-auth
 // mode, or the bearer token in auth mode). When neither is present the caller is
 // anonymous: the server simply resolves no session and evaluates the call
@@ -297,11 +308,36 @@ function rulesEndpointHint(tool) {
   return `atryum: to see the approval rules that apply to this call, GET ${url.toString()} (advisory only; Atryum re-checks policy during the actual gated call).`;
 }
 
-// The host's own session/thread identifier. Sent as the invocation `thread_id`
-// and `client_session_id`; Atryum resolves the internal session with
+// A host-native subagent instance id (e.g. Claude Code's Task-tool workers),
+// present on hook events fired from inside a subagent run. This is NOT
+// Atryum's `agent_id` agent-binding concept (see AGENT_ID above) — it does not
+// identify a caller, it disambiguates one subagent run from its parent
+// session and from sibling subagents. Hosts without a subagent concept
+// (cursor, codex) simply never send this field, so callers see "".
+function hostSubagentInstanceId(event) {
+  return (
+    event.agent_id ||
+    event.agentId ||
+    event.subagent_id ||
+    event.subagentId ||
+    ""
+  );
+}
+
+// Descriptive label for which named subagent produced the event (e.g.
+// "Explore", "Plan"). Observability metadata only — never part of the
+// get-or-create key.
+function hostSubagentType(event) {
+  return event.agent_type || event.agentType || "";
+}
+
+// The host's own session/thread identifier, composed with the host-native
+// subagent instance id (if any) so each subagent gets a distinct
+// `client_session_id`. Sent as the invocation `thread_id` and
+// `client_session_id`; Atryum resolves the internal session with
 // get-or-create keyed by (agent binding, client_session_id).
 function sessionId(event) {
-  return (
+  const base = (
     event.session_id ||
     event.sessionId ||
     event.thread_id ||
@@ -310,6 +346,9 @@ function sessionId(event) {
     event.conversationId ||
     ""
   );
+  const subagentInstanceId = hostSubagentInstanceId(event);
+  if (!subagentInstanceId) return base;
+  return base ? `${base}:${subagentInstanceId}` : subagentInstanceId;
 }
 
 // ---------------------------------------------------------------------------
@@ -322,6 +361,11 @@ async function submit(event) {
   const input = toolInput(event);
   const id = toolUseID(event);
   const clientSessionID = sessionId(event) || undefined;
+  // Descriptive-only: which named subagent (if any) produced this call, tacked
+  // onto client_name for observability. Never part of the get-or-create key —
+  // that's clientSessionID above.
+  const subagentType = hostSubagentType(event);
+  const clientName = subagentType ? `${CLIENT_NAME}:${subagentType}` : CLIENT_NAME;
   const res = await atryumFetch(`${API}/api/v1/external/invocations`, {
     method: "POST",
     contentType: true,
@@ -333,7 +377,7 @@ async function submit(event) {
       request_id: id,
       thread_id: clientSessionID,
       client_session_id: clientSessionID,
-      client_name: CLIENT_NAME,
+      client_name: clientName,
       client_version: CLIENT_VERSION || undefined,
       agent_id: AGENT_ID || undefined,
     }),

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3570,9 +3570,16 @@ func (h *Handler) externalInvocations(w http.ResponseWriter, r *http.Request) {
 }
 
 // externalSessions mints a harness session (POST /api/v1/external/sessions).
-// The harness calls this once at startup and echoes the returned session_id on
-// every subsequent /api/v1/external/invocations call, letting Atryum rebuild the
-// judge's context from prior tool calls in the same session.
+//
+// Deprecated: harnesses should instead send client_session_id on every
+// /api/v1/external/invocations call and let Atryum get-or-create the internal
+// session server-side (keyed by agent binding + client_session_id). This
+// endpoint stays fully functional for explicit-control callers and back-compat.
+//
+// On the old flow the harness calls this once at startup and echoes the
+// returned session_id on every subsequent /api/v1/external/invocations call,
+// letting Atryum rebuild the judge's context from prior tool calls in the same
+// session.
 func (h *Handler) externalSessions(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -626,6 +626,37 @@ func TestExternalSessionMintRejectionReturns400(t *testing.T) {
 	}
 }
 
+// TestExternalSubmitForwardsClientSessionID pins that the submit handler decodes
+// client_session_id from the body and forwards it to Service.Submit (where the
+// server-side get-or-create resolves the session), and that the resolved
+// internal session id is surfaced in the response. This is the field that
+// replaces the old mint-then-echo session_id flow for harnesses.
+func TestExternalSubmitForwardsClientSessionID(t *testing.T) {
+	resolved := "ses_resolved"
+	svc := &stubService{invoke: invocation.InvocationResponse{
+		InvocationID: "inv_123", ToolName: "bash", Status: invocation.StatusPendingApproval,
+		SessionID: &resolved,
+	}}
+	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
+	body := strings.NewReader(`{"source":"amp","tool":"bash","input":{"cmd":"ls"},"client_session_id":"amp-thread-1"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/external/invocations", body)
+	req.Header.Set("content-type", "application/json")
+	req = req.WithContext(auth.WithIdentity(req.Context(), auth.Identity{AgentID: "amp-1"}))
+	w := httptest.NewRecorder()
+
+	h.Routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if svc.submitReq == nil || svc.submitReq.ClientSessionID != "amp-thread-1" {
+		t.Fatalf("submit request client_session_id not forwarded: %+v", svc.submitReq)
+	}
+	if !strings.Contains(w.Body.String(), "ses_resolved") {
+		t.Fatalf("expected resolved session id in response body: %s", w.Body.String())
+	}
+}
+
 type stubAgentsRepo struct {
 	records     []store.AgentRecord
 	err         error

--- a/internal/invocation/model.go
+++ b/internal/invocation/model.go
@@ -114,10 +114,21 @@ type ExternalSubmitRequest struct {
 	RequestID      *string        `json:"request_id,omitempty"`
 	IdempotencyKey *string        `json:"idempotency_key,omitempty"`
 	ThreadID       string         `json:"thread_id,omitempty"`
-	// SessionID is an Atryum-minted session identifier (from POST
+	// ClientSessionID is the harness's own session/thread identifier (the id it
+	// already tracks for its host conversation). When set and no SessionID is
+	// provided, Atryum resolves the internal session with get-or-create
+	// semantics keyed by (agent binding, client_session_id): first sight mints
+	// the internal ses_ row, subsequent calls reuse it, and an expired row under
+	// the same key rolls over to a fresh session. This is the preferred path —
+	// the harness never has to mint, persist, or echo an Atryum session id.
+	ClientSessionID string `json:"client_session_id,omitempty"`
+	// Deprecated: prefer ClientSessionID (server-side get-or-create). SessionID
+	// is an Atryum-minted session identifier (from the deprecated POST
 	// /api/v1/external/sessions). When set, Atryum reconstructs the judge's
 	// session context from the prior invocations it recorded for this session,
-	// rather than trusting a harness-supplied context blob.
+	// rather than trusting a harness-supplied context blob. Still fully
+	// functional; the ownership/expiry/unbound rejections on this path remain
+	// hard.
 	SessionID string `json:"session_id,omitempty"`
 	// SessionContext is the agent's recent session history (human messages and
 	// tool calls/results) passed to the LLM judge. It is populated in-process by
@@ -166,6 +177,11 @@ type InvocationResponse struct {
 	Approval      *Approval `json:"approval"`
 	MatchedRuleID *string   `json:"matched_rule_id,omitempty"`
 	AgentID       *string   `json:"agent_id,omitempty"`
+	// SessionID is the internal Atryum session (ses_...) this invocation was
+	// linked to, if any. Exposed for observability/debugging — clients never
+	// need to send it back. Populated on both the explicit session_id path and
+	// the client_session_id get-or-create path.
+	SessionID *string `json:"session_id,omitempty"`
 	// AgentClientName / AgentClientVersion identify the MCP client software
 	// (e.g. "amp", "cursor", "claude-code") captured from the most recent
 	// `initialize` handshake associated with this AgentID. They describe the

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -161,6 +161,7 @@ type eventRepo interface {
 type sessionStore interface {
 	CreateSession(ctx context.Context, s ExternalSession) error
 	GetSession(ctx context.Context, id string) (ExternalSession, error)
+	GetSessionByAgentAndClientSessionID(ctx context.Context, agentID, clientSessionID string) (ExternalSession, error)
 	TouchSession(ctx context.Context, id string, expiresAt time.Time) error
 }
 
@@ -244,6 +245,13 @@ func (s *Service) SetSessionStore(store sessionStore) {
 }
 
 // CreateSession mints a new harness session bound to agentID and persists it.
+//
+// Deprecated: harnesses should send client_session_id on the submit path and
+// let Atryum get-or-create the internal session (see getOrCreateSession). This
+// endpoint stays fully functional for explicit-control callers and for
+// back-compat with harnesses that still pre-mint. It is also reused internally
+// by getOrCreateSession to mint the ses_ row on first sight of a key.
+//
 // agentID is the authenticated identity when present, else the self-declared id
 // (no-auth mode). A non-empty binding is required: session history is
 // identity-keyed, and an anonymous caller has no stable identity for ownership
@@ -772,6 +780,56 @@ func (s *Service) lookupSessionForAgent(ctx context.Context, sessionID, agentID 
 	return sess, nil
 }
 
+// getOrCreateSession resolves the internal session for a submit that carries a
+// client_session_id but no explicit session_id, keyed by (agentID,
+// clientSessionID). Callers must have already established that sessions are
+// enabled, agentID is a non-empty binding, and clientSessionID is non-empty —
+// the no-binding / empty-client-id cases degrade to history-free evaluation at
+// the call site rather than reaching here.
+//
+// The key is namespaced by the agent binding, so agent B presenting agent A's
+// client_session_id resolves to a different session with no context bleed —
+// the same isolation lookupSessionForAgent enforces by ownership comparison,
+// achieved here by key construction. First sight of a key mints the internal
+// ses_ row (reusing CreateSession's metadata caps / TTL / binding requirement);
+// subsequent calls reuse it. An expired row under the same key intentionally
+// rolls over to a fresh session — judge context resets rather than resurrecting
+// stale history, and the old row stays for audit.
+//
+// clientSessionID is truncated to the same width CreateSession stores so lookup
+// and persistence agree on the key.
+//
+// Concurrency: two racing first-submits for the same key can each miss the
+// lookup and both mint a row. That is acceptable — both are valid audit rows,
+// and GetSessionByAgentAndClientSessionID returns the newest, so subsequent
+// calls converge on one session. We deliberately don't add locking; a uniqueness
+// constraint isn't a clean fit here because expiry rollover legitimately creates
+// multiple rows per key over time.
+func (s *Service) getOrCreateSession(ctx context.Context, agentID, clientSessionID, harness string) (string, error) {
+	if s.sessions == nil {
+		return "", fmt.Errorf("sessions not enabled")
+	}
+	clientSessionID = truncateContextText(strings.TrimSpace(clientSessionID), maxExternalSessionMetadataChars)
+	agentID = strings.TrimSpace(agentID)
+	sess, err := s.sessions.GetSessionByAgentAndClientSessionID(ctx, agentID, clientSessionID)
+	switch {
+	case err == nil:
+		if sess.ExpiresAt.IsZero() || time.Now().UTC().Before(sess.ExpiresAt) {
+			return sess.ID, nil // reuse the live session
+		}
+		// expired: fall through to mint a fresh session (rollover).
+	case errors.Is(err, sql.ErrNoRows):
+		// first sight of this key: fall through to mint.
+	default:
+		return "", err
+	}
+	resp, err := s.CreateSession(ctx, CreateSessionRequest{Harness: harness, ClientSessionID: clientSessionID}, agentID)
+	if err != nil {
+		return "", err
+	}
+	return resp.SessionID, nil
+}
+
 // buildSessionContext reconstructs the judge's session context from the prior
 // invocations Atryum recorded for sessionID (oldest to newest). Each entry
 // carries the tool, the agent-chosen input, the approval disposition, and the
@@ -1226,18 +1284,36 @@ func (s *Service) Submit(ctx context.Context, req ExternalSubmitRequest) (Invoca
 	}
 	agentRec := s.resolveAgentRecord(ctx, agentID)
 
-	// Invocations API session: when the harness presents an Atryum-minted
-	// session_id, verify it belongs to this agent and rebuild the judge's
-	// session context from the prior invocations we recorded for it. Built
-	// before Create() so the current call is excluded from its own context.
-	// This supersedes any harness-supplied SessionContext on the API path.
+	// Invocations API session: resolve the internal session and rebuild the
+	// judge's context from the prior invocations Atryum recorded for it. Built
+	// before Create() so the current call is excluded from its own context, and
+	// it supersedes any harness-supplied SessionContext on the API path.
+	//
+	// Two ways in:
+	//   - Explicit session_id (deprecated, back-compat): verify it belongs to
+	//     this agent; ownership/expiry/unbound rejections stay hard.
+	//   - client_session_id (preferred): get-or-create keyed by (agent binding,
+	//     client_session_id). No binding or empty client_session_id → no session
+	//     → history-free evaluation (same rule as an anonymous caller today).
 	var sessionID string
-	if req.SessionID != "" {
+	switch {
+	case req.SessionID != "":
 		sess, err := s.lookupSessionForAgent(ctx, req.SessionID, agentID)
 		if err != nil {
 			return InvocationResponse{}, err
 		}
 		sessionID = sess.ID
+		sessionContext, sessionContextMessages = s.buildSessionContext(ctx, sessionID)
+	case s.sessions != nil && agentID != "" && strings.TrimSpace(req.ClientSessionID) != "":
+		harness := req.ClientName
+		if harness == "" {
+			harness = source
+		}
+		resolved, err := s.getOrCreateSession(ctx, agentID, req.ClientSessionID, harness)
+		if err != nil {
+			return InvocationResponse{}, err
+		}
+		sessionID = resolved
 		sessionContext, sessionContextMessages = s.buildSessionContext(ctx, sessionID)
 	}
 
@@ -1686,6 +1762,9 @@ func (s *Service) toResponse(inv Invocation) InvocationResponse {
 	resp := InvocationResponse{InvocationID: inv.InvocationID, ServerName: inv.Upstream, ToolName: inv.Tool, Status: inv.Status, Approval: inv.Approval, MatchedRuleID: inv.MatchedRuleID, AgentID: inv.AgentID, RequestID: inv.RequestID, SubmittedAt: inv.SubmittedAt, CompletedAt: inv.CompletedAt}
 	if inv.Summary != nil {
 		resp.Summary = *inv.Summary
+	}
+	if inv.SessionID != nil {
+		resp.SessionID = inv.SessionID
 	}
 	if inv.ClientName != nil {
 		resp.AgentClientName = inv.ClientName

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -996,6 +996,242 @@ func TestSubmitSucceedsWithProperlyBoundSession(t *testing.T) {
 	}
 }
 
+// newGetOrCreateTestService builds a service wired with an AI-evaluation rule
+// and a real session store, returning the evaluator so tests can inspect the
+// judge context. Mirrors the setup in
+// TestSubmitWithSessionReconstructsContextFromPriorInvocations.
+func newGetOrCreateTestService(t *testing.T, db *sql.DB) (*invocation.Service, *evaluateClientStub) {
+	t.Helper()
+	evaluator := &evaluateClientStub{resp: invocation.EvaluateResponse{Verdict: "approved", Reason: "ok"}}
+	defaultAgent := invocation.AgentRecord{ID: "a", VMCUID: "vm-a", VMOrganizationCUID: "org", Charter: "c"}
+	service := invocation.NewService(
+		store.NewInvocationRepo(db), store.NewEventRepo(db), nil, nil, nil, 5*time.Second,
+		rulesStoreStub{rules: []invocation.ApprovalRule{{
+			Action:          invocation.RuleActionAIEvaluation,
+			ModelConfigCUID: "model-ai",
+			Enabled:         true,
+		}}},
+		agentLookupStub{byVMCUID: map[string]invocation.AgentRecord{defaultAgent.VMCUID: defaultAgent}},
+		evaluator,
+		summarySettingsStub{charterFieldKey: "charter", defaultAgentVMCUID: defaultAgent.VMCUID},
+	)
+	service.SetSessionStore(store.NewExternalSessionRepo(db))
+	return service, evaluator
+}
+
+// TestSubmitGetOrCreateCreatesThenReusesSession pins the core get-or-create
+// contract: a submit carrying only client_session_id (no session_id) mints the
+// internal ses_ row on first sight, reuses it on the second call under the same
+// key, reconstructs context from the prior recorded invocation, and returns the
+// resolved session id in the response.
+func TestSubmitGetOrCreateCreatesThenReusesSession(t *testing.T) {
+	db := newSQLiteTestDB(t)
+	service, evaluator := newGetOrCreateTestService(t, db)
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "amp-1"})
+
+	first, err := service.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source: "amp", Tool: "bash", Input: map[string]any{"cmd": "ls"}, ClientSessionID: "thread-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.SessionID == nil || *first.SessionID == "" {
+		t.Fatal("expected resolved session id on first submit response")
+	}
+	if !strings.HasPrefix(*first.SessionID, "ses_") {
+		t.Fatalf("expected internal ses_ id, got %q", *first.SessionID)
+	}
+	if c := evaluator.request().Context; strings.Contains(c, "tool=bash") {
+		t.Fatalf("first call should have no prior history: %q", c)
+	}
+	if _, err := service.RecordExecution(ctx, first.InvocationID, invocation.ExternalExecutionUpdate{
+		ExecutionStatus: "completed", Result: json.RawMessage(`{"stdout":"file.txt"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := service.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source: "amp", Tool: "cat", Input: map[string]any{"path": "file.txt"}, ClientSessionID: "thread-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.SessionID == nil || *second.SessionID != *first.SessionID {
+		t.Fatalf("expected reuse of session %q, got %v", *first.SessionID, second.SessionID)
+	}
+	c := evaluator.request().Context
+	if !strings.Contains(c, `tool=bash disposition=succeeded`) || !strings.Contains(c, `{"stdout":"file.txt"}`) {
+		t.Fatalf("second call missing reconstructed context:\n%s", c)
+	}
+	if strings.Contains(c, "tool=cat") {
+		t.Fatalf("current call leaked into its own context:\n%s", c)
+	}
+
+	// Exactly one internal session row was minted across both calls.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM external_sessions`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one session row, got %d", count)
+	}
+}
+
+// TestSubmitGetOrCreateRollsOverExpiredKey pins that when the live session under
+// a key has expired, a submit rolls over to a fresh internal session and the
+// judge context resets rather than resurrecting the expired session's history.
+func TestSubmitGetOrCreateRollsOverExpiredKey(t *testing.T) {
+	db := newSQLiteTestDB(t)
+	service, evaluator := newGetOrCreateTestService(t, db)
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "amp-1"})
+
+	first, err := service.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source: "amp", Tool: "bash", Input: map[string]any{"cmd": "ls"}, ClientSessionID: "thread-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstID := *first.SessionID
+	if _, err := service.RecordExecution(ctx, first.InvocationID, invocation.ExternalExecutionUpdate{
+		ExecutionStatus: "completed", Result: json.RawMessage(`{"stdout":"file.txt"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Expire every session row under this key.
+	if _, err := db.Exec(`UPDATE external_sessions SET expires_at = ?`, time.Now().UTC().Add(-time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := service.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source: "amp", Tool: "cat", Input: map[string]any{"path": "file.txt"}, ClientSessionID: "thread-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.SessionID == nil || *second.SessionID == firstID {
+		t.Fatalf("expected rollover to a fresh session, still %v", second.SessionID)
+	}
+	if c := evaluator.request().Context; strings.Contains(c, "tool=bash") {
+		t.Fatalf("rolled-over session must start history-free:\n%s", c)
+	}
+
+	// The expired row stays for audit; the rollover adds a second row.
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM external_sessions`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("expected the expired row plus the rolled-over row, got %d", count)
+	}
+}
+
+// TestSubmitGetOrCreateIsolatesAgentsByBinding pins cross-agent isolation: the
+// same client_session_id under two different agent bindings resolves to two
+// different sessions with no context bleed. The key is namespaced by the binding.
+func TestSubmitGetOrCreateIsolatesAgentsByBinding(t *testing.T) {
+	db := newSQLiteTestDB(t)
+	service, evaluator := newGetOrCreateTestService(t, db)
+
+	agentA := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-a"})
+	agentB := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-b"})
+
+	a1, err := service.Submit(agentA, invocation.ExternalSubmitRequest{
+		Source: "amp", Tool: "bash", Input: map[string]any{"cmd": "secret-a"}, ClientSessionID: "shared-thread",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.RecordExecution(agentA, a1.InvocationID, invocation.ExternalExecutionUpdate{
+		ExecutionStatus: "completed", Result: json.RawMessage(`{"stdout":"A-PRIVATE"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	b1, err := service.Submit(agentB, invocation.ExternalSubmitRequest{
+		Source: "amp", Tool: "cat", Input: map[string]any{"path": "x"}, ClientSessionID: "shared-thread",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a1.SessionID == nil || b1.SessionID == nil || *a1.SessionID == *b1.SessionID {
+		t.Fatalf("same client_session_id under different agents must not share a session: %v vs %v", a1.SessionID, b1.SessionID)
+	}
+	if c := evaluator.request().Context; strings.Contains(c, "A-PRIVATE") || strings.Contains(c, "secret-a") {
+		t.Fatalf("agent A's history bled into agent B's context:\n%s", c)
+	}
+}
+
+// TestSubmitGetOrCreateNoSessionWithoutBindingOrClientID pins the two
+// degrade-to-history-free cases: no agent binding, or an empty
+// client_session_id. Neither mints a session; evaluation is history-free.
+func TestSubmitGetOrCreateNoSessionWithoutBindingOrClientID(t *testing.T) {
+	db := newSQLiteTestDB(t)
+	service, _ := newGetOrCreateTestService(t, db)
+
+	// (a) client_session_id present but no binding (fully anonymous caller).
+	anon, err := service.Submit(context.Background(), invocation.ExternalSubmitRequest{
+		Source: "amp", Tool: "bash", Input: map[string]any{"cmd": "ls"}, ClientSessionID: "thread-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if anon.SessionID != nil {
+		t.Fatalf("no binding must yield no session, got %v", *anon.SessionID)
+	}
+
+	// (b) valid binding but empty client_session_id.
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "amp-1"})
+	noID, err := service.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source: "amp", Tool: "bash", Input: map[string]any{"cmd": "ls"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if noID.SessionID != nil {
+		t.Fatalf("empty client_session_id must yield no session, got %v", *noID.SessionID)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM external_sessions`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no sessions created, got %d", count)
+	}
+}
+
+// TestSubmitExplicitSessionIDWinsOverClientSessionID pins that when both a
+// session_id and a client_session_id are supplied, the explicit session_id path
+// wins and no second session is minted from the client_session_id.
+func TestSubmitExplicitSessionIDWinsOverClientSessionID(t *testing.T) {
+	db := newSQLiteTestDB(t)
+	service, _ := newGetOrCreateTestService(t, db)
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "amp-1"})
+
+	sess, err := service.CreateSession(ctx, invocation.CreateSessionRequest{Harness: "amp"}, "amp-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := service.Submit(ctx, invocation.ExternalSubmitRequest{
+		Source: "amp", Tool: "bash", Input: map[string]any{"cmd": "ls"},
+		SessionID: sess.SessionID, ClientSessionID: "thread-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.SessionID == nil || *resp.SessionID != sess.SessionID {
+		t.Fatalf("expected explicit session %q to win, got %v", sess.SessionID, resp.SessionID)
+	}
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM external_sessions`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("client_session_id must not mint a second session on the explicit path, got %d rows", count)
+	}
+}
+
 func TestInvokeAIEvaluationIncludesToolDescriptionInContext(t *testing.T) {
 	toolDescription := "Attach an external URL reference to a Shortcut story. Non-destructive."
 	toolSchema := `{"type":"object","properties":{"story_public_id":{"type":"integer"},"url":{"type":"string"}}}`

--- a/internal/store/db_test.go
+++ b/internal/store/db_test.go
@@ -46,7 +46,7 @@ func TestResolveDBTarget_SelectsSQLiteForSQLiteFileAndBarePaths(t *testing.T) {
 }
 
 func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
-	if len(migrations) != 25 {
+	if len(migrations) != 26 {
 		t.Fatalf("migration count = %d", len(migrations))
 	}
 	want := []struct {
@@ -78,6 +78,7 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 		{23, "023_managed_agent_bindings"},
 		{24, "024_server_endpoint_slug"},
 		{25, "025_external_sessions"},
+		{26, "026_external_sessions_agent_client_index"},
 	}
 	for i, w := range want {
 		if migrations[i].Version != w.version || migrations[i].Name != w.name {
@@ -88,10 +89,10 @@ func TestMigrationRegistryPreservesExistingVersionsAndNames(t *testing.T) {
 
 func TestGetPendingMigrationsUsesRegistryOrder(t *testing.T) {
 	pending := getPendingMigrations(map[int]bool{1: true})
-	if len(pending) != 24 {
+	if len(pending) != 25 {
 		t.Fatalf("pending count = %d", len(pending))
 	}
-	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25}
+	wantVersions := []int{2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26}
 	for i, want := range wantVersions {
 		if pending[i].Version != want {
 			t.Fatalf("pending[%d].Version = %d, want %d", i, pending[i].Version, want)

--- a/internal/store/external_sessions.go
+++ b/internal/store/external_sessions.go
@@ -70,6 +70,33 @@ func (r *ExternalSessionRepo) GetSession(ctx context.Context, id string) (invoca
 	return s, nil
 }
 
+// GetSessionByAgentAndClientSessionID returns the most recently created session
+// matching (agent_id, client_session_id), or sql.ErrNoRows if none exists. This
+// backs the submit-path get-or-create: the (agent binding, client_session_id)
+// pair is the lookup key. Newest-first ordering makes a benign double-create
+// under a first-submit race resolve to the latest row — both rows are valid
+// audit records; see Service.getOrCreateSession.
+func (r *ExternalSessionRepo) GetSessionByAgentAndClientSessionID(ctx context.Context, agentID, clientSessionID string) (invocation.ExternalSession, error) {
+	query, args, err := r.sb.
+		Select("id", "agent_id", "harness", "client_session_id", "created_at", "last_seen_at", "expires_at").
+		From("external_sessions").
+		Where(sq.Eq{"agent_id": agentID, "client_session_id": clientSessionID}).
+		OrderBy("created_at DESC").
+		Limit(1).
+		ToSql()
+	if err != nil {
+		return invocation.ExternalSession{}, err
+	}
+	var s invocation.ExternalSession
+	err = r.db.QueryRowContext(ctx, query, args...).Scan(
+		&s.ID, &s.AgentID, &s.Harness, &s.ClientSessionID, &s.CreatedAt, &s.LastSeenAt, &s.ExpiresAt,
+	)
+	if err != nil {
+		return invocation.ExternalSession{}, err
+	}
+	return s, nil
+}
+
 // TouchSession updates last_seen_at to now and slides expires_at to the given
 // time. Best-effort; callers may ignore the error.
 func (r *ExternalSessionRepo) TouchSession(ctx context.Context, id string, expiresAt time.Time) error {

--- a/internal/store/migrations/026_external_sessions_agent_client_index.go
+++ b/internal/store/migrations/026_external_sessions_agent_client_index.go
@@ -1,0 +1,16 @@
+package migrations
+
+func migration026() Definition {
+	return Definition{
+		Version: 26,
+		Name:    "026_external_sessions_agent_client_index",
+		Steps: []Step{
+			// Backs Service.getOrCreateSession's lookup on (agent binding,
+			// client_session_id). CREATE INDEX IF NOT EXISTS is idempotent, so
+			// this step is safe to re-run under a shifted migration number (see
+			// AddColumnIfMissing's doc comment for why that matters here).
+			Raw("index external_sessions by (agent_id, client_session_id)",
+				`CREATE INDEX IF NOT EXISTS idx_external_sessions_agent_client ON external_sessions (agent_id, client_session_id)`),
+		},
+	}
+}

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -165,5 +165,6 @@ func All() []Definition {
 		migration023(),
 		migration024(),
 		migration025(),
+		migration026(),
 	}
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -45,8 +45,8 @@ func TestInitDB_FreshDatabase(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 25 {
-		t.Fatalf("expected 25 migrations, got %d", count)
+	if count != 26 {
+		t.Fatalf("expected 26 migrations, got %d", count)
 	}
 
 	// Verify all tables exist
@@ -74,8 +74,8 @@ func TestInitDB_Idempotent(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 25 {
-		t.Fatalf("expected 25 migrations after double init, got %d", count)
+	if count != 26 {
+		t.Fatalf("expected 26 migrations after double init, got %d", count)
 	}
 }
 
@@ -1044,8 +1044,8 @@ func TestInitDBToleratesRenumberedMigrationStamps(t *testing.T) {
 	if err := db.QueryRow(`SELECT COUNT(*) FROM schema_migrations`).Scan(&count); err != nil {
 		t.Fatalf("count migrations: %v", err)
 	}
-	if count != 25 {
-		t.Fatalf("expected 25 migrations recorded, got %d", count)
+	if count != 26 {
+		t.Fatalf("expected 26 migrations recorded, got %d", count)
 	}
 
 	// The columns/tables the renumbered migrations add must still be


### PR DESCRIPTION
## Problem

Every harness integration (amp, pi, the shared Claude Code/Cursor/Codex hook) had to manage a session's lifecycle itself: mint a session up front, persist the session id somewhere that survives across calls, send it on every tool call, and detect and recover from expired-session errors by minting again. That's real weight — the shared hook runs as a fresh process per tool event, so "persist" meant an on-disk cache file just to remember its own session id. It was also implemented three separate times, which drifted: a review pass on the original session feature (#126) caught one integration's session-creation call missing its own auth header, and separately drew the feedback that some harnesses simply hadn't been updated to the new model at all.

## What this PR does

Session management moves to the server. A harness now just sends its own session/thread id (something every one of them already has, for its own bookkeeping) alongside its identity on every tool call. Atryum resolves or creates the matching session on the fly, keyed by the combination of the caller's identity and that id. Nothing needs to be minted, cached, or retried on the client side — the three integrations lose that logic entirely, including the hook's on-disk cache file.

The trust model is unchanged: the judge's context still only ever comes from tool calls Atryum recorded itself, never from anything a harness asserts. Keying by identity + the harness's own id preserves isolation the same way it worked before — a different identity presenting the same id gets a completely separate session, with no context crossing between them.

## Nuance and edge cases surfaced along the way

- **Session churn as an evasion path.** A harness could already, before and after this change, avoid ever building up judge history by simply not reusing a session id (or not sending one at all) — every call then gets judged with no prior context. This PR doesn't introduce or close that; it's a pre-existing property of the trust model that's now written up as a separate, dedicated design question (worth its own review, since closing it well means changing what "session" is scoped to).
- **Concurrent instances of the same harness on one host.** As long as each running instance has its own session/thread id from the host (which is the normal case — separate conversations, separate threads), they naturally isolate from each other under the same identity. If a host ever reused an id across genuinely unrelated concurrent tasks, those tasks would be merged into one judge context — a property of the host, not something this design can see or prevent.
- **Subagents.** Claude Code's Task-tool subagents (Explore, Plan, etc.) share their parent conversation's session id, but each subagent invocation carries its own instance id on the same event. Without accounting for that, every subagent spawned from one conversation would have collapsed into a single shared session — noisy at best, cross-contaminating at worst. This PR folds the subagent's own instance id in alongside the parent's, so each subagent isolates cleanly from its parent and from its siblings, the same as if they were separate processes.
- **A session still requires a real identity.** Anonymous callers get no session and are evaluated without history, same graceful fallback as always — this just changes who decides that (the server, instead of the client refusing to mint).

## Deliberately out of scope

- Actually preventing session-churn evasion (flagged above as its own design question).
- Removing the old explicit session-creation endpoint — it's marked deprecated but still fully supported for any external caller not yet migrated.
- Deliberately sharing one judge context across multiple cooperating agents/subagents that want to see each other's work — today isolation is the only mode; shared-by-design context would need its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
