### PR TITLE
Rename invocation review API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ admin_claim_value = true
 
 The admin client must be a browser-safe public SPA client that supports authorization code with PKCE. For Auth0, create a Single Page Application client; allow `http://localhost:5174/ui/auth/callback` for Vite development and `http://localhost:8080/ui/auth/callback` for the embedded UI, and allow the corresponding `http://localhost:5174/ui/` and `http://localhost:8080/ui/` logout URLs. For local Keycloak, run `KC_URL=http://localhost:8089 ./keycloak/setup-realm.sh`; it provisions the `atryum-admin` public client, its callback and post-logout redirect URLs, and an `atryum_admin=true` access-token claim.
 
-The frontend fetches `/api/v1/admin-auth/config`, shows a sign-in screen, redirects through the selected provider, attaches `Authorization: Bearer <access_token>` to admin API calls, and uses authenticated fetch-based SSE for `/api/v1/admin/invocations/stream`. With one configured provider, the screen skips the provider selector; with several, it shows an identity-provider selector. It attempts silent token refresh before retrying an expiry-related `401` once. Signing out uses the provider's autodiscovered OIDC `end_session_endpoint` and returns to `/ui/`; providers without a usable end-session endpoint fall back to local logout. Browser console debug logs are emitted for refresh and logout attempts and outcomes under the `[admin-auth]` prefix; access token values are never logged.
+The frontend fetches `/api/v1/auth/config`, shows a sign-in screen, redirects through the selected provider, attaches `Authorization: Bearer <access_token>` to protected API calls, and uses authenticated fetch-based SSE for `/api/v1/review/invocations/stream`. With one configured provider, the screen skips the provider selector; with several, it shows an identity-provider selector. It attempts silent token refresh before retrying an expiry-related `401` once. Signing out uses the provider's autodiscovered OIDC `end_session_endpoint` and returns to `/ui/`; providers without a usable end-session endpoint fall back to local logout. Browser console debug logs are emitted for refresh and logout attempts and outcomes under the `[admin-auth]` prefix; access token values are never logged.
 
 ## HTTP surface
 
@@ -137,9 +137,12 @@ Public (auth-protected when `[[auth]]` is configured):
 - `GET /api/v1/agent/rules` — agent-facing rule introspection.
 - `GET /healthz` — liveness.
 
+Review workflow:
+
+- `/api/v1/review/invocations`, `/{id}`, `/{id}/events`, `/{id}/approve`, `/{id}/deny`, `/stream` (SSE)
+
 Admin (UI and operators):
 
-- `/api/v1/admin/invocations`, `/{id}`, `/{id}/events`, `/{id}/approve`, `/{id}/deny`, `/stream` (SSE)
 - `/api/v1/admin/servers`, `/{name}`, `/{name}/test`, `/{name}/connect`, `/{name}/connect/status`
 - `/api/v1/admin/rules`, `/{id}` (including reorder/move)
 - `/api/v1/admin/agents`, `/{id}`
@@ -147,7 +150,7 @@ Admin (UI and operators):
 - `/api/v1/admin/managed-agents/accounts`, `/managed-agents/agents` — discover configured Anthropic accounts and Claude agents for UI linking
 - `/api/v1/admin/managed-agents/sessions` — manually register a Claude Managed Agents session for the events bridge to watch; kept as a debugging escape hatch
 - `/api/v1/mcp/oauth/callback` — public OAuth callback for upstream MCP server connect flows
