### PR TITLE
[SC-17293] Add a copy button for "mcp endpoint" field

### DIFF
--- a/ui/src/pages/Servers.tsx
+++ b/ui/src/pages/Servers.tsx
@@ -16,7 +16,10 @@ import {
   FormLabel,
   HStack,
   Icon,
+  IconButton,
   Input,
+  InputGroup,
+  InputRightElement,
   NumberDecrementStepper,
   NumberIncrementStepper,
   NumberInput,
@@ -32,10 +35,16 @@ import {
   Textarea,
   Th,
   Thead,
+  Tooltip,
   Tr,
+  useClipboard,
   VStack,
 } from '@chakra-ui/react';
-import { CircleStackIcon } from '@heroicons/react/24/outline';
+import {
+  CheckIcon,
+  CircleStackIcon,
+  ClipboardDocumentIcon,
+} from '@heroicons/react/24/outline';
 
 import { ContentPageTitle } from '../components/Layout';
 import {
@@ -299,6 +308,9 @@ const Servers: React.FC = () => {
     testServer.isLoading;
 
   const currentServer = servers.find((s) => s.name === selectedName);
+  const { hasCopied, onCopy } = useClipboard(
+    currentServer ? endpointLabel(currentServer) : '',
+  );
 
   return (
     <Box h="full" display="flex" flexDirection="column">
@@ -474,12 +486,34 @@ const Servers: React.FC = () => {
                   {currentServer && endpointLabel(currentServer) && (
                     <FormControl>
                       <FormLabel fontSize="sm">MCP Endpoint</FormLabel>
-                      <Input
-                        size="sm"
-                        fontFamily="mono"
-                        value={endpointLabel(currentServer)}
-                        isReadOnly
-                      />
+                      <InputGroup size="sm">
+                        <Input
+                          fontFamily="mono"
+                          value={endpointLabel(currentServer)}
+                          isReadOnly
+                          pr="2rem"
+                        />
+                        <InputRightElement>
+                          <Tooltip
+                            label={hasCopied ? 'Copied!' : 'Copy'}
+                            closeOnClick={false}
+                          >
+                            <IconButton
+                              aria-label={hasCopied ? 'Copied' : 'Copy MCP endpoint'}
+                              icon={
+                                <Icon
+                                  as={hasCopied ? CheckIcon : ClipboardDocumentIcon}
+                                  boxSize={4}
+                                />
+                              }
+                              variant="ghost"
+                              size="sm"
+                              colorScheme={hasCopied ? 'green' : undefined}
+                              onClick={onCopy}
+                            />
+                          </Tooltip>
+                        </InputRightElement>
+                      </InputGroup>
                     </FormControl>
                   )}
 


### PR DESCRIPTION
## What and why?

Adds a copy-to-clipboard button to the read-only **MCP Endpoint** field on the Servers page, so users can grab a server's endpoint URL in one click instead of selecting the text by hand. 

<img width="324" height="100" alt="Screenshot 2026-07-23 at 17 20 32" src="https://github.com/user-attachments/assets/2fb3da11-1caa-4ab5-a8f4-3c1895534087" />


## How to test

**Automated**
- `cd ui && npx tsc --noEmit` — passes (no test harness exists for this page).

**Manual**
1. Run atryum locally (`just run`) and the UI dev server (`just ui-dev`, http://localhost:5174).
2. Go to **Servers** and select or create an HTTP server (Base URL e.g. `https://example.com/mcp`).
3. Confirm a copy icon appears at the right edge of the **MCP Endpoint** field.
4. Click it → icon turns to a green check, tooltip reads "Copied!"; paste elsewhere and confirm it matches the endpoint URL shown.
5. Confirm the field is still read-only and the button is absent for servers with no endpoint.

## What needs special review

- `useClipboard` is called unconditionally at the top of the component with a `''` fallback when no server is selected (rules-of-hooks) — the button itself only renders inside the endpoint-gated block, so the empty value is never reachable via the UI.
- `navigator.clipboard` requires a secure context; `useClipboard` handles the write, and localhost/https both qualify.

## Dependencies / breaking changes / deployment

None. No new dependencies (Chakra `useClipboard`, `Tooltip`, `InputGroup` and the heroicons are already in use), no companion PR, no migrations, no env vars.

---
Closes #148 
