### PR TITLE
Add v0.3.0 changelog; fix stale module path in release ldflags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-24
+
+### Added
+
+- Atryum can now be embedded as a Go library by downstream programs: import
+  `github.com/validmind/atryum/pkg/atryum` and call `atryum.Main(...)` from
+  another binary's `main` package, with `WithRoutes`, `WithMigrations`, and
+  `WithDatabase` extension points.
+- Agent plan preapproval: agents can submit an entire plan for approval
+  before executing its individual tool calls. Each planned action is
+  evaluated against the existing invocation rules, and a shared LLM judge
+  reviews the whole plan for charter compliance once.
+- Server-side session get-or-create, keyed by agent binding and the
+  caller's own client session ID. Harnesses (the shared Claude Code/Cursor/
+  Codex hook, amp, pi) now just send their own session/thread ID on every
+  tool call — Atryum resolves or creates the matching session itself, so
+  no harness needs to mint, cache, or retry session creation anymore.
+- Harnesses can poll a rules endpoint every 5 minutes to fetch their
+  current approval rules, so agents can read their own rules and reduce
+  denied calls; the MCP rules tool is available again as well.
+- Charter preview for agents in the admin UI: synced agents show the
+  charter hierarchy assembled from the ValidMind backend, local agents
+  show their own stored charter.
+- Logout button in the UI.
+- Copy-to-clipboard button on the MCP Endpoint field.
+- CI workflow publishing the production Atryum image to Docker Hub.
+- Initial architecture documentation.
+
+### Fixed
+
+- `ClearSessions` now stops each session's background watcher immediately
+  after that session's own delete succeeds, instead of deleting everything
+  first and cancelling watchers in a second pass — a delete failing partway
+  through could previously leave already-deleted sessions with a watcher
+  still running (and still able to approve/deny tool calls) until the
+  process restarted. The reported cleared-count is also now the honest
+  partial count rather than always `0` on error.
+- A rule whose stored server/tool/agent scope had become corrupted (bad
+  manual edit, partial write, disk corruption) could silently start
+  matching everything it wasn't scoped to; corrupted rule data now blocks
+  the rule load and falls back to human review instead.
+- A database error while loading rules during an external tool-call
+  submission is now logged and recorded in the invocation's audit trail,
+  instead of failing silently.
+- `Invoke` no longer falls through to the permissive global policy when
+  approval-rule loading fails (e.g. a brief database hiccup) — a rule-load
+  failure now safely requires human approval and is logged, matching how
+  `Submit` already behaved.
+- AI-decided invocations (hard denials and auto-approvals) now persist
+  their `matched_rule_id`, so the invocation audit view no longer mislabels
+  a still-present rule as "Deleted Rule". The UI also distinguishes a rule
+  that is simply not in the loaded list ("Unknown rule") from one that is
+  genuinely unrecorded or deleted.
+- Doc generation (`just docs`) no longer chops off the first character of
+  3-space-indented numbered-list continuation lines.
+
+### Security
+
+- Fixed an issue where an external executor could mark a tool invocation
+  as completed, failed, or cancelled before it was approved — bypassing
+  human approval and forging the audit record. Execution outcomes can now
+  only be reported for approved invocations, executors may only report on
+  their own invocations, and recorded outcomes can no longer be
+  overwritten; retrying an already-recorded outcome is a safe no-op.
+
 ## [0.2.0] - 2026-07-14
 
 ### Added
@@ -70,7 +135,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.3] - 2026-06-05
 
-[Unreleased]: https://github.com/validmind/atryum/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/validmind/atryum/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/validmind/atryum/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/validmind/atryum/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/validmind/atryum/compare/v0.0.4...v0.1.0
 [0.0.4]: https://github.com/validmind/atryum/compare/v0.0.3...v0.0.4

--- a/Justfile
+++ b/Justfile
@@ -181,7 +181,7 @@ release-build tag:
           local goarch="$2"
           local out="atryum-${goos}-${goarch}"
 
-          (cd "$build_dir" && GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -trimpath -tags release_notices -ldflags "-X atryum/internal/version.Version={{tag}}" -o "$release_dir/$out" ./cmd/atryum)
+          (cd "$build_dir" && GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -trimpath -tags release_notices -ldflags "-X github.com/validmind/atryum/internal/version.Version={{tag}}" -o "$release_dir/$out" ./cmd/atryum)
         }
 
         # Build targets

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,5 +2,5 @@
 package version
 
 // Version is "dev" for local builds. Release builds inject the release tag
-// via -ldflags "-X atryum/internal/version.Version=<tag>".
+// via -ldflags "-X github.com/validmind/atryum/internal/version.Version=<tag>".
 var Version = "dev"


### PR DESCRIPTION
Changelog: agent plan preapproval, embeddable-library extension points (pkg/atryum), server-side session get-or-create, rules-polling for agents, charter preview, logout button, MCP endpoint copy button, Docker Hub image publishing, plus the ClearSessions zombie-watcher fix, two rule-loading fail-safe fixes, and the RecordExecution approval- bypass security fix.

Also fixes release-build's version ldflags: the module path changed from `atryum` to `github.com/validmind/atryum` (#137) but the -X target was never updated, so a release binary would silently report "dev" instead of the tag (confirmed: go build accepts an unmatched -X target without warning). The release-build version self-report check would have caught this at release time, but it's better fixed now than relied on.