-- `/api/v1/admin-auth/config` — public, non-secret OIDC metadata for the admin UI login screen
+- `/api/v1/auth/config` — public, non-secret OIDC metadata for the admin UI login screen
 
 ## Frontend
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -373,7 +373,7 @@ func TestUnprotectedRoutesRemainOpenWhenAuthEnabled(t *testing.T) {
 		want   int
 	}{
 		{http.MethodGet, "/healthz", "", http.StatusOK},
-		{http.MethodGet, "/api/v1/admin/invocations", "", http.StatusOK},
+		{http.MethodGet, "/api/v1/review/invocations", "", http.StatusOK},
 		{http.MethodGet, "/ui/", "", http.StatusOK},
 	}
 	for _, c := range cases {
@@ -404,7 +404,7 @@ func TestAdminRoutesRequireAdminTokenWhenAdminAuthEnabled(t *testing.T) {
 	})
 	h := newAuthedHandler(t, &stubService{}, rig)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {
@@ -413,7 +413,7 @@ func TestAdminRoutesRequireAdminTokenWhenAdminAuthEnabled(t *testing.T) {
 
 	claims := defaultClaims()
 	tok := rig.sign(t, claims)
-	req = httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req.Header.Set("Authorization", "Bearer "+tok)
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -423,7 +423,7 @@ func TestAdminRoutesRequireAdminTokenWhenAdminAuthEnabled(t *testing.T) {
 
 	claims["atryum_admin"] = true
 	tok = rig.sign(t, claims)
-	req = httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req.Header.Set("Authorization", "Bearer "+tok)
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -440,7 +440,7 @@ func TestAdminAuthConfigEndpointReturnsSafeProviderMetadata(t *testing.T) {
 		c.AdminScopes = "openid profile email"
 	})
 	h := newAuthedHandler(t, &stubService{}, rig)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-auth/config", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/config", nil)
 	req.Host = "atryum.example"
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -494,7 +494,7 @@ func TestAdminAuthConfigProviderIDsAreUniqueForSharedClientID(t *testing.T) {
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 	h.SetAuthValidator(v)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-auth/config", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/config", nil)
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -509,6 +509,22 @@ func TestAdminAuthConfigProviderIDsAreUniqueForSharedClientID(t *testing.T) {
 	}
 	if resp.Providers[0].ID == resp.Providers[1].ID {
 		t.Fatalf("expected unique provider IDs, got %q", resp.Providers[0].ID)
+	}
+}
+
+func TestRenamedRoutesDoNotKeepLegacyAliases(t *testing.T) {
+	h := newAuthedHandler(t, &stubService{}, newAuthTestRig(t))
+	for _, path := range []string{
+		"/api/v1/admin/invocations",
+		"/api/v1/admin/invocations/inv_123",
+		"/api/v1/admin-auth/config",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("GET %s: status = %d, want 404", path, w.Code)
+		}
 	}
 }
 

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -903,10 +903,10 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/mcp", h.mcpRootNotFound)
 	mux.Handle("/mcp/", mcpHandler)
 	mux.Handle("/api/v1/invocations", h.agentRuntimeHandler(http.HandlerFunc(h.invocations)))
-	mux.HandleFunc("/api/v1/admin-auth/config", h.adminAuthConfig)
-	mux.Handle("/api/v1/admin/invocations", admin(h.adminInvocations))
-	mux.Handle("/api/v1/admin/invocations/stream", admin(h.adminInvocationStream))
-	mux.Handle("/api/v1/admin/invocations/", admin(h.adminInvocationDetail))
+	mux.HandleFunc("/api/v1/auth/config", h.adminAuthConfig)
+	mux.Handle("/api/v1/review/invocations", admin(h.reviewInvocations))
+	mux.Handle("/api/v1/review/invocations/stream", admin(h.reviewInvocationStream))
+	mux.Handle("/api/v1/review/invocations/", admin(h.reviewInvocationDetail))
 	mux.Handle("/api/v1/admin/servers", admin(h.adminServers))
 	mux.Handle("/api/v1/admin/servers/", admin(h.adminServerDetail))
 	mux.Handle("/api/v1/admin/rules", admin(h.adminRules))
@@ -1934,7 +1934,7 @@ func (h *Handler) appendRulesContextToToolResult(ctx context.Context, result any
 	return m
 }
 
