### PR TITLE
feat: agent charter preview (+ vm_cuid, agent-save enabled fix)

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -380,6 +380,7 @@ type AdminAgent struct {
 	SyncedAt            time.Time                  `json:"synced_at"`
 	Enabled             bool                       `json:"enabled"`
 	Charter             string                     `json:"charter,omitempty"`
+	VMCUID              string                     `json:"vm_cuid,omitempty"`
 	// Synced is true when this agent originated from a ValidMind sync
 	// (vm_organization_cuid is non-empty). Synced agents cannot be deleted
 	// manually — they are removed by re-syncing with a different org/record-type.
@@ -387,7 +388,7 @@ type AdminAgent struct {
 }
 
 type AdminAgentInput struct {
-	Enabled                        bool                        `json:"enabled"`
+	Enabled                        *bool                       `json:"enabled,omitempty"`
 	AgentIDs                       []string                    `json:"agent_ids,omitempty"`
 	Name                           string                      `json:"name,omitempty"`
 	Description                    string                      `json:"description,omitempty"`
@@ -446,6 +447,7 @@ func toAdminAgent(a store.AgentRecord) AdminAgent {
 		SyncedAt:    a.SyncedAt,
 		Enabled:     a.Enabled,
 		Charter:     a.Charter,
+		VMCUID:      a.VMCUID,
 		Synced:      a.VMOrganizationCUID != "",
 	}
 }
@@ -3008,6 +3010,14 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// GET /api/v1/admin/agents/:id/charter-preview — assemble the charter hierarchy
+	if strings.HasSuffix(trimmed, "/charter-preview") {
+		id := strings.TrimSuffix(trimmed, "/charter-preview")
+		id = strings.Trim(id, "/")
+		h.adminAgentCharterPreview(w, r, id)
+		return
+	}
+
 	// /api/v1/admin/agents/:id — GET / PATCH / DELETE
 	id := trimmed
 	switch r.Method {
@@ -3072,14 +3082,16 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 				h.releaseNewManagedAgentClaims(r.Context(), id, beforeBindings, bindings)
 			}
 		}
