### PR TITLE
fix: enforce agent ownership on GET /api/v1/external/invocations/{id}

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -4394,11 +4394,15 @@ func (h *Handler) externalInvocationDetail(w http.ResponseWriter, r *http.Reques
 	case http.MethodGet:
 		resp, err := h.svc.Get(r.Context(), id)
 		if err != nil {
-			status := http.StatusInternalServerError
-			if err == sql.ErrNoRows {
-				status = http.StatusNotFound
+			// Not-found and not-owner map to the same generic 404 so a
+			// non-owning caller can't distinguish "doesn't exist" from
+			// "exists but belongs to another agent" (existence would
+			// otherwise leak through the error path).
+			if err == sql.ErrNoRows || errors.Is(err, invocation.ErrNotOwner) {
+				writeError(w, http.StatusNotFound, "not found")
+				return
 			}
-			writeError(w, status, err.Error())
+			writeError(w, http.StatusInternalServerError, err.Error())
 			return
 		}
 		writeJSON(w, http.StatusOK, resp)

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -2218,6 +2218,39 @@ func TestExternalInvocationPatchErrorStatusMapping(t *testing.T) {
 	}
 }
 
+func TestExternalInvocationGetErrorStatusMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"not owner maps to 404", fmt.Errorf("invocation inv_1: %w", invocation.ErrNotOwner), http.StatusNotFound},
+		{"missing invocation maps to 404", sql.ErrNoRows, http.StatusNotFound},
+		{"generic error maps to 500", fmt.Errorf("boom"), http.StatusInternalServerError},
+		{"success maps to 200", nil, http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &stubService{getErr: tc.err}
+			h := NewHandler(svc, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/external/invocations/inv_1", nil)
+			w := httptest.NewRecorder()
+			h.Routes().ServeHTTP(w, req)
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body=%s)", w.Code, tc.wantStatus, w.Body.String())
+			}
+			// The not-owner 404 must read identically to a real "missing
+			// invocation" 404 — a distinguishable body would leak that the
+			// invocation exists to a non-owning caller.
+			if tc.wantStatus == http.StatusNotFound {
+				if got, want := w.Body.String(), `{"error":{"message":"not found"}}`+"\n"; got != want {
+					t.Fatalf("body = %q, want %q (must not leak ownership details)", got, want)
+				}
+			}
+		})
+	}
+}
+
 func TestAddExtraRoutesMountsRoutesOutsideAuthChains(t *testing.T) {
 	h := NewHandler(&stubService{}, stubServerService{}, nil, nil, nil, nil, nil, nil, nil, nil)
 	// A configured validator protects the normal runtime and privileged routes;

--- a/internal/invocation/record_execution_test.go
+++ b/internal/invocation/record_execution_test.go
@@ -324,3 +324,57 @@ func TestRecordExecutionEnforcesAgentOwnership(t *testing.T) {
 		}
 	})
 }