-func (h *Handler) adminInvocations(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) reviewInvocations(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -1955,7 +1955,7 @@ func (h *Handler) adminInvocations(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (h *Handler) adminInvocationStream(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) reviewInvocationStream(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeError(w, http.StatusInternalServerError, "streaming unsupported")
@@ -1996,8 +1996,8 @@ func (h *Handler) adminInvocationStream(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) {
-	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/invocations/")
+func (h *Handler) reviewInvocationDetail(w http.ResponseWriter, r *http.Request) {
+	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/review/invocations/")
 	trimmed = strings.Trim(trimmed, "/")
 	if trimmed == "" {
 		writeError(w, http.StatusNotFound, "not found")
@@ -2144,13 +2144,13 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 }
 
 // SummarizeInvocationRequest is the JSON body accepted by
-// POST /api/v1/admin/invocations/{id}/summarize.
+// POST /api/v1/review/invocations/{id}/summarize.
 type SummarizeInvocationRequest struct {
 	ModelConfigCUID string `json:"model_config_cuid"`
 }
 
 // SummarizeInvocationResponse is the JSON shape returned by
-// POST /api/v1/admin/invocations/{id}/summarize.
+// POST /api/v1/review/invocations/{id}/summarize.
 type SummarizeInvocationResponse struct {
 	InvocationID string `json:"invocation_id"`
 	Summary      string `json:"summary"`

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -861,7 +861,7 @@ func TestSummarizeInvocationPersistsBackendSummary(t *testing.T) {
 	summarizer := &stubSummarizer{resp: backendclient.SummarizeInvocationResponse{Summary: "Read /tmp/a and returned hello."}}
 	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 	h.summarizeClient = summarizer
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/invocations/inv_123/summarize", strings.NewReader(`{"model_config_cuid":" model_abc "}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/review/invocations/inv_123/summarize", strings.NewReader(`{"model_config_cuid":" model_abc "}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -911,7 +911,7 @@ func TestSummarizeInvocationUsesSettingsModelConfigWhenRequestBodyEmpty(t *testi
 	summarizer := &stubSummarizer{resp: backendclient.SummarizeInvocationResponse{Summary: "Read /tmp/a."}}
 	h := NewHandler(svc, stubServerService{}, nil, nil, nil, settings, nil, nil, nil, nil)
 	h.summarizeClient = summarizer
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/invocations/inv_123/summarize", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/review/invocations/inv_123/summarize", nil)
 	w := httptest.NewRecorder()
 
 	h.Routes().ServeHTTP(w, req)
@@ -2024,7 +2024,7 @@ func TestAdminInvocationsResponsesIncludeServerToolAndInput(t *testing.T) {
 	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	t.Run("list", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 		w := httptest.NewRecorder()
 		h.Routes().ServeHTTP(w, req)
 		if !strings.Contains(w.Body.String(), `"server_name":"demo-server"`) {
@@ -2039,7 +2039,7 @@ func TestAdminInvocationsResponsesIncludeServerToolAndInput(t *testing.T) {
 	})
 
 	t.Run("detail", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations/inv_123", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations/inv_123", nil)
 		w := httptest.NewRecorder()
 		h.Routes().ServeHTTP(w, req)
 		if !strings.Contains(w.Body.String(), `"server_name":"demo-server"`) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -722,7 +722,7 @@ func TestAdminMiddlewareLogsMissingToken(t *testing.T) {
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	h := AdminMiddleware(v, APIKeyConfig{}, MiddlewareOptions{})(next)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -748,7 +748,7 @@ func TestAdminMiddlewareLogsInvalidScheme(t *testing.T) {
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	h := AdminMiddleware(v, APIKeyConfig{}, MiddlewareOptions{})(next)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req.Header.Set("Authorization", "Basic abc")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -778,7 +778,7 @@ func TestAdminMiddlewareMachineKeyBypassesBearer(t *testing.T) {
 	h := AdminMiddleware(v, apiKeyCfg, MiddlewareOptions{})(next)
 
 	// Correct machine key/secret — should be admitted without a Bearer token.
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req.Header.Set("X-API-Key", "vm-key")
 	req.Header.Set("X-API-Secret", "vm-secret")
 	w := httptest.NewRecorder()
@@ -789,7 +789,7 @@ func TestAdminMiddlewareMachineKeyBypassesBearer(t *testing.T) {
 
 	// Wrong secret — should be rejected.
 	admitted = false
-	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req2.Header.Set("X-API-Key", "vm-key")
 	req2.Header.Set("X-API-Secret", "wrong-secret")
 	w2 := httptest.NewRecorder()

--- a/ui/src/api/AtryumAPI.ts
+++ b/ui/src/api/AtryumAPI.ts
@@ -132,21 +132,21 @@ export const invocationsApi = {
     if (filters.offset != null) params.set('offset', String(filters.offset));
     params.set('limit', String(filters.limit ?? 50));
     const { data } = await atryumApi.get(
-      `/api/v1/admin/invocations?${params.toString()}`,
+      `/api/v1/review/invocations?${params.toString()}`,
     );
     return data;
   },
 
   detail: async (id: string): Promise<InvocationDetail> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}`,
     );
     return data;
   },
 
   events: async (id: string): Promise<{ items: InvocationEvent[] }> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}/events?limit=200`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}/events?limit=200`,
     );
     return data;
   },
@@ -156,7 +156,7 @@ export const invocationsApi = {
     body?: { create_rule?: RuleInput },
   ): Promise<void> => {
     await atryumApi.post(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}/approve`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}/approve`,
       body ?? {},
     );
   },
@@ -170,7 +170,7 @@ export const invocationsApi = {
     if (message) body.message = message;
     if (createRule) body.create_rule = createRule;
     await atryumApi.post(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}/deny`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}/deny`,
       body,
     );
   },
@@ -181,7 +181,7 @@ export const invocationsApi = {
   ): Promise<{ summary: string }> => {
     const body = modelConfigCuid ? { model_config_cuid: modelConfigCuid } : {};
     const { data } = await atryumApi.post(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}/summarize`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}/summarize`,
       body,
     );
     return data;

--- a/ui/src/auth/adminAuth.tsx
+++ b/ui/src/auth/adminAuth.tsx
@@ -66,7 +66,7 @@ let authCallbackPromise: Promise<void> | null = null;
 const SELECTED_PROVIDER_KEY = 'atryum.adminAuth.provider';
 
 const fetchConfig = async (): Promise<AdminAuthConfig> => {
-  const res = await fetch('/api/v1/admin-auth/config', {
+  const res = await fetch('/api/v1/auth/config', {
     headers: { Accept: 'application/json' },
   });
   if (!res.ok) throw new Error(`admin auth config failed (${res.status})`);

--- a/ui/src/hooks/useApprovalNotifications.ts
+++ b/ui/src/hooks/useApprovalNotifications.ts
@@ -86,7 +86,7 @@ const parseInvocationStreamPayload = (
   }
 };
 
-const STREAM_URL = '/api/v1/admin/invocations/stream?status=pending_approval&limit=50';
+const STREAM_URL = '/api/v1/review/invocations/stream?status=pending_approval&limit=50';
 
 const ensurePermissionAfterUserGesture = (onPermissionGranted: () => void) => {
   if (!('Notification' in window) || Notification.permission !== 'default') {

--- a/ui/src/hooks/useInvocationStream.ts
+++ b/ui/src/hooks/useInvocationStream.ts
@@ -24,7 +24,7 @@ const buildStreamUrl = (filters: InvocationFilters): string => {
   if (filters.status) params.set('status', filters.status);
   if (filters.client_name) params.set('client_name', filters.client_name);
   params.set('limit', String(filters.limit ?? 50));
-  return `/api/v1/admin/invocations/stream?${params.toString()}`;
+  return `/api/v1/review/invocations/stream?${params.toString()}`;
 };
 
 const detailKey = (id: string): QueryKey => [INVOCATION_DETAIL_KEY, id];

--- a/website/documentation/1_integrations/2_connect-agents.html
+++ b/website/documentation/1_integrations/2_connect-agents.html
@@ -290,7 +290,7 @@ admin_scopes = &quot;openid profile email atryum:mcp&quot;
 admin_claim = &quot;atryum_admin&quot;
 admin_claim_value = true</code></pre><button class="copy-btn code-block-copy-btn" type="button" data-command="[[auth]]&#10;enabled = true&#10;issuer = &quot;http://localhost:8089/realms/atryum&quot;&#10;audience = &quot;atryum&quot;&#10;required_scope = &quot;atryum:mcp&quot;&#10;agent_id_claim = &quot;client_id&quot;&#10;&#10;admin_enabled = true&#10;admin_provider = &quot;keycloak&quot;&#10;admin_client_id = &quot;atryum-admin&quot;&#10;admin_scopes = &quot;openid profile email atryum:mcp&quot;&#10;admin_claim = &quot;atryum_admin&quot;&#10;admin_claim_value = true" aria-label="Copy code block"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg><span>Copy</span></button></div>
 
-        <p>Multiple admin-enabled IdPs can be configured at the same time. The frontend discovers them from <code>/api/v1/admin-auth/config</code>; with one provider it shows a sign-in screen without a provider selector, and with several it shows an identity-provider selector.</p>
+        <p>Multiple admin-enabled IdPs can be configured at the same time. The frontend discovers them from <code>/api/v1/auth/config</code>; with one provider it shows a sign-in screen without a provider selector, and with several it shows an identity-provider selector.</p>
 
         <p>For local Keycloak, run the setup script after Keycloak is available:</p>
 

--- a/website/md-drafts/1_integrations/2_connect-agents.md
+++ b/website/md-drafts/1_integrations/2_connect-agents.md
@@ -406,7 +406,7 @@ admin_claim = "atryum_admin"
 admin_claim_value = true
 ```
 
-Multiple admin-enabled IdPs can be configured at the same time. The frontend discovers them from `/api/v1/admin-auth/config`; with one provider it shows a sign-in screen without a provider selector, and with several it shows an identity-provider selector.
+Multiple admin-enabled IdPs can be configured at the same time. The frontend discovers them from `/api/v1/auth/config`; with one provider it shows a sign-in screen without a provider selector, and with several it shows an identity-provider selector.
 
 For local Keycloak, run the setup script after Keycloak is available:
 


### PR DESCRIPTION
## Summary
- move human invocation review endpoints from /api/v1/admin/invocations to /api/v1/review/invocations
- move browser auth discovery from /api/v1/admin-auth/config to /api/v1/auth/config
- update the Atryum UI, tests, README, and integration documentation
- keep no compatibility aliases; removed paths return 404

## Verification
- go test ./...
- cd ui && npm run build