-		if err := h.agentsRepo.UpdateEnabled(r.Context(), id, req.Enabled); err != nil {
-			cleanupNewClaims()
-			status := http.StatusInternalServerError
-			if err == sql.ErrNoRows {
-				status = http.StatusNotFound
+		if req.Enabled != nil {
+			if err := h.agentsRepo.UpdateEnabled(r.Context(), id, *req.Enabled); err != nil {
+				cleanupNewClaims()
+				status := http.StatusInternalServerError
+				if err == sql.ErrNoRows {
+					status = http.StatusNotFound
+				}
+				writeError(w, status, "agent not found")
+				return
 			}
-			writeError(w, status, "agent not found")
-			return
 		}
 		if req.AgentIDs != nil {
 			idsJSON, err := json.Marshal(req.AgentIDs)
@@ -3151,6 +3163,68 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
+}
+
+// adminAgentCharterPreview assembles the per-agent charter hierarchy. For synced
+// agents (with a VM cuid) it delegates to the ValidMind backend; for local
+// agents it returns the agent's own stored charter.
+func (h *Handler) adminAgentCharterPreview(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if id == "" {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	agent, err := h.agentsRepo.Get(r.Context(), id)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if err == sql.ErrNoRows {
+			status = http.StatusNotFound
+		}
+		writeError(w, status, "agent not found")
+		return
+	}
+
+	var charterFieldKey string
+	if h.agentSyncSettingsRepo != nil {
+		settings, _ := h.agentSyncSettingsRepo.Get(r.Context())
+		charterFieldKey = settings.CharterFieldKey
+	}
+
+	if agent.VMCUID != "" && h.backendClient != nil {
+		result, err := h.backendClient.CharterPreview(r.Context(), agent.VMCUID, charterFieldKey, agent.VMOrganizationCUID)
+		if err != nil {
+			log.Printf("charter-preview: backend call failed for agent %s: %v", id, err)
+			writeError(w, http.StatusBadGateway, "failed to assemble charter from ValidMind backend")
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+		return
+	}
+
+	// Local agent (or no backend client): show the agent's own stored charter.
+	if agent.Charter != "" {
+		header := agent.VMName
+		if header == "" {
+			header = "This agent"
+		}
+		writeJSON(w, http.StatusOK, backendclient.CharterPreviewResult{
+			Segments: []backendclient.CharterSegment{{
+				Kind:   "agent",
+				Header: header,
+				Text:   agent.Charter,
+			}},
+			Combined: agent.Charter,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, backendclient.CharterPreviewResult{
+		Segments: []backendclient.CharterSegment{},
+		Combined: "",
+	})
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -3194,7 +3194,12 @@ func (h *Handler) adminAgentCharterPreview(w http.ResponseWriter, r *http.Reques
 		charterFieldKey = settings.CharterFieldKey
 	}
 
-	if agent.VMCUID != "" && h.backendClient != nil {
+	// VMOrganizationCUID (mirrored in AdminAgent.Synced) is the correct "is this
+	// a real ValidMind-synced agent" signal. VMCUID alone is NOT — manually
+	// created agents get VMCUID reused as their local id (see the create
+	// handler above) while VMOrganizationCUID stays empty, precisely so a fake
+	// VMCUID is never mistaken for a real ValidMind inventory-model cuid here.
+	if agent.VMOrganizationCUID != "" && h.backendClient != nil {
 		result, err := h.backendClient.CharterPreview(r.Context(), agent.VMCUID, charterFieldKey, agent.VMOrganizationCUID)
 		if err != nil {
 			log.Printf("charter-preview: backend call failed for agent %s: %v", id, err)

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -17,6 +17,7 @@ const connectionPath = atryumAPIPath + "/connection"
 const agentsPath = atryumAPIPath + "/agents"
 const modelConfigsPath = atryumAPIPath + "/model-configs"
 const evaluatePath = atryumAPIPath + "/evaluate"
+const charterPreviewPath = atryumAPIPath + "/charter-preview"
 const summarizeInvocationPath = atryumAPIPath + "/summarize-invocation"
 const organizationsPath = atryumAPIPath + "/organizations"
 const primaryRecordTypesPath = atryumAPIPath + "/primary-record-types"
@@ -400,6 +401,68 @@ func (c *Client) EvaluateToolCall(ctx context.Context, req EvaluateRequest) (Eva
 		return EvaluateResponse{}, fmt.Errorf("decode evaluate response: %w", err)
 	}
 	return payload, nil
+}
+
+// CharterPreviewRequest is sent to the VM backend to assemble the charter
+// hierarchy for a single synced agent.
+type CharterPreviewRequest struct {
+	AgentVMCUID     string `json:"agent_vm_cuid"`
+	CharterFieldKey string `json:"charter_field_key"`
+}
+
+// CharterSegment is a single labelled piece of the assembled charter hierarchy.
+type CharterSegment struct {
+	Kind   string `json:"kind"`
+	Header string `json:"header"`
+	Text   string `json:"text"`
+}
+
+// CharterPreviewResult is the response returned by the charter-preview endpoint.
+type CharterPreviewResult struct {
+	Segments []CharterSegment `json:"segments"`
+	Combined string           `json:"combined"`
+}
+
+// CharterPreview calls the VM backend's charter-preview endpoint and returns the
+// assembled charter hierarchy for the given synced agent.
+func (c *Client) CharterPreview(ctx context.Context, agentVMCUID, charterFieldKey, orgCUID string) (*CharterPreviewResult, error) {
+	body, err := json.Marshal(CharterPreviewRequest{
+		AgentVMCUID:     agentVMCUID,
+		CharterFieldKey: charterFieldKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal charter-preview request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(
+		ctx, http.MethodPost, c.baseURL+charterPreviewPath,
+		strings.NewReader(string(body)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build charter-preview request: %w", err)
+	}
+	c.setAuthHeaders(httpReq)
+	if orgCUID != "" {
+		httpReq.Header.Set("X-Org-CUID", orgCUID)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("call charter-preview endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("charter-preview endpoint returned %s", resp.Status)
+	}
+
+	var payload CharterPreviewResult
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decode charter-preview response: %w", err)
+	}
+	return &payload, nil
 }
 
 // SummarizeInvocationRequest is sent to the VM backend to ask an LLM to

--- a/ui/src/api/AtryumAPI.ts
+++ b/ui/src/api/AtryumAPI.ts
@@ -420,6 +420,19 @@ export interface Agent {
   synced: boolean;
   /** Governing text used by local LLM-as-judge evaluation. Only editable for non-synced agents. */
   charter?: string;
+  /** ValidMind inventory model cuid; present only for synced agents. */
+  vm_cuid?: string;
+}
+
+export interface CharterSegment {
+  kind: string;
+  header: string;
+  text: string;
+}
+
+export interface CharterPreview {
+  segments: CharterSegment[];
+  combined: string;
 }
 
 export interface AgentCreateInput {
@@ -503,6 +516,13 @@ export const agentsApi = {
 
   sync: async (): Promise<void> => {
     await atryumApi.post('/api/v1/admin/agents/sync');
+  },
+
+  getAgentCharterPreview: async (id: string): Promise<CharterPreview> => {
+    const { data } = await atryumApi.get(
+      `/api/v1/admin/agents/${encodeURIComponent(id)}/charter-preview`,
+    );
+    return data;
   },
 
   managedAgentAccounts: async (): Promise<{ items: ClaudeManagedAgentAccount[] }> => {

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -281,6 +281,12 @@ const EditAgentModal: React.FC<EditAgentModalProps> = ({ agent, isOpen, onClose 
 	const updateMutation = useUpdateAgent();
 	const deleteMutation = useDeleteAgent();
 	const { data: agentsData } = useAgents();
+	const previewDisclosure = useDisclosure();
+	const charterPreviewQuery = useQuery(
+		['agent-charter-preview', agent.cuid],
+		() => agentsApi.getAgentCharterPreview(agent.cuid),
+		{ enabled: previewDisclosure.isOpen, refetchOnWindowFocus: false, retry: false },
+	);
 	const accountsQuery = useQuery(
     ['claude-managed-agent-accounts'],
     () => agentsApi.managedAgentAccounts(),
@@ -365,6 +371,7 @@ const EditAgentModal: React.FC<EditAgentModalProps> = ({ agent, isOpen, onClose 
   const isBusy = updateMutation.isLoading || deleteMutation.isLoading;
 
   return (
+    <>
     <Modal size="xl" isCentered isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
@@ -414,14 +421,19 @@ const EditAgentModal: React.FC<EditAgentModalProps> = ({ agent, isOpen, onClose 
             <Divider />
 
             <FormControl>
-              <FormLabel fontSize="sm">
-                Charter
-                {agent.synced && (
-                  <Text as="span" fontSize="xs" color="text.subtle" fontWeight="normal" ml={2}>
-                    (read-only — managed by ValidMind sync)
-                  </Text>
-                )}
-              </FormLabel>
+              <Flex align="center" justify="space-between">
+                <FormLabel fontSize="sm" mb={0}>
+                  Charter
+                  {agent.synced && (
+                    <Text as="span" fontSize="xs" color="text.subtle" fontWeight="normal" ml={2}>
+                      (read-only — managed by ValidMind sync)
+                    </Text>
+                  )}
+                </FormLabel>
+                <Button size="xs" variant="outline" onClick={previewDisclosure.onOpen}>
+                  Preview charter
+                </Button>
+              </Flex>
               <Textarea
                 size="sm"
                 value={charter}
@@ -625,6 +637,62 @@ const EditAgentModal: React.FC<EditAgentModalProps> = ({ agent, isOpen, onClose 
         </ModalFooter>
       </ModalContent>
     </Modal>
+
+    <Modal size="xl" isCentered isOpen={previewDisclosure.isOpen} onClose={previewDisclosure.onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Charter preview — {agent.name}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {charterPreviewQuery.isLoading ? (
+            <Flex align="center" justify="center" py={8}>
+              <Spinner size="md" />
+            </Flex>
+          ) : charterPreviewQuery.isError ? (
+            <Alert status="error" borderRadius="md" py={2}>
+              <AlertIcon />
+              <AlertDescription fontSize="sm">
+                {apiErrorMessage(charterPreviewQuery.error, 'Failed to load charter preview.')}
+              </AlertDescription>
+            </Alert>
+          ) : !charterPreviewQuery.data || charterPreviewQuery.data.segments.length === 0 ? (
+            <Text fontSize="sm" color="text.subtle" py={4}>
+              No charter configured for this agent.
+            </Text>
+          ) : (
+            <VStack align="stretch" gap={4}>
+              {charterPreviewQuery.data.segments.map((segment, idx) => (
+                <Box key={`${segment.header}-${idx}`}>
+                  <HStack mb={1}>
+                    <Badge colorScheme="purple" textTransform="none">
+                      {segment.header || 'Charter'}
+                    </Badge>
+                  </HStack>
+                  <Box
+                    as="pre"
+                    fontFamily="mono"
+                    fontSize="xs"
+                    whiteSpace="pre-wrap"
+                    borderWidth="1px"
+                    borderRadius="md"
+                    p={3}
+                    bg="bg.subtle"
+                  >
+                    {segment.text}
+                  </Box>
+                </Box>
+              ))}
+            </VStack>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" size="sm" onClick={previewDisclosure.onClose}>
+            Close
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
Adds a charter preview for agents in Atryum's admin UI. For **synced** agents Atryum calls the ValidMind backend to assemble the charter hierarchy; for **local** agents it shows the agent's own stored charter. Hierarchy only (no global charters — FOSS-safe). Fast-tracked off `main`.

Part of a coordinated 3-repo change: backend (validmind/backend#3397) + frontend + **atryum** (this).

## Changes
- `internal/api/handlers.go` — `GET /api/v1/admin/agents/{id}/charter-preview` (backend call for synced agents, local fallback otherwise); `vm_cuid` on `AdminAgent`.
- `internal/backend/client.go` — `CharterPreview(...)` client method (`/api/atryum/unstable/charter-preview`).
- `ui/` — Preview charter button + modal on the agents page.

## Bug fix (bundled)
- `AdminAgentInput.Enabled` was a plain `bool` and `UpdateEnabled` ran unconditionally, so saving an agent without an `enabled` field disabled it. Now `*bool`, updated only when present. Happy to split into its own PR if preferred.

## Testing
- `go build` / `go vet` / `go test ./internal/api/... ./internal/backend/...` pass; `ui` `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)