### PR TITLE
Rename admin API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ admin_claim_value = true
 
 The admin client must be a browser-safe public SPA client that supports authorization code with PKCE. For Auth0, create a Single Page Application client; allow `http://localhost:5174/ui/auth/callback` for Vite development and `http://localhost:8080/ui/auth/callback` for the embedded UI, and allow the corresponding `http://localhost:5174/ui/` and `http://localhost:8080/ui/` logout URLs. For local Keycloak, run `KC_URL=http://localhost:8089 ./keycloak/setup-realm.sh`; it provisions the `atryum-admin` public client, its callback and post-logout redirect URLs, and an `atryum_admin=true` access-token claim.
 
-The frontend fetches `/api/v1/admin-auth/config`, shows a sign-in screen, redirects through the selected provider, attaches `Authorization: Bearer <access_token>` to admin API calls, and uses authenticated fetch-based SSE for `/api/v1/admin/invocations/stream`. With one configured provider, the screen skips the provider selector; with several, it shows an identity-provider selector. It attempts silent token refresh before retrying an expiry-related `401` once. Signing out uses the provider's autodiscovered OIDC `end_session_endpoint` and returns to `/ui/`; providers without a usable end-session endpoint fall back to local logout. Browser console debug logs are emitted for refresh and logout attempts and outcomes under the `[admin-auth]` prefix; access token values are never logged.
+The frontend fetches `/api/v1/auth/config`, shows a sign-in screen, redirects through the selected provider, attaches `Authorization: Bearer <access_token>` to protected API calls, and uses authenticated fetch-based SSE for `/api/v1/review/invocations/stream`. With one configured provider, the screen skips the provider selector; with several, it shows an identity-provider selector. It attempts silent token refresh before retrying an expiry-related `401` once. Signing out uses the provider's autodiscovered OIDC `end_session_endpoint` and returns to `/ui/`; providers without a usable end-session endpoint fall back to local logout. Browser console debug logs are emitted for refresh and logout attempts and outcomes under the `[admin-auth]` prefix; access token values are never logged.
 
 ## HTTP surface
 
@@ -137,9 +137,12 @@ Public (auth-protected when `[[auth]]` is configured):
 - `GET /api/v1/agent/rules` — agent-facing rule introspection.
 - `GET /healthz` — liveness.
 
+Review workflow:
+
+- `/api/v1/review/invocations`, `/{id}`, `/{id}/events`, `/{id}/approve`, `/{id}/deny`, `/stream` (SSE)
+
 Admin (UI and operators):
 
-- `/api/v1/admin/invocations`, `/{id}`, `/{id}/events`, `/{id}/approve`, `/{id}/deny`, `/stream` (SSE)
 - `/api/v1/admin/servers`, `/{name}`, `/{name}/test`, `/{name}/connect`, `/{name}/connect/status`
 - `/api/v1/admin/rules`, `/{id}` (including reorder/move)
 - `/api/v1/admin/agents`, `/{id}`
@@ -147,7 +150,7 @@ Admin (UI and operators):
 - `/api/v1/admin/managed-agents/accounts`, `/managed-agents/agents` — discover configured Anthropic accounts and Claude agents for UI linking
 - `/api/v1/admin/managed-agents/sessions` — manually register a Claude Managed Agents session for the events bridge to watch; kept as a debugging escape hatch
 - `/api/v1/mcp/oauth/callback` — public OAuth callback for upstream MCP server connect flows
-- `/api/v1/admin-auth/config` — public, non-secret OIDC metadata for the admin UI login screen
+- `/api/v1/auth/config` — public, non-secret OIDC metadata for the admin UI login screen
 
 ## Frontend
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Atryum mediates three kinds of tool calls:
 
 - **Pre-tool hooks from agent harnesses.** Managed harnesses (Claude Code, Cursor, amp, Pi) and autonomous ones (Microsoft Foundry, custom orchestrators) post their intended tool call to `POST /api/v1/external/invocations` (when the harness executes the tool itself) or `POST /api/v1/invocations` (when Atryum should execute it). The harness blocks on the response and only proceeds if Atryum returns an approved status. In the hook path Atryum never touches the tool — it just answers "may this call happen."
 - **Direct MCP proxying.** Agents that speak MCP connect to `POST /mcp/{server}` as their MCP endpoint. Atryum implements the JSON-RPC surface (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) and proxies calls to the configured upstream — HTTP or stdio. Because Atryum is the MCP client to the upstream, it holds the credentials (OAuth tokens, bearer tokens, custom headers) and the agent never sees them. The same approval engine runs on every `tools/call`.
-- **Claude Managed Agents events bridge.** Anthropic's hosted harness runs the agent loop on its own infrastructure and never calls Atryum, so for those sessions Atryum dials *out*: it discovers linked Claude sessions, streams their [events](https://platform.claude.com/docs/en/managed-agents/events-and-streaming), records the raw session events on a synthetic audit invocation, and — when the session blocks on a tool call (`session.status_idle` / `requires_action`) — runs the normal approval rules and answers Claude with a `user.tool_confirmation` (or `user.custom_tool_result`). Each tool call is also recorded as its own invocation. This gates both built-in and MCP tools. Enable it by declaring one or more `[[managed_agents]]` accounts (each with a `name`, `workspace`, and `api_key`) and link Claude agents from the Agents UI. Manual session registration remains available at `POST /api/v1/admin/managed-agents/sessions`. See `examples/managed-agents/`.
+- **Claude Managed Agents events bridge.** Anthropic's hosted harness runs the agent loop on its own infrastructure and never calls Atryum, so for those sessions Atryum dials *out*: it discovers linked Claude sessions, streams their [events](https://platform.claude.com/docs/en/managed-agents/events-and-streaming), records the raw session events on a synthetic audit invocation, and — when the session blocks on a tool call (`session.status_idle` / `requires_action`) — runs the normal approval rules and answers Claude with a `user.tool_confirmation` (or `user.custom_tool_result`). Each tool call is also recorded as its own invocation. This gates both built-in and MCP tools. Enable it by declaring one or more `[[managed_agents]]` accounts (each with a `name`, `workspace`, and `api_key`) and link Claude agents from the Agents UI. Manual session registration remains available at `POST /api/v1/managed-agents/sessions`. See `examples/managed-agents/`.
 
 These paths converge on a single service so rules, audit, and the UI work identically regardless of how the call arrived.
 
@@ -140,23 +140,26 @@ Public (auth-protected when `[[auth]]` is configured):
 Review workflow:
 
 - `/api/v1/review/invocations`, `/{id}`, `/{id}/events`, `/{id}/approve`, `/{id}/deny`, `/stream` (SSE)
+- `/api/v1/plans`, `/{id}`, `/{id}/events`, `/{id}/approve`, `/{id}/deny`, `/{id}/revise`, `/{id}/expire`, `/stream` (SSE)
 
-Admin (UI and operators):
+Operator APIs:
 
-- `/api/v1/admin/servers`, `/{name}`, `/{name}/test`, `/{name}/connect`, `/{name}/connect/status`
-- `/api/v1/admin/rules`, `/{id}` (including reorder/move)
-- `/api/v1/admin/agents`, `/{id}`
-- `/api/v1/admin/settings`, `/api/v1/admin/policy`
-- `/api/v1/admin/managed-agents/accounts`, `/managed-agents/agents` — discover configured Anthropic accounts and Claude agents for UI linking
-- `/api/v1/admin/managed-agents/sessions` — manually register a Claude Managed Agents session for the events bridge to watch; kept as a debugging escape hatch
+- `/api/v1/servers`, `/{name}`, `/{name}/test`, `/{name}/connect`, `/{name}/connect/status`
+- `/api/v1/rules`, `/{id}` (including reorder/move)
+- `/api/v1/agents`, `/{id}`
+- `/api/v1/model-configs`, `/api/v1/llm-configs`, `/api/v1/llm-configs/{id}`
+- `/api/v1/settings`, `/api/v1/policy`
+- `/api/v1/vm/organizations`, `/api/v1/vm/record-types`, `/api/v1/vm/custom-fields`
+- `/api/v1/managed-agents/accounts`, `/managed-agents/agents` — discover configured Anthropic accounts and Claude agents for UI linking
+- `/api/v1/managed-agents/sessions` — manually register a Claude Managed Agents session for the events bridge to watch; kept as a debugging escape hatch
 - `/api/v1/mcp/oauth/callback` — public OAuth callback for upstream MCP server connect flows
-- `/api/v1/auth/config` — public, non-secret OIDC metadata for the admin UI login screen
+- `/api/v1/auth/config` — public, non-secret OIDC metadata for the UI login screen
 
 ## Frontend
 
 The local React UI lives under `ui/`. `just build-ui` builds it and copies the Vite output into `internal/api/web`, which is embedded into the Go binary and served at `/ui/`. It covers servers, rules, invocations (list + detail with live SSE updates), agent records, and settings.
 
-The embedded invocation view subscribes to the admin SSE stream, updates list/detail/event views live, surfaces stored input arguments, and renders MCP-style text content in a friendly view alongside raw JSON.
+The embedded invocation view subscribes to the review SSE stream, updates list/detail/event views live, surfaces stored input arguments, and renders MCP-style text content in a friendly view alongside raw JSON.
 
 ## Storage
 
@@ -256,11 +259,11 @@ When `skip_verify` is on, no bearer is required, no claims are parsed, and no ag
 
 ## Server connection management
 
-Runtime server resolution uses the `mcp_servers` table as the source of truth. Manage MCP server connections through the built-in UI at `/ui/` or the admin server APIs under `/api/v1/admin/servers`; do not treat TOML as the normal place to add or edit runtime MCP servers after bootstrap.
+Runtime server resolution uses the `mcp_servers` table as the source of truth. Manage MCP server connections through the built-in UI at `/ui/` or the operator APIs under `/api/v1/servers`; do not treat TOML as the normal place to add or edit runtime MCP servers after bootstrap.
 
 For HTTP-mode servers that use hosted OAuth, Atryum owns the browser connect flow. Admins enter the server URL, Atryum detects or assigns an auth provider where practical, and the UI shows provider/status plus `Connect` / `Reconnect`. OAuth tokens are stored separately, callback completion updates server auth status fields in the database, and missing or expired OAuth auth fails fast with actionable status fields. Current pragmatic provider support includes `github_hosted` for GitHub-style hosted HTTP servers plus a generic provider framework for future providers and discovery work.
 
-`POST /api/v1/admin/servers/{name}/test` updates server connection/auth status fields and returns the latest snapshot.
+`POST /api/v1/servers/{name}/test` updates server connection/auth status fields and returns the latest snapshot.
 
 ## How it differs from "just an MCP proxy"
 

--- a/atryum.example.toml
+++ b/atryum.example.toml
@@ -53,7 +53,7 @@ request_timeout_seconds = 30
 # table per Anthropic account/workspace you want to watch. When an entry's
 # api_key is set, Atryum connects outbound to Anthropic's Managed Agents
 # "events and streaming" API for every session registered (via