+
+// TestGetEnforcesAgentOwnership guards against a caller who knows another
+// agent's invocation_id reading that agent's tool input/output/error via
+// GET /api/v1/external/invocations/{id} — the same ownership boundary
+// RecordExecution enforces on the write path (TestRecordExecutionEnforcesAgentOwnership).
+func TestGetEnforcesAgentOwnership(t *testing.T) {
+	t.Run("different agent is rejected", func(t *testing.T) {
+		svc := newRecordExecutionService(t)
+		id := submitExternal(t, svc, "agent-a")
+		ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-b"})
+		_, err := svc.Get(ctx, id)
+		if !errors.Is(err, invocation.ErrNotOwner) {
+			t.Fatalf("err = %v, want ErrNotOwner", err)
+		}
+	})
+
+	t.Run("owning agent is allowed", func(t *testing.T) {
+		svc := newRecordExecutionService(t)
+		id := submitExternal(t, svc, "agent-a")
+		ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-a"})
+		resp, err := svc.Get(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.InvocationID != id {
+			t.Fatalf("invocation_id = %q, want %q", resp.InvocationID, id)
+		}
+	})
+
+	t.Run("caller without identity is exempt", func(t *testing.T) {
+		svc := newRecordExecutionService(t)
+		id := submitExternal(t, svc, "agent-a")
+		resp, err := svc.Get(context.Background(), id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.InvocationID != id {
+			t.Fatalf("invocation_id = %q, want %q", resp.InvocationID, id)
+		}
+	})
+
+	t.Run("anonymous invocation accepts any identity", func(t *testing.T) {
+		svc := newRecordExecutionService(t)
+		id := submitExternal(t, svc, "")
+		ctx := auth.WithIdentity(context.Background(), auth.Identity{AgentID: "agent-b"})
+		resp, err := svc.Get(ctx, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.InvocationID != id {
+			t.Fatalf("invocation_id = %q, want %q", resp.InvocationID, id)
+		}
+	})
+}

--- a/internal/invocation/service.go
+++ b/internal/invocation/service.go
@@ -1728,8 +1728,8 @@ func (s *Service) summarizePendingApproval(invocationID string) {
 // pending_approval, or after a human denied it.
 var ErrInvalidTransition = errors.New("invalid execution status transition")
 
-// ErrNotOwner is returned by RecordExecution when the verified agent identity
-// on the request does not match the agent the invocation belongs to.
+// ErrNotOwner is returned by Get and RecordExecution when the verified agent
+// identity on the request does not match the agent the invocation belongs to.
 var ErrNotOwner = errors.New("invocation belongs to a different agent")
 
 // requireStatus rejects an execution-status transition unless the invocation
@@ -1741,6 +1741,31 @@ func requireStatus(inv Invocation, target string, allowed ...Status) error {
 		}
 	}
 	return fmt.Errorf("invocation %s cannot move to %s from %s: %w", inv.InvocationID, target, inv.Status, ErrInvalidTransition)
+}
+
+// checkOwnership rejects access to inv when the request carries an
+// authenticated agent identity that does not match the invocation's owner.
+// Both the read (Get) and write (RecordExecution) paths on
+// /api/v1/external/invocations/{id} run under the agent-runtime OAuth
+// middleware, so in auth mode ctx carries the authenticated caller
+// (inv.AgentID is set from that same identity at Submit time, so a match
+// proves ownership). Invocations submitted anonymously (no agent_id) skip
+// the check, as does any caller with no identity in context — no-auth mode,
+// or the in-process managed-agents watcher and operator/review routes, which
+// authenticate by a different path and never carry an agent identity.
+func checkOwnership(ctx context.Context, inv Invocation) error {
+	callerID := strings.TrimSpace(auth.AgentIDFromContext(ctx))
+	if callerID == "" {
+		return nil
+	}
+	owner := ""
+	if inv.AgentID != nil {
+		owner = strings.TrimSpace(*inv.AgentID)
+	}
+	if owner != "" && owner != callerID {
+		return fmt.Errorf("invocation %s: %w", inv.InvocationID, ErrNotOwner)
+	}
+	return nil
 }
 
 // RecordExecution updates an externally-executed invocation with the outcome
@@ -1758,26 +1783,12 @@ func (s *Service) RecordExecution(ctx context.Context, invocationID string, upda
 	if err != nil {
 		return InvocationResponse{}, err
 	}
-	// Ownership: update.Result/Error are surfaced to the judge as trusted
-	// evidence, so a caller who knows another agent's invocation_id could
-	// poison that agent's session context. The PATCH
-	// /api/v1/external/invocations/{id} route runs under the agent-runtime
-	// OAuth middleware, so in auth mode ctx carries the authenticated caller.
-	// When an identity is present, reject any attempt to write an invocation
-	// this agent does not own (inv.AgentID is set from the authenticated
-	// identity at Submit time, so a match proves ownership). Invocations
-	// submitted anonymously (no agent_id) skip the ownership check. In no-auth
-	// mode there is no identity to check against — behavior is unchanged, and
-	// the in-process managed-agents watcher (which calls RecordExecution
-	// directly with no auth identity) is likewise unaffected.
-	if callerID := strings.TrimSpace(auth.AgentIDFromContext(ctx)); callerID != "" {
-		owner := ""
-		if inv.AgentID != nil {
-			owner = strings.TrimSpace(*inv.AgentID)
-		}
-		if owner != "" && owner != callerID {
-			return InvocationResponse{}, fmt.Errorf("invocation %s: %w", invocationID, ErrNotOwner)
-		}
+	// update.Result/Error are surfaced to the judge as trusted evidence, so a
+	// caller who knows another agent's invocation_id could poison that
+	// agent's session context — reject writes to invocations this caller
+	// doesn't own.
+	if err := checkOwnership(ctx, inv); err != nil {
+		return InvocationResponse{}, err
 	}
 	now := time.Now().UTC()
 	switch update.ExecutionStatus {
@@ -1884,6 +1895,12 @@ func (s *Service) ListTools(ctx context.Context, server string) ([]mcp.Tool, err
 func (s *Service) Get(ctx context.Context, id string) (InvocationResponse, error) {
 	inv, err := s.invocations.Get(ctx, id)
 	if err != nil {
+		return InvocationResponse{}, err
+	}
+	// A caller who knows another agent's invocation_id could otherwise read
+	// that agent's tool input/output/error — reject reads of invocations
+	// this caller doesn't own.
+	if err := checkOwnership(ctx, inv); err != nil {
 		return InvocationResponse{}, err
 	}
 	resp := s.toResponse(inv)


### PR DESCRIPTION
# Pull Request Description

## What and why?

`GET /api/v1/external/invocations/{id}` had no ownership check, so any
agent with a valid bearer token could read **any other agent's** invocation
record — tool name, input, output, and error — just by knowing or guessing its
`invocation_id`. There is no list-all endpoint for non-admins, so this wasn't
blind-enumerable, but it's a real gap in access control: an invocation record
can carry secrets or internal system output that was only ever meant for the
agent that submitted it.

The write side of this same route family (`PATCH .../invocations/{id}`, handled
by `RecordExecution`) already enforces this — it checks that the caller's
authenticated agent identity matches `inv.AgentID` before allowing an update.
`Service.Get` (the read side) never got the equivalent check when it was
written, even though it sits one method away in the same file.

**Fix:** Extracted the ownership check out of `RecordExecution` into a shared
`checkOwnership(ctx, inv)` helper in `internal/invocation/service.go`, and
applied it to `Service.Get` too. Same rules as before:

- Only enforced when the request carries an authenticated agent identity
  (i.e. it went through the agent-runtime OAuth middleware). No-auth mode,
  the operator/review UI routes, and the in-process managed-agents watcher
  never carry an agent identity, so they're unaffected.
- Invocations submitted anonymously (no `agent_id`) are exempt — there's no
  owner to check against.

**Before:**

| Caller | Owns the invocation? | GET response |
|---|---|---|
| Agent A | Yes | 200, full record |
| Agent B | **No** | **200, full record (bug)** |

**After:**

| Caller | Owns the invocation? | GET response |
|---|---|---|
| Agent A | Yes | 200, full record |
| Agent B | No | **404** (identical body to a truly-missing invocation) |

We deliberately made the "not yours" case return the *exact same* 404 body as
"doesn't exist," rather than a 403. A 403 would confirm to Agent B that the ID
is real, just not theirs — that's its own small information leak (existence
disclosure). A 404 tells them nothing either way.

### Sequence diagram — before the fix (vulnerable)

Agent B never submitted this invocation and has no relationship to it, but the
API hands over Agent A's data anyway because `Service.Get` never checks who's
asking.

```mermaid
sequenceDiagram
    actor A as Agent A (owner)
    actor B as Agent B (attacker)
    participant API as Atryum API
    participant Svc as invocation.Service
    participant DB as Database

    A->>API: POST /api/v1/external/invocations<br/>(bearer token: agent A)
    API->>Svc: Submit(ctx[agent=A], ...)
    Svc->>DB: INSERT invocation (agent_id = "A")
    DB-->>Svc: invocation_id = inv_123
    Svc-->>API: inv_123
    API-->>A: 200 OK { invocation_id: "inv_123" }

    Note over B: Agent B somehow learns/guesses "inv_123"

    B->>API: GET /api/v1/external/invocations/inv_123<br/>(bearer token: agent B)
    API->>Svc: Get(ctx[agent=B], "inv_123")
    Svc->>DB: SELECT invocation WHERE id = "inv_123"
    DB-->>Svc: invocation (agent_id = "A", input, output, error)
    Note over Svc: ❌ no check that ctx's agent ("B")<br/>matches invocation's agent_id ("A")
    Svc-->>API: full invocation record
    API-->>B: 200 OK — Agent A's tool input/output/error
```

### Sequence diagram — after the fix (protected)

Same request from Agent B now fails the ownership check inside `Service.Get`
before any data is returned, and gets back the same 404 shape a nonexistent ID
would.

```mermaid
sequenceDiagram
    actor A as Agent A (owner)
    actor B as Agent B (attacker)
    participant API as Atryum API
    participant Svc as invocation.Service
    participant DB as Database

    A->>API: POST /api/v1/external/invocations<br/>(bearer token: agent A)
    API->>Svc: Submit(ctx[agent=A], ...)
    Svc->>DB: INSERT invocation (agent_id = "A")
    DB-->>Svc: invocation_id = inv_123
    Svc-->>API: inv_123
    API-->>A: 200 OK { invocation_id: "inv_123" }

    Note over B: Agent B somehow learns/guesses "inv_123"

    B->>API: GET /api/v1/external/invocations/inv_123<br/>(bearer token: agent B)
    API->>Svc: Get(ctx[agent=B], "inv_123")
    Svc->>DB: SELECT invocation WHERE id = "inv_123"
    DB-->>Svc: invocation (agent_id = "A", input, output, error)
    Svc->>Svc: checkOwnership(ctx[agent=B], invocation)
    Note over Svc: ✅ "B" != "A" → return ErrNotOwner
    Svc-->>API: ErrNotOwner
    API-->>B: 404 Not Found { "error": "not found" }<br/>(same body as a nonexistent id)

    Note over A: Agent A can still GET inv_123 normally —<br/>ctx[agent=A] matches agent_id "A", check passes
```

## How to test

Automated (this is what a reviewer should run):

```bash
go build ./...
go vet ./...
gofmt -l internal/invocation/service.go internal/invocation/record_execution_test.go \
         internal/api/handlers.go internal/api/handlers_test.go
go test ./internal/invocation/... ./internal/api/...
```

New tests added:
- `internal/invocation/record_execution_test.go` → `TestGetEnforcesAgentOwnership`
  (service-level, real in-memory DB): different agent rejected, owning agent
  allowed, no-identity caller exempt, anonymous invocation exempt. Mirrors the
  existing `TestRecordExecutionEnforcesAgentOwnership` for the write path.
- `internal/api/handlers_test.go` → `TestExternalInvocationGetErrorStatusMapping`
  (handler-level): asserts `ErrNotOwner` and "missing invocation" both produce
  status 404 with the byte-identical response body, so a future regression
  that makes them distinguishable would fail the test.

Manual local check, if you want to see it end-to-end:

The stock local dev stack (`docker compose --profile dev up`) ships
`atryum.toml` with every `[[auth]]` block commented out, so there's no OAuth
to configure — Atryum's `noAuthAgentIDHint` middleware (`internal/api/handlers.go`)
lets an unauthenticated caller simulate an agent identity with a plain
`?agent_id=` query param instead. That's what the checks below use, and it
exercises the exact same `auth.AgentIDFromContext(ctx)` path a real bearer
token's `client_id` claim would populate — no need to stand up Keycloak.

1. Rebuild/restart the service from this branch: `docker compose --profile dev up -d --wait --build atryum`.
2. Submit an invocation as agent A:
   ```bash
   curl -X POST "localhost:8090/api/v1/external/invocations?agent_id=agent-a" \
     -H "Content-Type: application/json" \
     -d '{"source":"demo","tool":"bash","input":{"cmd":"whoami"}}'
   # → note the returned invocation_id
   ```
3. Read it back as a different agent:
   ```bash
   curl -i "localhost:8090/api/v1/external/invocations/<that_id>?agent_id=agent-b"
   # before this fix: 200 with agent A's data. After: 404 {"error":{"message":"not found"}}
   ```
4. Repeat as the owner — still works:
   ```bash
   curl -i "localhost:8090/api/v1/external/invocations/<that_id>?agent_id=agent-a"
   # 200, unaffected
   ```

If your environment *does* have real OAuth configured (an active `[[auth]]`
block pointed at Keycloak/Auth0/etc.), the same check applies but swap the
`?agent_id=` query param for `Authorization: Bearer <token>` headers from two
different agents' `client_credentials` tokens — the code path is identical,
just sourced from the verified JWT's `agent_id_claim` instead of the query hint.

To see it in a browser instead of a terminal: open any page already served by
Atryum (e.g. `http://localhost:8090/healthz`) so DevTools' Console runs
same-origin, then paste:
```js
const id = "<that_id>";
const asOwner = await fetch(`/api/v1/external/invocations/${id}?agent_id=agent-a`);
console.log("agent-a:", asOwner.status, await asOwner.json());
const asOther = await fetch(`/api/v1/external/invocations/${id}?agent_id=agent-b`);
console.log("agent-b:", asOther.status, await asOther.json());
```

## What needs special review?

- **Status code choice for GET (404, not 403).** Worth a second opinion on
  whether hiding existence is the right call here vs. matching PATCH's 403.
  We chose 404 because a read endpoint returning 403 would still leak "this ID
  is real" to a caller who shouldn't know that.
- **`checkOwnership` now sits on both the read and write path.** Double-check
  the extraction didn't change `RecordExecution`'s behavior — it's a straight
  lift of the same logic, but it's the write path for tool-execution results,
  so it's worth confirming nothing shifted.

## Dependencies, breaking changes, and deployment notes

- No migrations, no schema changes, no new config/env vars.
- No dependent or blocking PRs.
- **Behavior change:** any caller previously relying on being able to `GET`
  an invocation belonging to a *different* agent identity will now get a 404
  instead of 200. This should never have worked in the first place, so we
  don't expect a legitimate integration depends on it, but flagging since it
  is a visible response-code change on a public API route.

## Data impact

- [ ] Yes — this change is data-impacting
- [x] No — this change is not data-impacting

Justification: This is an access-control check on an existing read endpoint.
No database schema, stored data, or business-process behavior changes — the
same invocation record is returned as before, just gated to its owning agent.

## Release notes


Fixed an access-control gap where an agent could read another agent's
invocation details (tool name, input, output, error) through the external
invocations API if it obtained that invocation's ID. Reads are now scoped to
the invocation's owning agent, matching the access control already enforced
when reporting execution results.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend) — N/A, backend-only change
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied — apply `bug` when opening the PR
- [x] Data impact classified
- [ ] PR linked to Shortcut — add ticket link when opening the PR
- [x] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required) — N/A, no user-facing docs affected
- [ ] Environment variable additions/changes documented (if required) — N/A, none added
