### PR TITLE
fix: persist matched_rule_id for AI-decided invocations

### DIFF
--- a/internal/invocation/agent_id_test.go
+++ b/internal/invocation/agent_id_test.go
@@ -48,6 +48,17 @@ func TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents(t *testing.T) {
 		ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"},
 		Enabled: true,
 	}}}
+	// The stub decides which rule matches, but the id it hands back is still
+	// written to invocations.matched_rule_id, which carries a FK to
+	// approval_rules(id). Auto-approved invocations now persist that id, so the
+	// row has to exist for the write to succeed.
+	if err := store.NewRulesRepo(db).Create(context.Background(), store.Rule{
+		ID: "rule_auto_approve", Action: string(invocation.RuleActionAutoApprove),
+		ServerPatterns: []string{"*"}, ToolPatterns: []string{"*"},
+		Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	svc := invocation.NewService(
 		store.NewInvocationRepo(db), store.NewEventRepo(db), resolver,

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -496,10 +496,16 @@ func (s *Service) Invoke(ctx context.Context, req CreateInvocationRequest) (Invo
 			decision = policy.Decision{Disposition: policy.DispositionHuman, Reason: "policy error: " + policyErr.Error()}
 		}
 	}
-	// Persist matched_rule_id for human-approval invocations so approve/deny handlers can reference it.
-	// Also tag AI-escalated invocations so the UI can distinguish them from direct human_approval rules.
+	// Record the rule that decided this call regardless of disposition. AI-decided
+	// invocations (DispositionNever/DispositionAuto) need it just as much as gated
+	// ones: without it the audit view has no rule to name and has to guess. The
+	// downstream denyByPolicy/executeNow calls carry inv onward and their
+	// UpdateResult persists the id, so no extra write is needed here for those.
+	inv.MatchedRuleID = matchedRuleID
+	// Human-gated invocations must be written now, before the wait, so approve/deny
+	// handlers can reference the rule. Also tag AI-escalated invocations so the UI
+	// can distinguish them from direct human_approval rules.
 	if decision.Disposition == policy.DispositionHuman || decision.Disposition == policy.DispositionWorkflow || decision.Disposition == dispositionAIEscalated {
-		inv.MatchedRuleID = matchedRuleID
 		if decision.Disposition == dispositionAIEscalated {
 			inv.Approval = newApproval("ai_escalated", decision.Reason, aiConfidence)
 		}

--- a/internal/invocation/service_test.go
+++ b/internal/invocation/service_test.go
@@ -1403,6 +1403,127 @@ func newTestService(t *testing.T, cfg config.Config) *invocation.Service {
 	return invocation.NewService(store.NewInvocationRepo(db), store.NewEventRepo(db), resolver, mcp.NewHTTPClient(), policy.AlwaysApproveProvider{}, 5*time.Second, nil, nil, nil, nil)
 }
 
+// AI-decided invocations on the proxy Invoke path must persist the rule that
+// decided them. When they don't, the audit view has no id to look up and
+// misreports the (still-present) rule as deleted — sc-17298.
+func TestInvokeAIEvaluationPersistsMatchedRuleID(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		verdict    string
+		wantStatus invocation.Status
+	}{
+		{name: "denied", verdict: "denied", wantStatus: invocation.StatusDenied},
+		{name: "approved", verdict: "approved", wantStatus: invocation.StatusSucceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode: %v", err)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				switch body["method"] {
+				case "initialize":
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"jsonrpc": "2.0", "id": body["id"],
+						"result": map[string]any{
+							"serverInfo":   map[string]any{"name": "fake-shortcut", "version": "0.1.0"},
+							"capabilities": map[string]any{},
+						},
+					})
+				case "notifications/initialized":
+					w.WriteHeader(http.StatusAccepted)
+				case "tools/list":
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"jsonrpc": "2.0", "id": body["id"],
+						"result": map[string]any{"tools": []map[string]any{{
+							"name": "stories-get-by-id", "description": "Fetch a story.",
+						}}},
+					})
+				case "tools/call":
+					_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": body["id"], "result": map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}})
+				default:
+					t.Errorf("unexpected method: %v", body["method"])
+					w.WriteHeader(http.StatusBadRequest)
+				}
+			}))
+			defer upstream.Close()
+
+			db := newSQLiteTestDB(t)
+			resolver := mcp.NewResolver(store.NewServerRepo(db), config.Config{
+				Upstreams: []config.UpstreamConfig{{Name: "shortcut", Mode: "http", BaseURL: upstream.URL, Enabled: true, TimeoutSeconds: 5}},
+			})
+			if err := resolver.BootstrapIfEmpty(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+
+			defaultAgent := invocation.AgentRecord{
+				ID:                 "agent-local-default",
+				VMCUID:             "agent-vm-default",
+				VMOrganizationCUID: "org-default",
+				Charter:            "Deny destructive tool calls, otherwise approve.",
+			}
+			// Use the real rules repo, not a stub: invocations.matched_rule_id carries
+			// a FOREIGN KEY to approval_rules(id), so only a persisted rule proves the
+			// id actually lands in the row.
+			rules := store.NewRulesRepo(db)
+			if err := rules.Create(context.Background(), store.Rule{
+				ID:              "rule-ai-shortcut",
+				Action:          string(invocation.RuleActionAIEvaluation),
+				ServerPatterns:  []string{"shortcut"},
+				ToolPatterns:    []string{"stories-get-by-id"},
+				ModelConfigCUID: "model-ai",
+				Description:     "AI-evaluate Shortcut reads",
+				Enabled:         true,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			invocations := store.NewInvocationRepo(db)
+			service := invocation.NewService(
+				invocations,
+				store.NewEventRepo(db),
+				resolver,
+				mcp.NewHTTPClient(),
+				nil,
+				5*time.Second,
+				rules,
+				agentLookupStub{byVMCUID: map[string]invocation.AgentRecord{defaultAgent.VMCUID: defaultAgent}},
+				&evaluateClientStub{resp: invocation.EvaluateResponse{Verdict: tc.verdict, Reason: "charter says so"}},
+				summarySettingsStub{
+					charterFieldKey:    "constitution",
+					defaultAgentVMCUID: defaultAgent.VMCUID,
+				},
+			)
+
+			resp, err := service.Invoke(context.Background(), invocation.CreateInvocationRequest{
+				Server: "shortcut",
+				Tool:   "stories-get-by-id",
+				Input:  map[string]any{"storyPublicId": 17298},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q", resp.Status, tc.wantStatus)
+			}
+			if resp.MatchedRuleID == nil || *resp.MatchedRuleID != "rule-ai-shortcut" {
+				t.Errorf("response matched rule id = %v, want rule-ai-shortcut", resp.MatchedRuleID)
+			}
+			// The audit view reads the stored row, not the response, so that is
+			// the assertion that actually pins the bug.
+			stored, err := invocations.Get(context.Background(), resp.InvocationID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stored.MatchedRuleID == nil || *stored.MatchedRuleID != "rule-ai-shortcut" {
+				t.Fatalf("persisted matched rule id = %v, want rule-ai-shortcut", stored.MatchedRuleID)
+			}
+		})
+	}
+}
+
 type summaryClientStub struct {
 	mu      sync.Mutex
 	summary string

--- a/ui/src/hooks/useInvocationStream.ts
+++ b/ui/src/hooks/useInvocationStream.ts
@@ -71,7 +71,8 @@ export const useInvocationStream = (
 
       // Also refresh the rules cache: a new invocation may reference a rule
       // that was created after the rules list was last fetched, which would
-      // cause the audit display to show "*Deleted Rule*" for a valid rule.
+      // cause the audit display to fall back to "*Unknown rule (…)*" for a
+      // rule that is perfectly valid and simply not loaded yet.
       void queryClient.invalidateQueries([RULES_KEY]);
 
       const currentSelectedId = selectedIdRef.current;

--- a/ui/src/pages/Invocations.tsx
+++ b/ui/src/pages/Invocations.tsx
@@ -165,7 +165,14 @@ const AuditEntryRow: React.FC<{ entry: AuditEntry }> = ({ entry }) => {
             color="text.subtle"
             flexShrink={0}
           />
-          <Text fontSize="sm" fontWeight="medium" noOfLines={1}>
+          {/* The name can be a label derived from the rule's action and
+              patterns when the rule has no description, so expose the id on
+              hover — that is what pins down which rule this actually was. */}
+          <Text
+            fontSize="sm"
+            fontWeight="medium"
+            noOfLines={1}
+            title={entry.ruleId ?? undefined}>
             {entry.ruleName ?? "*No rule matched*"}
           </Text>
           {badge}

--- a/ui/src/pages/Rules.tsx
+++ b/ui/src/pages/Rules.tsx
@@ -24,6 +24,7 @@ import { CreateRuleModal } from '../components/CreateRuleModal';
 import { useRules, useMoveRule } from '../hooks/useRules';
 import { useAgents } from '../hooks/useAgents';
 import { type Agent, type Rule, type RuleAction } from '../api/AtryumAPI';
+import { RULE_ACTION_LABEL } from '../utils/invocationDisplay';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -34,12 +35,9 @@ const ACTION_COLOR: Record<RuleAction, string> = {
   ai_evaluation: 'purple',
 };
 
-const ACTION_LABEL: Record<RuleAction, string> = {
-  auto_approve: 'Auto Approve',
-  auto_deny: 'Auto Deny',
-  human_approval: 'Human Approval',
-  ai_evaluation: 'AI Evaluation',
-};
+// Shared with the invocation audit view, which derives a display name for rules
+// that have no description — the two must agree on what each action is called.
+const ACTION_LABEL = RULE_ACTION_LABEL;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/ui/src/utils/invocationDisplay.ts
+++ b/ui/src/utils/invocationDisplay.ts
@@ -1,4 +1,9 @@
-import type { Invocation, Rule, InvocationEvent } from '../api/AtryumAPI';
+import type {
+  Invocation,
+  Rule,
+  RuleAction,
+  InvocationEvent,
+} from '../api/AtryumAPI';
 
 export const STATUS_COLOR: Record<string, string> = {
   pending_approval: 'orange',
@@ -200,6 +205,36 @@ export function buildInvocationAudit(
   return entries;
 }
 
+export const RULE_ACTION_LABEL: Record<RuleAction, string> = {
+  auto_approve: 'Auto Approve',
+  auto_deny: 'Auto Deny',
+  human_approval: 'Human Approval',
+  ai_evaluation: 'AI Evaluation',
+};
+
+const rulePatternLabel = (patterns: string[]): string =>
+  patterns.length === 0 ? 'all' : patterns.join(', ');
+
+/**
+ * Display name for a rule we actually hold. Description is optional on a rule,
+ * so falling straight through to an "unknown rule" label would claim ignorance
+ * about a rule sitting right there. What it does and what it matches identifies
+ * it well enough to find on the Rules page.
+ */
+export const ruleDisplayName = (rule: Rule): string =>
+  rule.description?.trim() ||
+  `${RULE_ACTION_LABEL[rule.action]} · servers: ${rulePatternLabel(
+    rule.server_patterns,
+  )} · tools: ${rulePatternLabel(rule.tool_patterns)}`;
+
+// Label for a rule we have an id for but no loaded record. A present id can never
+// refer to a deleted rule: matched_rule_id is a FK with ON DELETE SET NULL, so
+// deleting a rule nulls the column rather than leaving it dangling. The id is
+// therefore valid and simply missing from the loaded rules list (see the RULES_KEY
+// invalidation in useInvocationStream) — most often because that list has not
+// finished loading. Callers surface the id itself on hover.
+const unresolvedRuleLabel = '*Unavailable rule*';
+
 function buildAuditFromEvents(
   inv: InvocationAuditInput,
   rules: Rule[],
@@ -220,8 +255,11 @@ function buildAuditFromEvents(
     const d = (evt.data ?? {}) as RuleEvaluatedEventData;
     const ruleId = d.rule_id ?? null;
     const rule = ruleId ? (rules.find((r) => r.id === ruleId) ?? null) : null;
-    const ruleName =
-      rule?.description ?? (ruleId ? '*Deleted Rule*' : null);
+    const ruleName = rule
+      ? ruleDisplayName(rule)
+      : ruleId
+        ? unresolvedRuleLabel
+        : null;
     const isAIEval = d.action === 'ai_evaluation' && !!ruleId;
     const confidence = d.confidence;
     const aiReason =
@@ -279,19 +317,22 @@ function buildAuditFromApproval(
     approvalStatus === 'ai_escalated_approved' ||
     approvalStatus === 'ai_escalated_denied';
 
-  // When matched_rule_id is absent but the reason indicates a specific rule was
-  // AI-evaluated (not the all-deferred fallback), the rule likely existed and
-  // was since deleted. Distinguish that from a genuine no-match fallback.
+  // An AI-evaluated decision with no matched_rule_id did match a specific rule
+  // (the all-deferred fallback is the one case that didn't) — we just cannot name
+  // it. Two indistinguishable causes: the invocation predates matched_rule_id
+  // being persisted on the AI-decided paths, or the rule was deleted and the
+  // column's ON DELETE SET NULL cleared it. Name both instead of asserting the
+  // deletion, which was wrong for every pre-fix record.
   const isAIAllDeferred = reason.startsWith(
     'ai_evaluation: all matching rules deferred',
   );
-  const ruleName =
-    rule?.description ??
-    (ruleId
-      ? '*Deleted Rule*'
+  const ruleName = rule
+    ? ruleDisplayName(rule)
+    : ruleId
+      ? unresolvedRuleLabel
       : isAIEval && !isAIAllDeferred
-        ? '*Deleted Rule*'
-        : null);
+        ? '*Unrecorded or deleted rule*'
+        : null;
 
   const steps = resolveDecisionSteps(
     approvalStatus ?? '',


### PR DESCRIPTION
The proxy Invoke path assigned inv.MatchedRuleID inside a branch covering only DispositionHuman, DispositionWorkflow, and dispositionAIEscalated, so AI-decided invocations — hard denials and auto-approvals — were stored with matched_rule_id = null. The audit view then had no id to look up and reported the still-present rule as "*Deleted Rule*".

Assign MatchedRuleID unconditionally before the disposition switch. The downstream denyByPolicy/executeNow calls carry inv onward and their UpdateResult already writes the column, so the remaining conditional write does only what it must: persist human-gated invocations before the wait so approve/deny handlers can reference the rule. This matches the Submit path, which has always set the id unconditionally.

On the UI side, stop inferring deletion from a missing rule. matched_rule_id is a FK with ON DELETE SET NULL, so a present id can never refer to a deleted rule — it is simply absent from the loaded rules list, and now renders as "*Unknown rule (<id>)*". A null id on an AI decision has two indistinguishable causes, a pre-fix record or a genuine deletion, so it renders as "*Unrecorded or deleted rule*" rather than asserting either.

TestInvokeUsesAuthenticatedAgentIDForRulesAndEvents needed an approval_rules row added: it feeds a rule id from a stub rules store, and the auto-approve path now actually writes that id, which the FK rejects without the row.

The equivalent copy of invocationDisplay.ts in the validmind/frontend repo still carries the old label and needs the same change.