-# POST /api/v1/admin/managed-agents/sessions) against that account. It records
+# POST /api/v1/managed-agents/sessions) against that account. It records
 # each session event in the invocations table and, when a session blocks on a
 # tool call (permission_policy = always_ask, or a custom tool), runs the normal
 # approval rules and replies to Claude with the decision. Entries with an empty
@@ -95,7 +95,7 @@ api_key = ""          # Anthropic API key created in that workspace
 # values. The credentials grant access to:
 #   - Read-only invocation reporting endpoints (GET /invocations/{agent_id},
 #     GET /agent_ids, GET /models/{cuid})
-#   - Admin API endpoints (/api/v1/admin/*), as a trusted machine-caller path
+#   - Operator API endpoints (/api/v1/*), as a trusted machine-caller path
 #     in addition to the OAuth Bearer-token path used by the human admin UI
 # When either field is empty, the reporting endpoints refuse every request with
 # 503. Admin endpoints fall through to Bearer-token validation instead.

--- a/examples/managed-agents/README.md
+++ b/examples/managed-agents/README.md
@@ -131,7 +131,7 @@ agent and discovers its sessions automatically.
 Manual session registration still exists as an escape hatch:
 
 ```bash
-curl -sS -X POST http://localhost:8080/api/v1/admin/managed-agents/sessions \
+curl -sS -X POST http://localhost:8080/api/v1/managed-agents/sessions \
   -H "content-type: application/json" \
   -d '{
     "session_id": "sess_...",

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -5,7 +5,7 @@ servers. Exercises harness MCP quirks, hook integrations from `examples/`, and
 harness→Atryum inbound auth protocols.
 
 Approval uses **rules only** — each test run seeds a catch-all `auto_approve` rule
-via `POST /api/v1/admin/rules` (no `[policy]` provider).
+via `POST /api/v1/rules` (no `[policy]` provider).
 
 ## Quick start
 

--- a/integrations/lib/atryum.sh
+++ b/integrations/lib/atryum.sh
@@ -93,7 +93,7 @@ seed_auto_approve_rules() {
     "tool_patterns": ["*"],
     "description": "integration test catch-all auto-approve"
   }'
-  curl -fsS -X POST "$ATRYUM_URL/api/v1/admin/rules" \
+  curl -fsS -X POST "$ATRYUM_URL/api/v1/rules" \
     -H 'Content-Type: application/json' \
     -d "$payload" >/dev/null || {
     warn "failed to create auto_approve rule; tailing atryum log:"

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -432,6 +432,36 @@ func TestAdminRoutesRequireAdminTokenWhenAdminAuthEnabled(t *testing.T) {
 	}
 }
 
+func TestRenamedOperatorRoutesAreRegisteredAndProtected(t *testing.T) {
+	rig := newAuthTestRig(t, func(c *auth.Config) {
+		c.AdminEnabled = true
+		c.AdminClientID = "admin-client"
+		c.AdminClaim = "atryum_admin"
+		c.AdminClaimValue = "true"
+	})
+	h := newAuthedHandler(t, &stubService{}, rig)
+	for _, path := range []string{
+		"/api/v1/review/invocations",
+		"/api/v1/plans",
+		"/api/v1/servers",
+		"/api/v1/rules",
+		"/api/v1/agents",
+		"/api/v1/model-configs",
+		"/api/v1/llm-configs",
+		"/api/v1/settings",
+		"/api/v1/vm/organizations",
+		"/api/v1/policy",
+		"/api/v1/managed-agents/accounts",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("GET %s: status = %d, want 401", path, w.Code)
+		}
+	}
+}
+
 func TestAdminAuthConfigEndpointReturnsSafeProviderMetadata(t *testing.T) {
 	rig := newAuthTestRig(t, func(c *auth.Config) {
 		c.AdminEnabled = true
@@ -517,6 +547,16 @@ func TestRenamedRoutesDoNotKeepLegacyAliases(t *testing.T) {
 	for _, path := range []string{
 		"/api/v1/admin/invocations",
 		"/api/v1/admin/invocations/inv_123",
+		"/api/v1/admin/plans",
+		"/api/v1/admin/servers",
+		"/api/v1/admin/rules",
+		"/api/v1/admin/agents",
+		"/api/v1/admin/model-configs",
+		"/api/v1/admin/llm-configs",
+		"/api/v1/admin/settings",
+		"/api/v1/admin/vm/organizations",
+		"/api/v1/admin/policy",
+		"/api/v1/admin/managed-agents/accounts",
 		"/api/v1/admin-auth/config",
 	} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -373,7 +373,7 @@ func TestUnprotectedRoutesRemainOpenWhenAuthEnabled(t *testing.T) {
 		want   int
 	}{
 		{http.MethodGet, "/healthz", "", http.StatusOK},
-		{http.MethodGet, "/api/v1/admin/invocations", "", http.StatusOK},
+		{http.MethodGet, "/api/v1/review/invocations", "", http.StatusOK},
 		{http.MethodGet, "/ui/", "", http.StatusOK},
 	}
 	for _, c := range cases {
@@ -404,7 +404,7 @@ func TestAdminRoutesRequireAdminTokenWhenAdminAuthEnabled(t *testing.T) {
 	})
 	h := newAuthedHandler(t, &stubService{}, rig)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusUnauthorized {
@@ -413,7 +413,7 @@ func TestAdminRoutesRequireAdminTokenWhenAdminAuthEnabled(t *testing.T) {
 
 	claims := defaultClaims()
 	tok := rig.sign(t, claims)
-	req = httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req.Header.Set("Authorization", "Bearer "+tok)
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -423,7 +423,7 @@ func TestAdminRoutesRequireAdminTokenWhenAdminAuthEnabled(t *testing.T) {
 
 	claims["atryum_admin"] = true
 	tok = rig.sign(t, claims)
-	req = httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req.Header.Set("Authorization", "Bearer "+tok)
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -440,7 +440,7 @@ func TestAdminAuthConfigEndpointReturnsSafeProviderMetadata(t *testing.T) {
 		c.AdminScopes = "openid profile email"
 	})
 	h := newAuthedHandler(t, &stubService{}, rig)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-auth/config", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/config", nil)
 	req.Host = "atryum.example"
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -494,7 +494,7 @@ func TestAdminAuthConfigProviderIDsAreUniqueForSharedClientID(t *testing.T) {
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 	h.SetAuthValidator(v)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin-auth/config", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/config", nil)
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -509,6 +509,22 @@ func TestAdminAuthConfigProviderIDsAreUniqueForSharedClientID(t *testing.T) {
 	}
 	if resp.Providers[0].ID == resp.Providers[1].ID {
 		t.Fatalf("expected unique provider IDs, got %q", resp.Providers[0].ID)
+	}
+}
+
+func TestRenamedRoutesDoNotKeepLegacyAliases(t *testing.T) {
+	h := newAuthedHandler(t, &stubService{}, newAuthTestRig(t))
+	for _, path := range []string{
+		"/api/v1/admin/invocations",
+		"/api/v1/admin/invocations/inv_123",
+		"/api/v1/admin-auth/config",
+	} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusNotFound {
+			t.Errorf("GET %s: status = %d, want 404", path, w.Code)
+		}
 	}
 }
 

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -395,7 +395,7 @@ func TestUnprotectedRoutesRemainOpenWhenAuthEnabled(t *testing.T) {
 	}
 }
 
-func TestAdminRoutesRequireAdminTokenWhenAdminAuthEnabled(t *testing.T) {
+func TestReviewRoutesRequireAdminTokenWhenAdminAuthEnabled(t *testing.T) {
 	rig := newAuthTestRig(t, func(c *auth.Config) {
 		c.AdminEnabled = true
 		c.AdminClientID = "admin-client"

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -828,7 +828,7 @@ func (h *Handler) SetAuthDebugSkipVerify(enabled bool) {
 }
 
 // SetManagedAgents installs the optional Claude Managed Agents events bridge,
-// enabling the POST /api/v1/admin/managed-agents/sessions endpoint.
+// enabling the POST /api/v1/managed-agents/sessions endpoint.
 func (h *Handler) SetManagedAgents(m managedAgentsAdmin) {
 	h.managedAgents = m
 }
@@ -907,25 +907,25 @@ func (h *Handler) Routes() http.Handler {
 	mux.Handle("/api/v1/review/invocations", admin(h.reviewInvocations))
 	mux.Handle("/api/v1/review/invocations/stream", admin(h.reviewInvocationStream))
 	mux.Handle("/api/v1/review/invocations/", admin(h.reviewInvocationDetail))
-	mux.Handle("/api/v1/admin/servers", admin(h.adminServers))
-	mux.Handle("/api/v1/admin/servers/", admin(h.adminServerDetail))
-	mux.Handle("/api/v1/admin/rules", admin(h.adminRules))
-	mux.Handle("/api/v1/admin/rules/", admin(h.adminRuleDetail))
-	mux.Handle("/api/v1/admin/agents", admin(h.adminAgents))
-	mux.Handle("/api/v1/admin/agents/", admin(h.adminAgentDetail))
-	mux.Handle("/api/v1/admin/model-configs", admin(h.adminModelConfigs))
-	mux.Handle("/api/v1/admin/llm-configs", admin(h.adminLLMConfigs))
-	mux.Handle("/api/v1/admin/llm-configs/", admin(h.adminLLMConfigDetail))
-	mux.Handle("/api/v1/admin/settings", admin(h.adminSettings))
-	mux.Handle("/api/v1/admin/vm/organizations", admin(h.adminVMOrganizations))
-	mux.Handle("/api/v1/admin/vm/record-types", admin(h.adminVMRecordTypes))
-	mux.Handle("/api/v1/admin/vm/custom-fields", admin(h.adminVMCustomFields))
+	mux.Handle("/api/v1/servers", admin(h.adminServers))
+	mux.Handle("/api/v1/servers/", admin(h.adminServerDetail))
+	mux.Handle("/api/v1/rules", admin(h.adminRules))
+	mux.Handle("/api/v1/rules/", admin(h.adminRuleDetail))
+	mux.Handle("/api/v1/agents", admin(h.adminAgents))
+	mux.Handle("/api/v1/agents/", admin(h.adminAgentDetail))
+	mux.Handle("/api/v1/model-configs", admin(h.adminModelConfigs))
+	mux.Handle("/api/v1/llm-configs", admin(h.adminLLMConfigs))
+	mux.Handle("/api/v1/llm-configs/", admin(h.adminLLMConfigDetail))
+	mux.Handle("/api/v1/settings", admin(h.adminSettings))
+	mux.Handle("/api/v1/vm/organizations", admin(h.adminVMOrganizations))
+	mux.Handle("/api/v1/vm/record-types", admin(h.adminVMRecordTypes))
+	mux.Handle("/api/v1/vm/custom-fields", admin(h.adminVMCustomFields))
 	mux.HandleFunc(upstreamMCPOAuthCallbackPath, h.oauthCallback)
-	mux.Handle("/api/v1/admin/policy", admin(h.adminPolicy))
-	mux.Handle("/api/v1/admin/managed-agents/accounts", admin(h.adminManagedAgentAccounts))
-	mux.Handle("/api/v1/admin/managed-agents/agents", admin(h.adminManagedAgents))
-	mux.Handle("/api/v1/admin/managed-agents/sessions/", admin(h.adminManagedAgentSessionDetail))
-	mux.Handle("/api/v1/admin/managed-agents/sessions", admin(h.adminManagedAgentSessions))
+	mux.Handle("/api/v1/policy", admin(h.adminPolicy))
+	mux.Handle("/api/v1/managed-agents/accounts", admin(h.adminManagedAgentAccounts))
+	mux.Handle("/api/v1/managed-agents/agents", admin(h.adminManagedAgents))
+	mux.Handle("/api/v1/managed-agents/sessions/", admin(h.adminManagedAgentSessionDetail))
+	mux.Handle("/api/v1/managed-agents/sessions", admin(h.adminManagedAgentSessions))
 	agentRulesHandler := h.agentRuntimeHandler(http.HandlerFunc(h.agentRules))
 	mux.Handle("/api/v1/agent/rules", agentRulesHandler)
 	mux.Handle("/api/v1/external/invocations", h.agentRuntimeHandler(http.HandlerFunc(h.externalInvocations)))
@@ -933,9 +933,9 @@ func (h *Handler) Routes() http.Handler {
 	mux.Handle("/api/v1/external/sessions", h.agentRuntimeHandler(http.HandlerFunc(h.externalSessions)))
 	mux.Handle("/api/v1/external/plans", h.agentRuntimeHandler(http.HandlerFunc(h.externalPlans)))
 	mux.Handle("/api/v1/external/plans/", h.agentRuntimeHandler(http.HandlerFunc(h.externalPlanDetail)))
-	mux.Handle("/api/v1/admin/plans", admin(h.adminPlans))
-	mux.Handle("/api/v1/admin/plans/stream", admin(h.adminPlanStream))
-	mux.Handle("/api/v1/admin/plans/", admin(h.adminPlanDetail))
+	mux.Handle("/api/v1/plans", admin(h.adminPlans))
+	mux.Handle("/api/v1/plans/stream", admin(h.adminPlanStream))
+	mux.Handle("/api/v1/plans/", admin(h.adminPlanDetail))
 	apiKeyMW := auth.APIKeyMiddleware(h.apiKeyAuth)
 	mux.Handle("/agent_ids", apiKeyMW(http.HandlerFunc(h.agentIDs)))
 	mux.Handle("/invocations/", apiKeyMW(http.HandlerFunc(h.invocationsByAgentID)))
@@ -2301,7 +2301,7 @@ func (h *Handler) adminServers(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) adminServerDetail(w http.ResponseWriter, r *http.Request) {
-	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/servers/")
+	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/servers/")
 	trimmed = strings.Trim(trimmed, "/")
 	if trimmed == "" {
 		writeError(w, http.StatusNotFound, "not found")
@@ -2564,7 +2564,7 @@ func (h *Handler) adminRules(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) adminRuleDetail(w http.ResponseWriter, r *http.Request) {
-	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/rules/")
+	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/rules/")
 	trimmed = strings.Trim(trimmed, "/")
 	if trimmed == "" {
 		writeError(w, http.StatusNotFound, "not found")
@@ -2787,7 +2787,7 @@ func (h *Handler) adminLLMConfigs(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) adminLLMConfigDetail(w http.ResponseWriter, r *http.Request) {
-	id := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/llm-configs/")
+	id := strings.TrimPrefix(r.URL.Path, "/api/v1/llm-configs/")
 	id = strings.Trim(id, "/")
 	if id == "" {
 		writeError(w, http.StatusNotFound, "not found")
@@ -3238,14 +3238,14 @@ func (h *Handler) adminAgents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
-	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/agents/")
+	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/agents/")
 	trimmed = strings.Trim(trimmed, "/")
 	if trimmed == "" {
 		writeError(w, http.StatusNotFound, "not found")
 		return
 	}
 
-	// POST /api/v1/admin/agents/sync — trigger a backend sync
+	// POST /api/v1/agents/sync — trigger a backend sync
 	if trimmed == "sync" {
 		if r.Method != http.MethodPost {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -3272,7 +3272,7 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// GET /api/v1/admin/agents/:id/charter-preview — assemble the charter hierarchy
+	// GET /api/v1/agents/:id/charter-preview — assemble the charter hierarchy
 	if strings.HasSuffix(trimmed, "/charter-preview") {
 		id := strings.TrimSuffix(trimmed, "/charter-preview")
 		id = strings.Trim(id, "/")
@@ -3280,7 +3280,7 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// /api/v1/admin/agents/:id — GET / PATCH / DELETE
+	// /api/v1/agents/:id — GET / PATCH / DELETE
 	id := trimmed
 	switch r.Method {
 	case http.MethodGet:
@@ -4075,7 +4075,7 @@ func (h *Handler) externalPlanDetail(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, plan)
 }
 
-// adminPlans handles GET /api/v1/admin/plans.
+// adminPlans handles GET /api/v1/plans.
 func (h *Handler) adminPlans(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -4137,10 +4137,10 @@ func (h *Handler) adminPlanStream(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// adminPlanDetail handles GET /api/v1/admin/plans/{id}, GET .../{id}/events,
+// adminPlanDetail handles GET /api/v1/plans/{id}, GET .../{id}/events,
 // and POST .../{id}/approve|deny|revise|expire.
 func (h *Handler) adminPlanDetail(w http.ResponseWriter, r *http.Request) {
-	trimmed := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/admin/plans/"), "/")
+	trimmed := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/plans/"), "/")
 	if trimmed == "" {
 		writeError(w, http.StatusNotFound, "not found")
 		return
@@ -4305,7 +4305,7 @@ func (h *Handler) adminManagedAgentSessionDetail(w http.ResponseWriter, r *http.
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
 	}
-	rawID := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/admin/managed-agents/sessions/"), "/")
+	rawID := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/managed-agents/sessions/"), "/")
 	sessionID, err := url.PathUnescape(rawID)
 	if err != nil || strings.TrimSpace(sessionID) == "" {
 		writeError(w, http.StatusNotFound, "not found")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -903,10 +903,10 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/mcp", h.mcpRootNotFound)
 	mux.Handle("/mcp/", mcpHandler)
 	mux.Handle("/api/v1/invocations", h.agentRuntimeHandler(http.HandlerFunc(h.invocations)))
-	mux.HandleFunc("/api/v1/admin-auth/config", h.adminAuthConfig)
-	mux.Handle("/api/v1/admin/invocations", admin(h.adminInvocations))
-	mux.Handle("/api/v1/admin/invocations/stream", admin(h.adminInvocationStream))
-	mux.Handle("/api/v1/admin/invocations/", admin(h.adminInvocationDetail))
+	mux.HandleFunc("/api/v1/auth/config", h.adminAuthConfig)
+	mux.Handle("/api/v1/review/invocations", admin(h.reviewInvocations))
+	mux.Handle("/api/v1/review/invocations/stream", admin(h.reviewInvocationStream))
+	mux.Handle("/api/v1/review/invocations/", admin(h.reviewInvocationDetail))
 	mux.Handle("/api/v1/admin/servers", admin(h.adminServers))
 	mux.Handle("/api/v1/admin/servers/", admin(h.adminServerDetail))
 	mux.Handle("/api/v1/admin/rules", admin(h.adminRules))
@@ -1934,7 +1934,7 @@ func (h *Handler) appendRulesContextToToolResult(ctx context.Context, result any
 	return m
 }
 
-func (h *Handler) adminInvocations(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) reviewInvocations(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -1955,7 +1955,7 @@ func (h *Handler) adminInvocations(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (h *Handler) adminInvocationStream(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) reviewInvocationStream(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeError(w, http.StatusInternalServerError, "streaming unsupported")
@@ -1996,8 +1996,8 @@ func (h *Handler) adminInvocationStream(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) {
-	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/admin/invocations/")
+func (h *Handler) reviewInvocationDetail(w http.ResponseWriter, r *http.Request) {
+	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/review/invocations/")
 	trimmed = strings.Trim(trimmed, "/")
 	if trimmed == "" {
 		writeError(w, http.StatusNotFound, "not found")
@@ -2144,13 +2144,13 @@ func (h *Handler) adminInvocationDetail(w http.ResponseWriter, r *http.Request) 
 }
 
 // SummarizeInvocationRequest is the JSON body accepted by
-// POST /api/v1/admin/invocations/{id}/summarize.
+// POST /api/v1/review/invocations/{id}/summarize.
 type SummarizeInvocationRequest struct {
 	ModelConfigCUID string `json:"model_config_cuid"`
 }
 
 // SummarizeInvocationResponse is the JSON shape returned by
-// POST /api/v1/admin/invocations/{id}/summarize.
+// POST /api/v1/review/invocations/{id}/summarize.
 type SummarizeInvocationResponse struct {
 	InvocationID string `json:"invocation_id"`
 	Summary      string `json:"summary"`

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -172,7 +172,7 @@ type Handler struct {
 
 	// managedAgents is the optional Claude Managed Agents events bridge.
 	// nil when not configured (no anthropic api key).
-	managedAgents managedAgentsAdmin
+	managedAgents managedAgentsOperator
 
 	// extraRoutes are registrations contributed by embedding programs (via
 	// pkg/atryum WithRoutes). They are applied to the mux after the built-in
@@ -190,9 +190,9 @@ func (h *Handler) AddExtraRoutes(register func(mux *http.ServeMux)) {
 	}
 }
 
-// managedAgentsAdmin is the slice of the managed-agents service the admin API
-// needs for session registration and Claude agent discovery.
-type managedAgentsAdmin interface {
+// managedAgentsOperator is the slice of the managed-agents service the
+// operator API needs for session registration and Claude agent discovery.
+type managedAgentsOperator interface {
 	RegisterSession(ctx context.Context, req managedagents.RegisterSessionRequest) (managedagents.SessionRegistration, error)
 	ListSessions(ctx context.Context) ([]managedagents.SessionRegistration, error)
 	DeleteSession(ctx context.Context, sessionID string) error
@@ -390,7 +390,7 @@ type RuleListResponse struct {
 	Items []AdminRule `json:"items"`
 }
 
-// ─── Agent admin types ────────────────────────────────────────────────────────
+// ─── Agent operator types ─────────────────────────────────────────────────────
 
 type AdminAgent struct {
 	CUID                string                     `json:"cuid"`
@@ -829,7 +829,7 @@ func (h *Handler) SetAuthDebugSkipVerify(enabled bool) {
 
 // SetManagedAgents installs the optional Claude Managed Agents events bridge,
 // enabling the POST /api/v1/managed-agents/sessions endpoint.
-func (h *Handler) SetManagedAgents(m managedAgentsAdmin) {
+func (h *Handler) SetManagedAgents(m managedAgentsOperator) {
 	h.managedAgents = m
 }
 
@@ -857,7 +857,7 @@ func (h *Handler) protectedResourceMetadata() http.Handler {
 	})
 }
 
-func (h *Handler) adminAuthConfig(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) authConfig(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -896,36 +896,44 @@ func (h *Handler) Routes() http.Handler {
 		mux.Handle("/.well-known/oauth-protected-resource", h.protectedResourceMetadata())
 	}
 	mcpHandler := h.agentRuntimeHandler(http.HandlerFunc(h.invokeUpstream))
-	adminAuthMW := auth.AdminMiddleware(h.authValidator, h.apiKeyAuth, auth.MiddlewareOptions{SkipVerify: h.authDebugSkip, DebugLogIdentity: h.debug})
-	admin := func(fn http.HandlerFunc) http.Handler {
-		return adminAuthMW(fn)
+	operatorAuthMW := auth.AdminMiddleware(h.authValidator, h.apiKeyAuth, auth.MiddlewareOptions{SkipVerify: h.authDebugSkip, DebugLogIdentity: h.debug})
+	// Review and operator routes currently share Atryum's legacy admin-token
+	// middleware. Keeping separate wrappers makes their authorization roles
+	// explicit and lets embedders split the capabilities without renaming the
+	// route layer again.
+	reviewAuthMW := operatorAuthMW
+	review := func(fn http.HandlerFunc) http.Handler {
+		return reviewAuthMW(fn)
+	}
+	operator := func(fn http.HandlerFunc) http.Handler {
+		return operatorAuthMW(fn)
 	}
 	mux.HandleFunc("/mcp", h.mcpRootNotFound)
 	mux.Handle("/mcp/", mcpHandler)
 	mux.Handle("/api/v1/invocations", h.agentRuntimeHandler(http.HandlerFunc(h.invocations)))
-	mux.HandleFunc("/api/v1/auth/config", h.adminAuthConfig)
-	mux.Handle("/api/v1/review/invocations", admin(h.reviewInvocations))
-	mux.Handle("/api/v1/review/invocations/stream", admin(h.reviewInvocationStream))
-	mux.Handle("/api/v1/review/invocations/", admin(h.reviewInvocationDetail))
-	mux.Handle("/api/v1/servers", admin(h.adminServers))
-	mux.Handle("/api/v1/servers/", admin(h.adminServerDetail))
-	mux.Handle("/api/v1/rules", admin(h.adminRules))
-	mux.Handle("/api/v1/rules/", admin(h.adminRuleDetail))
-	mux.Handle("/api/v1/agents", admin(h.adminAgents))
-	mux.Handle("/api/v1/agents/", admin(h.adminAgentDetail))
-	mux.Handle("/api/v1/model-configs", admin(h.adminModelConfigs))
-	mux.Handle("/api/v1/llm-configs", admin(h.adminLLMConfigs))
-	mux.Handle("/api/v1/llm-configs/", admin(h.adminLLMConfigDetail))
-	mux.Handle("/api/v1/settings", admin(h.adminSettings))
-	mux.Handle("/api/v1/vm/organizations", admin(h.adminVMOrganizations))
-	mux.Handle("/api/v1/vm/record-types", admin(h.adminVMRecordTypes))
-	mux.Handle("/api/v1/vm/custom-fields", admin(h.adminVMCustomFields))
+	mux.HandleFunc("/api/v1/auth/config", h.authConfig)
+	mux.Handle("/api/v1/review/invocations", review(h.reviewInvocations))
+	mux.Handle("/api/v1/review/invocations/stream", review(h.reviewInvocationStream))
+	mux.Handle("/api/v1/review/invocations/", review(h.reviewInvocationDetail))
+	mux.Handle("/api/v1/servers", operator(h.operatorServers))
+	mux.Handle("/api/v1/servers/", operator(h.operatorServerDetail))
+	mux.Handle("/api/v1/rules", operator(h.operatorRules))
+	mux.Handle("/api/v1/rules/", operator(h.operatorRuleDetail))
+	mux.Handle("/api/v1/agents", operator(h.operatorAgents))
+	mux.Handle("/api/v1/agents/", operator(h.operatorAgentDetail))
+	mux.Handle("/api/v1/model-configs", operator(h.operatorModelConfigs))
+	mux.Handle("/api/v1/llm-configs", operator(h.operatorLLMConfigs))
+	mux.Handle("/api/v1/llm-configs/", operator(h.operatorLLMConfigDetail))
+	mux.Handle("/api/v1/settings", operator(h.operatorSettings))
+	mux.Handle("/api/v1/vm/organizations", operator(h.operatorVMOrganizations))
+	mux.Handle("/api/v1/vm/record-types", operator(h.operatorVMRecordTypes))
+	mux.Handle("/api/v1/vm/custom-fields", operator(h.operatorVMCustomFields))
 	mux.HandleFunc(upstreamMCPOAuthCallbackPath, h.oauthCallback)
-	mux.Handle("/api/v1/policy", admin(h.adminPolicy))
-	mux.Handle("/api/v1/managed-agents/accounts", admin(h.adminManagedAgentAccounts))
-	mux.Handle("/api/v1/managed-agents/agents", admin(h.adminManagedAgents))
-	mux.Handle("/api/v1/managed-agents/sessions/", admin(h.adminManagedAgentSessionDetail))
-	mux.Handle("/api/v1/managed-agents/sessions", admin(h.adminManagedAgentSessions))
+	mux.Handle("/api/v1/policy", operator(h.operatorPolicy))
+	mux.Handle("/api/v1/managed-agents/accounts", operator(h.operatorManagedAgentAccounts))
+	mux.Handle("/api/v1/managed-agents/agents", operator(h.operatorManagedAgents))
+	mux.Handle("/api/v1/managed-agents/sessions/", operator(h.operatorManagedAgentSessionDetail))
+	mux.Handle("/api/v1/managed-agents/sessions", operator(h.operatorManagedAgentSessions))
 	agentRulesHandler := h.agentRuntimeHandler(http.HandlerFunc(h.agentRules))
 	mux.Handle("/api/v1/agent/rules", agentRulesHandler)
 	mux.Handle("/api/v1/external/invocations", h.agentRuntimeHandler(http.HandlerFunc(h.externalInvocations)))
@@ -933,9 +941,9 @@ func (h *Handler) Routes() http.Handler {
 	mux.Handle("/api/v1/external/sessions", h.agentRuntimeHandler(http.HandlerFunc(h.externalSessions)))
 	mux.Handle("/api/v1/external/plans", h.agentRuntimeHandler(http.HandlerFunc(h.externalPlans)))
 	mux.Handle("/api/v1/external/plans/", h.agentRuntimeHandler(http.HandlerFunc(h.externalPlanDetail)))
-	mux.Handle("/api/v1/plans", admin(h.adminPlans))
-	mux.Handle("/api/v1/plans/stream", admin(h.adminPlanStream))
-	mux.Handle("/api/v1/plans/", admin(h.adminPlanDetail))
+	mux.Handle("/api/v1/plans", review(h.reviewPlans))
+	mux.Handle("/api/v1/plans/stream", review(h.reviewPlanStream))
+	mux.Handle("/api/v1/plans/", review(h.reviewPlanDetail))
 	apiKeyMW := auth.APIKeyMiddleware(h.apiKeyAuth)
 	mux.Handle("/agent_ids", apiKeyMW(http.HandlerFunc(h.agentIDs)))
 	mux.Handle("/invocations/", apiKeyMW(http.HandlerFunc(h.invocationsByAgentID)))
@@ -2192,7 +2200,7 @@ func (h *Handler) summarizeInvocation(w http.ResponseWriter, r *http.Request, id
 		return
 	}
 
-	// Round-trip via JSON so the backend sees the same shape as the admin
+	// Round-trip via JSON so the backend sees the same shape as the review
 	// detail endpoint (input/result/error are json.RawMessage on the wire).
 	raw, err := json.Marshal(inv)
 	if err != nil {
@@ -2265,7 +2273,7 @@ func (h *Handler) summarizeInvocation(w http.ResponseWriter, r *http.Request, id
 	})
 }
 
-func (h *Handler) adminServers(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorServers(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		filter := mcp.ServerFilter{Offset: readUintQuery(r, "offset", 0), Limit: readUintQuery(r, "limit", 50)}
@@ -2300,7 +2308,7 @@ func (h *Handler) adminServers(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) adminServerDetail(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorServerDetail(w http.ResponseWriter, r *http.Request) {
 	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/servers/")
 	trimmed = strings.Trim(trimmed, "/")
 	if trimmed == "" {
@@ -2332,14 +2340,14 @@ func (h *Handler) adminServerDetail(w http.ResponseWriter, r *http.Request) {
 		}
 		name := strings.TrimSuffix(trimmed, "/test")
 		name = strings.TrimSuffix(name, "/")
-		h.debugf("admin server test request method=%s path=%s server=%s remote=%s origin=%q referer=%q user_agent=%q content_length=%d", r.Method, r.URL.Path, name, r.RemoteAddr, r.Header.Get("Origin"), r.Header.Get("Referer"), r.UserAgent(), r.ContentLength)
+		h.debugf("operator server test request method=%s path=%s server=%s remote=%s origin=%q referer=%q user_agent=%q content_length=%d", r.Method, r.URL.Path, name, r.RemoteAddr, r.Header.Get("Origin"), r.Header.Get("Referer"), r.UserAgent(), r.ContentLength)
 		resp, err := h.serverSvc.Test(r.Context(), name)
 		if err != nil {
-			h.debugf("admin server test error server=%s err=%v", name, err)
+			h.debugf("operator server test error server=%s err=%v", name, err)
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		h.debugf("admin server test response server=%s ok=%t connection_status=%s auth_status=%s reauth_needed=%t last_check_ok=%t message=%q action_required=%q", name, resp.Ok, resp.ConnectionStatus, resp.AuthStatus, resp.ReauthNeeded, resp.LastCheckOK, resp.Message, debugStringPtr(resp.ActionRequired))
+		h.debugf("operator server test response server=%s ok=%t connection_status=%s auth_status=%s reauth_needed=%t last_check_ok=%t message=%q action_required=%q", name, resp.Ok, resp.ConnectionStatus, resp.AuthStatus, resp.ReauthNeeded, resp.LastCheckOK, resp.Message, debugStringPtr(resp.ActionRequired))
 		writeJSON(w, http.StatusOK, resp)
 		return
 	}
@@ -2433,7 +2441,7 @@ func (h *Handler) oauthCallback(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write([]byte(`<html><body><h1>OAuth connect complete</h1><p>` + escapeHTMLString(message) + `</p><script>window.close && window.close()</script></body></html>`))
 }
 
-func (h *Handler) adminPolicy(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorPolicy(w http.ResponseWriter, r *http.Request) {
 	if h.policyRegistry == nil {
 		writeError(w, http.StatusServiceUnavailable, "policy registry not configured")
 		return
@@ -2496,7 +2504,7 @@ func debugStringPtr(value *string) string {
 	return *value
 }
 
-func (h *Handler) adminRules(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorRules(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		rules, err := h.rulesRepo.List(r.Context())
@@ -2563,7 +2571,7 @@ func (h *Handler) adminRules(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) adminRuleDetail(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorRuleDetail(w http.ResponseWriter, r *http.Request) {
 	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/rules/")
 	trimmed = strings.Trim(trimmed, "/")
 	if trimmed == "" {
@@ -2673,7 +2681,7 @@ func (h *Handler) adminRuleDetail(w http.ResponseWriter, r *http.Request) {
 
 // ─── Model config handler ─────────────────────────────────────────────────────
 
-func (h *Handler) adminModelConfigs(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorModelConfigs(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -2696,8 +2704,8 @@ func (h *Handler) adminModelConfigs(w http.ResponseWriter, r *http.Request) {
 
 // ─── Agent Sync Settings handlers ────────────────────────────────────────────
 
-// AgentSyncSettingsResponse is the JSON shape returned by GET /admin/settings
-// and PUT /admin/settings. SyncError is non-empty when the post-save agent
+// AgentSyncSettingsResponse is the JSON shape returned by GET /api/v1/settings
+// and PUT /api/v1/settings. SyncError is non-empty when the post-save agent
 // sync failed; settings are persisted regardless.
 type AgentSyncSettingsResponse struct {
 	OrgCUID                  string `json:"org_cuid"`
@@ -2711,7 +2719,7 @@ type AgentSyncSettingsResponse struct {
 	BackendConfigured        bool   `json:"backend_configured"`
 }
 
-// AgentSyncSettingsInput is the JSON body accepted by PUT /admin/settings.
+// AgentSyncSettingsInput is the JSON body accepted by PUT /api/v1/settings.
 type AgentSyncSettingsInput struct {
 	OrgCUID                  string `json:"org_cuid"`
 	AgentRecordTypeSlug      string `json:"agent_record_type_slug"`
@@ -2723,7 +2731,7 @@ type AgentSyncSettingsInput struct {
 
 // ─── Local LLM Config handlers ────────────────────────────────────────────────
 
-func (h *Handler) adminLLMConfigs(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorLLMConfigs(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		if h.llmConfigsRepo == nil {
@@ -2769,13 +2777,13 @@ func (h *Handler) adminLLMConfigs(w http.ResponseWriter, r *http.Request) {
 			Enabled:  enabled,
 		}
 		if err := h.llmConfigsRepo.Create(r.Context(), cfg); err != nil {
-			log.Printf("[adminLLMConfigs] create failed id=%s provider=%s: %v", cfg.ID, cfg.Provider, err)
+			log.Printf("[operatorLLMConfigs] create failed id=%s provider=%s: %v", cfg.ID, cfg.Provider, err)
 			writeError(w, http.StatusInternalServerError, "failed to create llm config")
 			return
 		}
 		created, err := h.llmConfigsRepo.Get(r.Context(), cfg.ID)
 		if err != nil {
-			log.Printf("[adminLLMConfigs] get after create failed id=%s: %v", cfg.ID, err)
+			log.Printf("[operatorLLMConfigs] get after create failed id=%s: %v", cfg.ID, err)
 			writeError(w, http.StatusInternalServerError, "failed to retrieve llm config")
 			return
 		}
@@ -2786,7 +2794,7 @@ func (h *Handler) adminLLMConfigs(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) adminLLMConfigDetail(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorLLMConfigDetail(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimPrefix(r.URL.Path, "/api/v1/llm-configs/")
 	id = strings.Trim(id, "/")
 	if id == "" {
@@ -2908,7 +2916,7 @@ func validateLLMConfigInput(req AdminLLMConfigInput) error {
 
 // ─── Settings handler ─────────────────────────────────────────────────────────
 
-func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorSettings(w http.ResponseWriter, r *http.Request) {
 	if h.agentSyncSettingsRepo == nil {
 		writeError(w, http.StatusServiceUnavailable, "settings not available")
 		return
@@ -2980,7 +2988,7 @@ func (h *Handler) adminSettings(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusInternalServerError, "failed to read saved settings: "+err.Error())
 			return
 		}
-		log.Printf("[adminSettings] GET after save: org_cuid=%q record_type=%q", s.OrgCUID, s.AgentRecordTypeSlug)
+		log.Printf("[operatorSettings] GET after save: org_cuid=%q record_type=%q", s.OrgCUID, s.AgentRecordTypeSlug)
 		resp := AgentSyncSettingsResponse{
 			OrgCUID:                  s.OrgCUID,
 			AgentRecordTypeSlug:      s.AgentRecordTypeSlug,
@@ -3036,7 +3044,7 @@ type VMCustomFieldListResponse struct {
 	Total int                 `json:"total"`
 }
 
-func (h *Handler) adminVMOrganizations(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorVMOrganizations(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -3057,7 +3065,7 @@ func (h *Handler) adminVMOrganizations(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, VMOrgListResponse{Items: items, Total: len(items), AuthMode: resp.AuthMode, SingleOrg: resp.SingleOrg})
 }
 
-func (h *Handler) adminVMRecordTypes(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorVMRecordTypes(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -3083,7 +3091,7 @@ func (h *Handler) adminVMRecordTypes(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, VMRecordTypeListResponse{Items: items, Total: len(items)})
 }
 
-func (h *Handler) adminVMCustomFields(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorVMCustomFields(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -3150,7 +3158,7 @@ func normalizePatternSlice(s []string) []string {
 
 // ─── Agent handlers ───────────────────────────────────────────────────────────
 
-func (h *Handler) adminAgents(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorAgents(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		records, err := h.agentsRepo.List(r.Context())
@@ -3237,7 +3245,7 @@ func (h *Handler) adminAgents(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorAgentDetail(w http.ResponseWriter, r *http.Request) {
 	trimmed := strings.TrimPrefix(r.URL.Path, "/api/v1/agents/")
 	trimmed = strings.Trim(trimmed, "/")
 	if trimmed == "" {
@@ -3276,7 +3284,7 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 	if strings.HasSuffix(trimmed, "/charter-preview") {
 		id := strings.TrimSuffix(trimmed, "/charter-preview")
 		id = strings.Trim(id, "/")
-		h.adminAgentCharterPreview(w, r, id)
+		h.operatorAgentCharterPreview(w, r, id)
 		return
 	}
 
@@ -3427,10 +3435,10 @@ func (h *Handler) adminAgentDetail(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// adminAgentCharterPreview assembles the per-agent charter hierarchy. For synced
+// operatorAgentCharterPreview assembles the per-agent charter hierarchy. For synced
 // agents (with a VM cuid) it delegates to the ValidMind backend; for local
 // agents it returns the agent's own stored charter.
-func (h *Handler) adminAgentCharterPreview(w http.ResponseWriter, r *http.Request, id string) {
+func (h *Handler) operatorAgentCharterPreview(w http.ResponseWriter, r *http.Request, id string) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -3565,7 +3573,7 @@ func (s *ServerAdminService) List(ctx context.Context, filter mcp.ServerFilter) 
 	}
 	servers := make([]AdminServer, 0, len(items))
 	for _, item := range items {
-		servers = append(servers, s.adminViewWithGrantedScopes(ctx, item))
+		servers = append(servers, s.operatorViewWithGrantedScopes(ctx, item))
 	}
 	return ServerListResponse{Items: servers, Total: total, Offset: filter.Offset, Limit: normalizeLimit(filter.Limit, 50)}, nil
 }
@@ -3575,14 +3583,14 @@ func (s *ServerAdminService) Get(ctx context.Context, name string) (AdminServer,
 	if err != nil {
 		return AdminServer{}, err
 	}
-	return s.adminViewWithGrantedScopes(ctx, upstream), nil
+	return s.operatorViewWithGrantedScopes(ctx, upstream), nil
 }
 
-// adminViewWithGrantedScopes is toAdminServer + an overlay of the actual
+// operatorViewWithGrantedScopes is toAdminServer + an overlay of the actual
 // scope string the AS granted on the latest successful token exchange.
 // Pulled separately from oauth_credentials.scope so the UI can show both
 // what we requested and what's actually live.
-func (s *ServerAdminService) adminViewWithGrantedScopes(ctx context.Context, upstream mcp.Upstream) AdminServer {
+func (s *ServerAdminService) operatorViewWithGrantedScopes(ctx context.Context, upstream mcp.Upstream) AdminServer {
 	view := toAdminServer(upstream)
 	view.EndpointURL = s.endpointURL(view.EndpointSlug)
 	if cred, err := s.oauthRepo.GetCredential(ctx, upstream.Name); err == nil {
@@ -3675,7 +3683,7 @@ func (s *ServerAdminService) Upsert(ctx context.Context, name string, req AdminS
 	if err := s.repo.UpsertServer(ctx, upstream); err != nil {
 		return AdminServer{}, err
 	}
-	return s.adminViewWithGrantedScopes(ctx, upstream), nil
+	return s.operatorViewWithGrantedScopes(ctx, upstream), nil
 }
 
 func (s *ServerAdminService) validateEndpointSlugAvailable(ctx context.Context, serverName string, slug string) error {
@@ -3958,7 +3966,7 @@ type PlanReviseRequest struct {
 	Feedback string `json:"feedback"`
 }
 
-// PlanDetailResponse is the admin detail view: the plan plus its direct revisions.
+// PlanDetailResponse is the review detail view: the plan plus its direct revisions.
 type PlanDetailResponse struct {
 	invocation.Plan
 	Revisions []invocation.Plan `json:"revisions"`
@@ -4075,8 +4083,8 @@ func (h *Handler) externalPlanDetail(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, plan)
 }
 
-// adminPlans handles GET /api/v1/plans.
-func (h *Handler) adminPlans(w http.ResponseWriter, r *http.Request) {
+// reviewPlans handles GET /api/v1/plans.
+func (h *Handler) reviewPlans(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -4095,7 +4103,7 @@ func (h *Handler) adminPlans(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (h *Handler) adminPlanStream(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) reviewPlanStream(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -4137,9 +4145,9 @@ func (h *Handler) adminPlanStream(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// adminPlanDetail handles GET /api/v1/plans/{id}, GET .../{id}/events,
+// reviewPlanDetail handles GET /api/v1/plans/{id}, GET .../{id}/events,
 // and POST .../{id}/approve|deny|revise|expire.
-func (h *Handler) adminPlanDetail(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) reviewPlanDetail(w http.ResponseWriter, r *http.Request) {
 	trimmed := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/plans/"), "/")
 	if trimmed == "" {
 		writeError(w, http.StatusNotFound, "not found")
@@ -4247,10 +4255,10 @@ func (h *Handler) adminPlanDetail(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, PlanDetailResponse{Plan: plan, Revisions: revisions})
 }
 
-// adminManagedAgentSessions registers a Claude Managed Agents session for
+// operatorManagedAgentSessions registers a Claude Managed Agents session for
 // Atryum to watch. Once registered, Atryum streams the session's events into
 // the invocations table and gates blocking tool calls through approval rules.
-func (h *Handler) adminManagedAgentSessions(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorManagedAgentSessions(w http.ResponseWriter, r *http.Request) {
 	if h.managedAgents == nil {
 		h.debugf("managed-agents session registration rejected: bridge not configured method=%s path=%s remote=%s", r.Method, r.URL.Path, r.RemoteAddr)
 		writeError(w, http.StatusNotImplemented, "managed agents bridge not configured (set [managed_agents].api_key)")
@@ -4296,7 +4304,7 @@ func (h *Handler) adminManagedAgentSessions(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (h *Handler) adminManagedAgentSessionDetail(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorManagedAgentSessionDetail(w http.ResponseWriter, r *http.Request) {
 	if h.managedAgents == nil {
 		writeError(w, http.StatusNotImplemented, "managed agents bridge not configured (set [managed_agents].api_key)")
 		return
@@ -4322,7 +4330,7 @@ func (h *Handler) adminManagedAgentSessionDetail(w http.ResponseWriter, r *http.
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *Handler) adminManagedAgentAccounts(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorManagedAgentAccounts(w http.ResponseWriter, r *http.Request) {
 	if h.managedAgents == nil {
 		writeError(w, http.StatusNotImplemented, "managed agents bridge not configured (set [managed_agents].api_key)")
 		return
@@ -4334,7 +4342,7 @@ func (h *Handler) adminManagedAgentAccounts(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, ManagedAgentAccountListResponse{Items: h.managedAgents.Accounts()})
 }
 
-func (h *Handler) adminManagedAgents(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) operatorManagedAgents(w http.ResponseWriter, r *http.Request) {
 	if h.managedAgents == nil {
 		writeError(w, http.StatusNotImplemented, "managed agents bridge not configured (set [managed_agents].api_key)")
 		return

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -569,11 +569,11 @@ func TestAdminServerTestDebugLogsRequestContext(t *testing.T) {
 	}
 	got := logs.String()
 	for _, want := range []string{
-		"admin server test request method=POST path=/api/v1/servers/shortcut/test server=shortcut",
+		"operator server test request method=POST path=/api/v1/servers/shortcut/test server=shortcut",
 		"origin=\"http://localhost:8080\"",
 		"referer=\"http://localhost:8080/ui/\"",
 		"user_agent=\"debug-test\"",
-		"admin server test response server=shortcut",
+		"operator server test response server=shortcut",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected logs to contain %q, got:\n%s", want, got)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -555,7 +555,7 @@ func TestAdminServerTestDebugLogsRequestContext(t *testing.T) {
 	}()
 
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/servers/shortcut/test", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/servers/shortcut/test", nil)
 	req.Header.Set("Origin", "http://localhost:8080")
 	req.Header.Set("Referer", "http://localhost:8080/ui/")
 	req.Header.Set("User-Agent", "debug-test")
@@ -569,7 +569,7 @@ func TestAdminServerTestDebugLogsRequestContext(t *testing.T) {
 	}
 	got := logs.String()
 	for _, want := range []string{
-		"admin server test request method=POST path=/api/v1/admin/servers/shortcut/test server=shortcut",
+		"admin server test request method=POST path=/api/v1/servers/shortcut/test server=shortcut",
 		"origin=\"http://localhost:8080\"",
 		"referer=\"http://localhost:8080/ui/\"",
 		"user_agent=\"debug-test\"",
@@ -604,7 +604,7 @@ func TestManagedAgentSessionRegistrationDebugLogsFailure(t *testing.T) {
 		"account": "default",
 		"agent_id": "agent_013popGjeyhH8qPYqziHxdLk"
 	}`)
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/managed-agents/sessions", body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/managed-agents/sessions", body)
 	req.Header.Set("content-type", "application/json")
 	w := httptest.NewRecorder()
 

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -861,7 +861,7 @@ func TestSummarizeInvocationPersistsBackendSummary(t *testing.T) {
 	summarizer := &stubSummarizer{resp: backendclient.SummarizeInvocationResponse{Summary: "Read /tmp/a and returned hello."}}
 	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 	h.summarizeClient = summarizer
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/invocations/inv_123/summarize", strings.NewReader(`{"model_config_cuid":" model_abc "}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/review/invocations/inv_123/summarize", strings.NewReader(`{"model_config_cuid":" model_abc "}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -911,7 +911,7 @@ func TestSummarizeInvocationUsesSettingsModelConfigWhenRequestBodyEmpty(t *testi
 	summarizer := &stubSummarizer{resp: backendclient.SummarizeInvocationResponse{Summary: "Read /tmp/a."}}
 	h := NewHandler(svc, stubServerService{}, nil, nil, nil, settings, nil, nil, nil, nil)
 	h.summarizeClient = summarizer
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/invocations/inv_123/summarize", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/review/invocations/inv_123/summarize", nil)
 	w := httptest.NewRecorder()
 
 	h.Routes().ServeHTTP(w, req)
@@ -2024,7 +2024,7 @@ func TestAdminInvocationsResponsesIncludeServerToolAndInput(t *testing.T) {
 	h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	t.Run("list", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 		w := httptest.NewRecorder()
 		h.Routes().ServeHTTP(w, req)
 		if !strings.Contains(w.Body.String(), `"server_name":"demo-server"`) {
@@ -2039,7 +2039,7 @@ func TestAdminInvocationsResponsesIncludeServerToolAndInput(t *testing.T) {
 	})
 
 	t.Run("detail", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations/inv_123", nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations/inv_123", nil)
 		w := httptest.NewRecorder()
 		h.Routes().ServeHTTP(w, req)
 		if !strings.Contains(w.Body.String(), `"server_name":"demo-server"`) {

--- a/internal/api/plans_handlers_test.go
+++ b/internal/api/plans_handlers_test.go
@@ -153,7 +153,7 @@ func TestAdminPlansListAndDetail(t *testing.T) {
 	stub := &stubService{plan: newPlanStub()}
 	h := NewHandler(stub, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/plans?status=pending_approval", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/plans?status=pending_approval", nil)
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -170,7 +170,7 @@ func TestAdminPlansListAndDetail(t *testing.T) {
 		t.Fatalf("list = %+v", list)
 	}
 
-	req = httptest.NewRequest(http.MethodGet, "/api/v1/admin/plans/plan_123", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/plans/plan_123", nil)
 	w = httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -192,7 +192,7 @@ func TestAdminPlanDecisions(t *testing.T) {
 	stub := &stubService{plan: newPlanStub()}
 	h := NewHandler(stub, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/plans/plan_123/approve", strings.NewReader(`{"ttl_seconds": 600}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/plans/plan_123/approve", strings.NewReader(`{"ttl_seconds": 600}`))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
@@ -203,7 +203,7 @@ func TestAdminPlanDecisions(t *testing.T) {
 		t.Fatalf("approve call = id %q ttl %d", stub.planApproveID, stub.planTTL)
 	}
 
-	req = httptest.NewRequest(http.MethodPost, "/api/v1/admin/plans/plan_123/deny", strings.NewReader(`{"message": "too risky"}`))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/plans/plan_123/deny", strings.NewReader(`{"message": "too risky"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
@@ -214,7 +214,7 @@ func TestAdminPlanDecisions(t *testing.T) {
 		t.Fatalf("deny call = id %q msg %q", stub.planDenyID, stub.planDenyMsg)
 	}
 
-	req = httptest.NewRequest(http.MethodPost, "/api/v1/admin/plans/plan_123/revise", strings.NewReader(`{"feedback": "pin the version"}`))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/plans/plan_123/revise", strings.NewReader(`{"feedback": "pin the version"}`))
 	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
@@ -225,7 +225,7 @@ func TestAdminPlanDecisions(t *testing.T) {
 		t.Fatalf("revise call = id %q feedback %q", stub.planReviseID, stub.planFeedback)
 	}
 
-	req = httptest.NewRequest(http.MethodPost, "/api/v1/admin/plans/plan_123/expire", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/plans/plan_123/expire", nil)
 	w = httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -237,7 +237,7 @@ func TestAdminPlanDecisions(t *testing.T) {
 
 	// Revise without feedback is rejected before hitting the service.
 	stub.planReviseID = ""
-	req = httptest.NewRequest(http.MethodPost, "/api/v1/admin/plans/plan_123/revise", strings.NewReader(`{}`))
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/plans/plan_123/revise", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	w = httptest.NewRecorder()
 	h.Routes().ServeHTTP(w, req)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -722,7 +722,7 @@ func TestAdminMiddlewareLogsMissingToken(t *testing.T) {
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	h := AdminMiddleware(v, APIKeyConfig{}, MiddlewareOptions{})(next)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
 
@@ -748,7 +748,7 @@ func TestAdminMiddlewareLogsInvalidScheme(t *testing.T) {
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	h := AdminMiddleware(v, APIKeyConfig{}, MiddlewareOptions{})(next)
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req.Header.Set("Authorization", "Basic abc")
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, req)
@@ -778,7 +778,7 @@ func TestAdminMiddlewareMachineKeyBypassesBearer(t *testing.T) {
 	h := AdminMiddleware(v, apiKeyCfg, MiddlewareOptions{})(next)
 
 	// Correct machine key/secret — should be admitted without a Bearer token.
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req.Header.Set("X-API-Key", "vm-key")
 	req.Header.Set("X-API-Secret", "vm-secret")
 	w := httptest.NewRecorder()
@@ -789,7 +789,7 @@ func TestAdminMiddlewareMachineKeyBypassesBearer(t *testing.T) {
 
 	// Wrong secret — should be rejected.
 	admitted = false
-	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/admin/invocations", nil)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/review/invocations", nil)
 	req2.Header.Set("X-API-Key", "vm-key")
 	req2.Header.Set("X-API-Secret", "wrong-secret")
 	w2 := httptest.NewRecorder()

--- a/pkg/atryum/atryum.go
+++ b/pkg/atryum/atryum.go
@@ -148,7 +148,7 @@ func runServer(args []string, o options) error {
 	planEventsRepo := store.NewPlanEventsRepoWithDialect(db, dialect)
 
 	// syncAgents is the shared sync function used both at startup and via the
-	// admin API POST /api/v1/admin/agents/sync endpoint.
+	// admin API POST /api/v1/agents/sync endpoint.
 	// org_cuid and agent_record_type_slug are read exclusively from the DB
 	// (configured via the Settings UI).
 	syncAgents := func(ctx context.Context) error {

--- a/ui/src/api/AtryumAPI.ts
+++ b/ui/src/api/AtryumAPI.ts
@@ -274,26 +274,26 @@ export const serversApi = {
     const params = new URLSearchParams({ limit: '100' });
     if (!showDisabled) params.set('enabled', 'true');
     const { data } = await atryumApi.get(
-      `/api/v1/admin/servers?${params.toString()}`,
+      `/api/v1/servers?${params.toString()}`,
     );
     return data;
   },
 
   detail: async (name: string): Promise<Server> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/servers/${encodeURIComponent(name)}`,
+      `/api/v1/servers/${encodeURIComponent(name)}`,
     );
     return data;
   },
 
   create: async (input: ServerInput): Promise<Server> => {
-    const { data } = await atryumApi.post('/api/v1/admin/servers', input);
+    const { data } = await atryumApi.post('/api/v1/servers', input);
     return data;
   },
 
   update: async (name: string, input: ServerInput): Promise<Server> => {
     const { data } = await atryumApi.put(
-      `/api/v1/admin/servers/${encodeURIComponent(name)}`,
+      `/api/v1/servers/${encodeURIComponent(name)}`,
       input,
     );
     return data;
@@ -301,35 +301,35 @@ export const serversApi = {
 
   remove: async (name: string, disable = false): Promise<void> => {
     const url = disable
-      ? `/api/v1/admin/servers/${encodeURIComponent(name)}?disable=true`
-      : `/api/v1/admin/servers/${encodeURIComponent(name)}`;
+      ? `/api/v1/servers/${encodeURIComponent(name)}?disable=true`
+      : `/api/v1/servers/${encodeURIComponent(name)}`;
     await atryumApi.delete(url);
   },
 
   test: async (name: string): Promise<{ ok: boolean; message: string }> => {
     const { data } = await atryumApi.post(
-      `/api/v1/admin/servers/${encodeURIComponent(name)}/test`,
+      `/api/v1/servers/${encodeURIComponent(name)}/test`,
     );
     return data;
   },
 
   connect: async (name: string): Promise<OAuthConnectStartResponse> => {
     const { data } = await atryumApi.post(
-      `/api/v1/admin/servers/${encodeURIComponent(name)}/connect`,
+      `/api/v1/servers/${encodeURIComponent(name)}/connect`,
     );
     return data;
   },
 
   connectStatus: async (name: string): Promise<OAuthConnectStatusResponse> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/servers/${encodeURIComponent(name)}/connect/status`,
+      `/api/v1/servers/${encodeURIComponent(name)}/connect/status`,
     );
     return data;
   },
 
   tools: async (name: string): Promise<{ items: ServerTool[] }> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/servers/${encodeURIComponent(name)}/tools`,
+      `/api/v1/servers/${encodeURIComponent(name)}/tools`,
     );
     return data;
   },
@@ -375,25 +375,25 @@ export interface RuleInput {
 
 export const rulesApi = {
   list: async (): Promise<{ items: Rule[] }> => {
-    const { data } = await atryumApi.get('/api/v1/admin/rules');
+    const { data } = await atryumApi.get('/api/v1/rules');
     return data;
   },
 
   create: async (input: RuleInput): Promise<Rule> => {
-    const { data } = await atryumApi.post('/api/v1/admin/rules', input);
+    const { data } = await atryumApi.post('/api/v1/rules', input);
     return data;
   },
 
   update: async (id: string, input: RuleInput): Promise<Rule> => {
     const { data } = await atryumApi.put(
-      `/api/v1/admin/rules/${encodeURIComponent(id)}`,
+      `/api/v1/rules/${encodeURIComponent(id)}`,
       input,
     );
     return data;
   },
 
   remove: async (id: string): Promise<void> => {
-    await atryumApi.delete(`/api/v1/admin/rules/${encodeURIComponent(id)}`);
+    await atryumApi.delete(`/api/v1/rules/${encodeURIComponent(id)}`);
   },
 
   move: async (
@@ -401,7 +401,7 @@ export const rulesApi = {
     direction: 'up' | 'down',
   ): Promise<{ items: Rule[] }> => {
     const { data } = await atryumApi.put(
-      `/api/v1/admin/rules/${encodeURIComponent(id)}/move`,
+      `/api/v1/rules/${encodeURIComponent(id)}/move`,
       { direction },
     );
     return data;
@@ -470,20 +470,20 @@ export const plansApi = {
     if (filters.agent_id) params.set('agent_id', filters.agent_id);
     if (filters.offset != null) params.set('offset', String(filters.offset));
     params.set('limit', String(filters.limit ?? 50));
-    const { data } = await atryumApi.get(`/api/v1/admin/plans?${params.toString()}`);
+    const { data } = await atryumApi.get(`/api/v1/plans?${params.toString()}`);
     return data;
   },
 
   detail: async (id: string): Promise<PlanDetail> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/plans/${encodeURIComponent(id)}`,
+      `/api/v1/plans/${encodeURIComponent(id)}`,
     );
     return data;
   },
 
   events: async (id: string): Promise<{ items: InvocationEvent[] }> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/plans/${encodeURIComponent(id)}/events?limit=200`,
+      `/api/v1/plans/${encodeURIComponent(id)}/events?limit=200`,
     );
     return data;
   },
@@ -491,7 +491,7 @@ export const plansApi = {
   approve: async (id: string, ttlSeconds?: number): Promise<Plan> => {
     const body = ttlSeconds ? { ttl_seconds: ttlSeconds } : {};
     const { data } = await atryumApi.post(
-      `/api/v1/admin/plans/${encodeURIComponent(id)}/approve`,
+      `/api/v1/plans/${encodeURIComponent(id)}/approve`,
       body,
     );
     return data;
@@ -500,7 +500,7 @@ export const plansApi = {
   deny: async (id: string, message?: string): Promise<Plan> => {
     const body = message ? { message } : {};
     const { data } = await atryumApi.post(
-      `/api/v1/admin/plans/${encodeURIComponent(id)}/deny`,
+      `/api/v1/plans/${encodeURIComponent(id)}/deny`,
       body,
     );
     return data;
@@ -508,7 +508,7 @@ export const plansApi = {
 
   revise: async (id: string, feedback: string): Promise<Plan> => {
     const { data } = await atryumApi.post(
-      `/api/v1/admin/plans/${encodeURIComponent(id)}/revise`,
+      `/api/v1/plans/${encodeURIComponent(id)}/revise`,
       { feedback },
     );
     return data;
@@ -516,7 +516,7 @@ export const plansApi = {
 
   expire: async (id: string): Promise<Plan> => {
     const { data } = await atryumApi.post(
-      `/api/v1/admin/plans/${encodeURIComponent(id)}/expire`,
+      `/api/v1/plans/${encodeURIComponent(id)}/expire`,
     );
     return data;
   },
@@ -607,18 +607,18 @@ export interface ManagedAgentSession {
 
 export const agentsApi = {
   list: async (): Promise<{ items: Agent[] }> => {
-    const { data } = await atryumApi.get('/api/v1/admin/agents');
+    const { data } = await atryumApi.get('/api/v1/agents');
     return data;
   },
 
   create: async (input: AgentCreateInput): Promise<Agent> => {
-    const { data } = await atryumApi.post('/api/v1/admin/agents', input);
+    const { data } = await atryumApi.post('/api/v1/agents', input);
     return data;
   },
 
   update: async (cuid: string, input: AgentUpdateInput): Promise<Agent> => {
     const { data } = await atryumApi.patch(
-      `/api/v1/admin/agents/${encodeURIComponent(cuid)}`,
+      `/api/v1/agents/${encodeURIComponent(cuid)}`,
       input,
     );
     return data;
@@ -626,39 +626,39 @@ export const agentsApi = {
 
   remove: async (cuid: string): Promise<void> => {
     await atryumApi.delete(
-      `/api/v1/admin/agents/${encodeURIComponent(cuid)}`,
+      `/api/v1/agents/${encodeURIComponent(cuid)}`,
     );
   },
 
   sync: async (): Promise<void> => {
-    await atryumApi.post('/api/v1/admin/agents/sync');
+    await atryumApi.post('/api/v1/agents/sync');
   },
 
   getAgentCharterPreview: async (id: string): Promise<CharterPreview> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/agents/${encodeURIComponent(id)}/charter-preview`,
+      `/api/v1/agents/${encodeURIComponent(id)}/charter-preview`,
     );
     return data;
   },
 
   managedAgentAccounts: async (): Promise<{ items: ClaudeManagedAgentAccount[] }> => {
-    const { data } = await atryumApi.get('/api/v1/admin/managed-agents/accounts');
+    const { data } = await atryumApi.get('/api/v1/managed-agents/accounts');
     return data;
   },
 
   managedAgentSessions: async (): Promise<{ items: ManagedAgentSession[] }> => {
-    const { data } = await atryumApi.get('/api/v1/admin/managed-agents/sessions');
+    const { data } = await atryumApi.get('/api/v1/managed-agents/sessions');
     return data;
   },
 
   deleteManagedAgentSession: async (sessionID: string): Promise<void> => {
     await atryumApi.delete(
-      `/api/v1/admin/managed-agents/sessions/${encodeURIComponent(sessionID)}`,
+      `/api/v1/managed-agents/sessions/${encodeURIComponent(sessionID)}`,
     );
   },
 
   clearManagedAgentSessions: async (): Promise<{ deleted: number }> => {
-    const { data } = await atryumApi.delete('/api/v1/admin/managed-agents/sessions');
+    const { data } = await atryumApi.delete('/api/v1/managed-agents/sessions');
     return data;
   },
 
@@ -670,7 +670,7 @@ export const agentsApi = {
     if (account) params.set('account', account);
     if (q) params.set('q', q);
     const suffix = params.toString() ? `?${params.toString()}` : '';
-    const { data } = await atryumApi.get(`/api/v1/admin/managed-agents/agents${suffix}`);
+    const { data } = await atryumApi.get(`/api/v1/managed-agents/agents${suffix}`);
     return data;
   },
 };
@@ -690,14 +690,14 @@ export interface AgentSyncSettings {
 
 export const settingsApi = {
   get: async (): Promise<AgentSyncSettings> => {
-    const { data } = await atryumApi.get('/api/v1/admin/settings');
+    const { data } = await atryumApi.get('/api/v1/settings');
     return data;
   },
 
   update: async (
     input: Omit<AgentSyncSettings, 'updated_at' | 'sync_error'>,
   ): Promise<AgentSyncSettings> => {
-    const { data } = await atryumApi.put('/api/v1/admin/settings', input);
+    const { data } = await atryumApi.put('/api/v1/settings', input);
     return data;
   },
 };
@@ -711,7 +711,7 @@ export interface ModelConfig {
 
 export const modelConfigsApi = {
   list: async (): Promise<{ items: ModelConfig[]; total: number }> => {
-    const { data } = await atryumApi.get('/api/v1/admin/model-configs');
+    const { data } = await atryumApi.get('/api/v1/model-configs');
     return data;
   },
 };
@@ -769,25 +769,25 @@ export interface LLMConfigInput {
 
 export const llmConfigsApi = {
   list: async (): Promise<{ items: LLMConfig[] }> => {
-    const { data } = await atryumApi.get('/api/v1/admin/llm-configs');
+    const { data } = await atryumApi.get('/api/v1/llm-configs');
     return data;
   },
 
   create: async (input: LLMConfigInput): Promise<LLMConfig> => {
-    const { data } = await atryumApi.post('/api/v1/admin/llm-configs', input);
+    const { data } = await atryumApi.post('/api/v1/llm-configs', input);
     return data;
   },
 
   update: async (id: string, input: Partial<LLMConfigInput>): Promise<LLMConfig> => {
     const { data } = await atryumApi.patch(
-      `/api/v1/admin/llm-configs/${encodeURIComponent(id)}`,
+      `/api/v1/llm-configs/${encodeURIComponent(id)}`,
       input,
     );
     return data;
   },
 
   remove: async (id: string): Promise<void> => {
-    await atryumApi.delete(`/api/v1/admin/llm-configs/${encodeURIComponent(id)}`);
+    await atryumApi.delete(`/api/v1/llm-configs/${encodeURIComponent(id)}`);
   },
 };
 
@@ -795,7 +795,7 @@ export const llmConfigsApi = {
 
 export const vmDiscoveryApi = {
   listOrganizations: async (): Promise<VmOrgListResponse> => {
-    const { data } = await atryumApi.get('/api/v1/admin/vm/organizations');
+    const { data } = await atryumApi.get('/api/v1/vm/organizations');
     return data;
   },
 
@@ -803,7 +803,7 @@ export const vmDiscoveryApi = {
     orgCUID: string,
   ): Promise<{ items: VmRecordType[]; total: number }> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/vm/record-types?org_cuid=${encodeURIComponent(orgCUID)}`,
+      `/api/v1/vm/record-types?org_cuid=${encodeURIComponent(orgCUID)}`,
     );
     return data;
   },
@@ -813,7 +813,7 @@ export const vmDiscoveryApi = {
     recordTypeSlug: string,
   ): Promise<{ items: VmCustomField[]; total: number }> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/vm/custom-fields?org_cuid=${encodeURIComponent(orgCUID)}&record_type_slug=${encodeURIComponent(recordTypeSlug)}`,
+      `/api/v1/vm/custom-fields?org_cuid=${encodeURIComponent(orgCUID)}&record_type_slug=${encodeURIComponent(recordTypeSlug)}`,
     );
     return data;
   },

--- a/ui/src/api/AtryumAPI.ts
+++ b/ui/src/api/AtryumAPI.ts
@@ -132,21 +132,21 @@ export const invocationsApi = {
     if (filters.offset != null) params.set('offset', String(filters.offset));
     params.set('limit', String(filters.limit ?? 50));
     const { data } = await atryumApi.get(
-      `/api/v1/admin/invocations?${params.toString()}`,
+      `/api/v1/review/invocations?${params.toString()}`,
     );
     return data;
   },
 
   detail: async (id: string): Promise<InvocationDetail> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}`,
     );
     return data;
   },
 
   events: async (id: string): Promise<{ items: InvocationEvent[] }> => {
     const { data } = await atryumApi.get(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}/events?limit=200`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}/events?limit=200`,
     );
     return data;
   },
@@ -156,7 +156,7 @@ export const invocationsApi = {
     body?: { create_rule?: RuleInput },
   ): Promise<void> => {
     await atryumApi.post(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}/approve`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}/approve`,
       body ?? {},
     );
   },
@@ -170,7 +170,7 @@ export const invocationsApi = {
     if (message) body.message = message;
     if (createRule) body.create_rule = createRule;
     await atryumApi.post(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}/deny`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}/deny`,
       body,
     );
   },
@@ -181,7 +181,7 @@ export const invocationsApi = {
   ): Promise<{ summary: string }> => {
     const body = modelConfigCuid ? { model_config_cuid: modelConfigCuid } : {};
     const { data } = await atryumApi.post(
-      `/api/v1/admin/invocations/${encodeURIComponent(id)}/summarize`,
+      `/api/v1/review/invocations/${encodeURIComponent(id)}/summarize`,
       body,
     );
     return data;

--- a/ui/src/auth/adminAuth.tsx
+++ b/ui/src/auth/adminAuth.tsx
@@ -66,7 +66,7 @@ let authCallbackPromise: Promise<void> | null = null;
 const SELECTED_PROVIDER_KEY = 'atryum.adminAuth.provider';
 
 const fetchConfig = async (): Promise<AdminAuthConfig> => {
-  const res = await fetch('/api/v1/admin-auth/config', {
+  const res = await fetch('/api/v1/auth/config', {
     headers: { Accept: 'application/json' },
   });
   if (!res.ok) throw new Error(`admin auth config failed (${res.status})`);

--- a/ui/src/hooks/useApprovalNotifications.ts
+++ b/ui/src/hooks/useApprovalNotifications.ts
@@ -86,7 +86,7 @@ const parseInvocationStreamPayload = (
   }
 };
 
-const STREAM_URL = '/api/v1/admin/invocations/stream?status=pending_approval&limit=50';
+const STREAM_URL = '/api/v1/review/invocations/stream?status=pending_approval&limit=50';
 
 const ensurePermissionAfterUserGesture = (onPermissionGranted: () => void) => {
   if (!('Notification' in window) || Notification.permission !== 'default') {

--- a/ui/src/hooks/useApprovalNotifications.ts
+++ b/ui/src/hooks/useApprovalNotifications.ts
@@ -13,7 +13,7 @@ interface PlansPayload {
 const NOTIFICATION_TITLE = 'Atryum approval needed';
 const NOTIFICATION_ICON = '/ui/atryum-notification-icon.svg';
 const PENDING_PLANS_STREAM_URL =
-  '/api/v1/admin/plans/stream?status=pending_approval&limit=50';
+  '/api/v1/plans/stream?status=pending_approval&limit=50';
 
 const buildNotificationBody = (invocation: Invocation): string => {
   const parts = [invocation.agent_id, invocation.server_name, invocation.tool_name]

--- a/ui/src/hooks/useInvocationStream.ts
+++ b/ui/src/hooks/useInvocationStream.ts
@@ -24,7 +24,7 @@ const buildStreamUrl = (filters: InvocationFilters): string => {
   if (filters.status) params.set('status', filters.status);
   if (filters.client_name) params.set('client_name', filters.client_name);
   params.set('limit', String(filters.limit ?? 50));
-  return `/api/v1/admin/invocations/stream?${params.toString()}`;
+  return `/api/v1/review/invocations/stream?${params.toString()}`;
 };
 
 const detailKey = (id: string): QueryKey => [INVOCATION_DETAIL_KEY, id];

--- a/ui/src/hooks/usePlanStream.ts
+++ b/ui/src/hooks/usePlanStream.ts
@@ -19,7 +19,7 @@ const buildStreamUrl = (filters: PlanFilters): string => {
   if (filters.agent_id) params.set('agent_id', filters.agent_id);
   if (filters.offset != null) params.set('offset', String(filters.offset));
   params.set('limit', String(filters.limit ?? 50));
-  return `/api/v1/admin/plans/stream?${params.toString()}`;
+  return `/api/v1/plans/stream?${params.toString()}`;
 };
 
 export const usePlanStream = (

--- a/website/documentation/1_integrations/2_connect-agents.html
+++ b/website/documentation/1_integrations/2_connect-agents.html
@@ -290,7 +290,7 @@ admin_scopes = &quot;openid profile email atryum:mcp&quot;
 admin_claim = &quot;atryum_admin&quot;
 admin_claim_value = true</code></pre><button class="copy-btn code-block-copy-btn" type="button" data-command="[[auth]]&#10;enabled = true&#10;issuer = &quot;http://localhost:8089/realms/atryum&quot;&#10;audience = &quot;atryum&quot;&#10;required_scope = &quot;atryum:mcp&quot;&#10;agent_id_claim = &quot;client_id&quot;&#10;&#10;admin_enabled = true&#10;admin_provider = &quot;keycloak&quot;&#10;admin_client_id = &quot;atryum-admin&quot;&#10;admin_scopes = &quot;openid profile email atryum:mcp&quot;&#10;admin_claim = &quot;atryum_admin&quot;&#10;admin_claim_value = true" aria-label="Copy code block"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg><span>Copy</span></button></div>
 
-        <p>Multiple admin-enabled IdPs can be configured at the same time. The frontend discovers them from <code>/api/v1/admin-auth/config</code>; with one provider it shows a sign-in screen without a provider selector, and with several it shows an identity-provider selector.</p>
+        <p>Multiple admin-enabled IdPs can be configured at the same time. The frontend discovers them from <code>/api/v1/auth/config</code>; with one provider it shows a sign-in screen without a provider selector, and with several it shows an identity-provider selector.</p>
 
         <p>For local Keycloak, run the setup script after Keycloak is available:</p>
 

--- a/website/md-drafts/1_integrations/2_connect-agents.md
+++ b/website/md-drafts/1_integrations/2_connect-agents.md
@@ -406,7 +406,7 @@ admin_claim = "atryum_admin"
 admin_claim_value = true
 ```
 
-Multiple admin-enabled IdPs can be configured at the same time. The frontend discovers them from `/api/v1/admin-auth/config`; with one provider it shows a sign-in screen without a provider selector, and with several it shows an identity-provider selector.
+Multiple admin-enabled IdPs can be configured at the same time. The frontend discovers them from `/api/v1/auth/config`; with one provider it shows a sign-in screen without a provider selector, and with several it shows an identity-provider selector.
 
 For local Keycloak, run the setup script after Keycloak is available:
 


### PR DESCRIPTION
## Summary
- remove the /api/v1/admin namespace from every current resource route
- use /api/v1/review/invocations for the invocation review workflow
- move plans and operator resources to resource-oriented /api/v1 paths
- rename Go handlers to review* and operator* to match their route roles
- split router wrappers into review(...) and operator(...); both intentionally delegate to the legacy admin-token middleware on this standalone branch
- move browser auth discovery to /api/v1/auth/config
- update the Atryum UI, integrations, examples, tests, README, and configuration comments
- keep no compatibility aliases; removed paths return 404

## Route groups
- review invocations: /api/v1/review/invocations
- plans: /api/v1/plans
- operator resources: /api/v1/servers, /rules, /agents, /model-configs, /llm-configs, /settings, /vm, /policy, and /managed-agents

## Authorization layering
Review and operator wrappers are separate by design. Their behavior remains unchanged in this standalone rename: both use the existing admin-token middleware. The later access-control work can map review routes, including plans, to its protected tier while retaining operator routes as privileged.

## Verification
- go test ./...
- cd ui && npm run build

## Compatibility
This is intentionally a breaking route rename with no legacy aliases.